### PR TITLE
Addressing monorepo issue: #1984 by changing network name from Betane…

### DIFF
--- a/apps/block_scout_web/assets/css/components/_network-selector.scss
+++ b/apps/block_scout_web/assets/css/components/_network-selector.scss
@@ -289,7 +289,7 @@ $network-selector-item-icon-dimensions: 30px !default;
   &-celo-integration {
     background-image: url(/images/network-selector-icons/celo.svg)
   }
-  &-celo-betanet {
+  &-celo-baklava {
     background-image: url(/images/network-selector-icons/celo.svg)
   }
   &-celo {

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -17,8 +17,8 @@ defmodule BlockScoutWeb.LayoutView do
       test_net?: true
     },
     %{
-      title: "Celo Betanet",
-      url: "https://betanet-blockscout.celo-testnet.org/",
+      title: "Celo Baklava",
+      url: "https://baklava-blockscout.celo-testnet.org/",
       test_net?: true
     }
   ]


### PR DESCRIPTION
#2700  Motivation

Addressing https://github.com/celo-org/celo-monorepo/issues/1984 by changing "Celo Betanet" network name to proper "Celo Baklava".

Tested by locally building/running blockscout. Link to `https://baklava-blockscout.celo-testnet.org/` obviously doesn't work currently, but I believe this is correct for the future
