### PR TITLE
Disable exchange rates

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -59,7 +59,7 @@ config :explorer, Explorer.Counters.AddressesCounter,
   enable_consolidation: true,
   update_interval_in_seconds: balances_update_interval || 30 * 60
 
-config :explorer, Explorer.ExchangeRates, enabled: true, store: :ets
+config :explorer, Explorer.ExchangeRates, enabled: false, store: :ets
 
 config :explorer, Explorer.KnownTokens, enabled: true, store: :ets
 


### PR DESCRIPTION
Disable exchange rate module AFA it is failing now (because `COIN` not found on source):
```
iex(1)> 2019-11-28T04:25:41.258 [error] Task #PID<0.6422.5> started from Explorer.ExchangeRates terminating
** (MatchError) no match of right hand side value: {:error, :not_found}
    (explorer) lib/explorer/exchange_rates/source/coin_gecko.ex:47: Explorer.ExchangeRates.Source.CoinGecko.source_url/0
    (explorer) lib/explorer/exchange_rates/source.ex:17: Explorer.ExchangeRates.Source.fetch_exchange_rates_request/1
    (elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Function: #Function<0.73601901/0 in Explorer.ExchangeRates.fetch_rates/0>
    Args: []
```