### PR TITLE
Bugfix: getLogs query

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -222,6 +222,8 @@ defmodule BlockScoutWeb.Etherscan do
         "timeStamp" => "0x561d688c",
         "gasPrice" => "0xba43b7400",
         "gasUsed" => "0x10682",
+        "gasFeeRecipient" => "0xe7c7177b6e5418f27e435f96dbf3f7edae41c133",
+        "gasCurrency" => "0x88f24de331525cf6cfd7455eb96a9e4d49b7f292",
         "logIndex" => "0x",
         "transactionHash" => "0x0b03498648ae2da924f961dda00dc6bb0a8df15519262b7e012b7d67f4bb7e83",
         "transactionIndex" => "0x"
@@ -793,6 +795,16 @@ defmodule BlockScoutWeb.Etherscan do
         type: "gas",
         definition: "A nonnegative number roughly equivalent to computational steps.",
         example: ~s("0x10682")
+      },
+      gasCurrency: %{
+        type: "address hash",
+        definition: "A 160-bit code used for identifying accounts or contracts.",
+        example: ~s("0x88f24de331525cf6cfd7455eb96a9e4d49b7f292")
+      },
+      feeRecipeint: %{
+        type: "address hash",
+        definition: "A 160-bit code used for identifying accounts or contracts.",
+        example: ~s("0xbbae99f0e1ee565404465638d40827b54d343638")
       },
       logIndex: %{
         type: "hexadecimal",

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/logs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/logs_view.ex
@@ -21,6 +21,8 @@ defmodule BlockScoutWeb.API.RPC.LogsView do
       "timeStamp" => datetime_to_hex(log.block_timestamp),
       "gasPrice" => decimal_to_hex(log.gas_price.value),
       "gasUsed" => decimal_to_hex(log.gas_used),
+      "gasCurrency" => "#{log.gas_currency_hash}",
+      "feeRecipient" => "#{log.gas_fee_recipient_hash}",
       "logIndex" => integer_to_hex(log.index),
       "transactionHash" => "#{log.transaction_hash}",
       "transactionIndex" => integer_to_hex(log.transaction_index)

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -92,6 +92,8 @@ defmodule Explorer.Etherscan.Logs do
         select:
           merge(map(log, ^@log_fields), %{
             gas_price: transaction.gas_price,
+            gas_currency_hash: transaction.gas_currency_hash,
+            gas_fee_recipient_hash: transaction.gas_fee_recipient_hash,
             gas_used: transaction.gas_used,
             transaction_index: transaction.index,
             block_number: transaction.block_number


### PR DESCRIPTION
## Motivation

Fix query `curl "http://localhost:4000/api?module=logs&action=getLogs&fromBlock=48486&toBlock=latest&address=0x88F24De331525cf6cFD7455Eb96A9E4D49B7F292"`
