### PR TITLE
Removed transaction with "0x000.." hash from DB

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
@@ -6,7 +6,7 @@
     </div>
     <!-- Content -->
     <div class="col-md-7 col-lg-8 d-flex flex-column pr-2 pr-sm-2 pr-md-0">
-      <%= render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @token_transfer.transaction_hash %>
+      <%= if @token_transfer.transaction_hash != nil do render BlockScoutWeb.TransactionView, "_link.html", transaction_hash: @token_transfer.transaction_hash else "System transfer" end %>
       <span class="text-nowrap">
         <%= link to: address_token_transfers_path(@conn, :index, @token_transfer.from_address, @token.contract_address_hash), "data-test": "address_hash_link" do %>
             <%= render(

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -9,8 +9,8 @@ defmodule Explorer.Chain.Log do
   alias Explorer.Chain.{Address, Block, ContractMethod, Data, Hash, Transaction}
   alias Explorer.Repo
 
-  @required_attrs ~w(address_hash data index block_number block_hash transaction_hash)a
-  @optional_attrs ~w(first_topic second_topic third_topic fourth_topic type)a
+  @required_attrs ~w(address_hash data index block_number block_hash)a
+  @optional_attrs ~w(first_topic second_topic third_topic fourth_topic type transaction_hash)a
 
   @typedoc """
    * `address` - address of contract that generate the event

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -115,8 +115,8 @@ defmodule Explorer.Chain.TokenTransfer do
     timestamps()
   end
 
-  @required_attrs ~w(block_number log_index from_address_hash to_address_hash block_hash token_contract_address_hash transaction_hash)a
-  @optional_attrs ~w(amount token_id)a
+  @required_attrs ~w(block_number log_index from_address_hash to_address_hash block_hash token_contract_address_hash)a
+  @optional_attrs ~w(amount token_id transaction_hash)a
 
   @doc false
   def changeset(%TokenTransfer{} = struct, params \\ %{}) do

--- a/apps/explorer/priv/repo/migrations/20180212222309_create_logs.exs
+++ b/apps/explorer/priv/repo/migrations/20180212222309_create_logs.exs
@@ -23,7 +23,7 @@ defmodule Explorer.Repo.Migrations.CreateLogs do
       add(
         :transaction_hash,
         references(:transactions, column: :hash, on_delete: :delete_all, type: :bytea),
-        null: false
+        null: true
       )
     end
 

--- a/apps/explorer/priv/repo/migrations/20180606135150_create_token_transfers.exs
+++ b/apps/explorer/priv/repo/migrations/20180606135150_create_token_transfers.exs
@@ -6,7 +6,7 @@ defmodule Explorer.Repo.Migrations.CreateTokenTransfers do
       add(
         :transaction_hash,
         references(:transactions, column: :hash, on_delete: :delete_all, type: :bytea),
-        null: false
+        null: true
       )
 
       add(

--- a/apps/explorer/priv/repo/migrations/20191011140922_create_celo_account.exs
+++ b/apps/explorer/priv/repo/migrations/20191011140922_create_celo_account.exs
@@ -54,29 +54,5 @@ defmodule Explorer.Repo.Migrations.CreateCeloAccount do
     end
 
     create(index(:celo_validator_history, [:block_number, :index], unique: true))
-"""
-    if Mix.env() != :test do
-      Explorer.Repo.insert(
-        Explorer.Chain.Address.changeset(%Explorer.Chain.Address{}, %{
-          hash: "0x0000000000000000000000000000000000000000"
-        })
-      )
-
-      Explorer.Repo.insert(
-        Explorer.Chain.Transaction.changeset(%Explorer.Chain.Transaction{}, %{
-          gas: 0,
-          gas_price: 0,
-          hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-          v: 27,
-          r: 123,
-          s: 234,
-          nonce: 1_000_000_000,
-          input: "0x1234",
-          from_address_hash: "0x0000000000000000000000000000000000000000",
-          value: 0
-        })
-      )
-    end
-    """
   end
 end

--- a/apps/explorer/priv/repo/migrations/20191011140922_create_celo_account.exs
+++ b/apps/explorer/priv/repo/migrations/20191011140922_create_celo_account.exs
@@ -54,7 +54,7 @@ defmodule Explorer.Repo.Migrations.CreateCeloAccount do
     end
 
     create(index(:celo_validator_history, [:block_number, :index], unique: true))
-
+"""
     if Mix.env() != :test do
       Explorer.Repo.insert(
         Explorer.Chain.Address.changeset(%Explorer.Chain.Address{}, %{
@@ -77,5 +77,6 @@ defmodule Explorer.Repo.Migrations.CreateCeloAccount do
         })
       )
     end
+    """
   end
 end

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -118,7 +118,7 @@ defmodule Indexer.Block.Fetcher do
         tx_hash == block_hash
       end)
       |> Enum.map(fn log ->
-        Map.put(log, :transaction_hash, "0x0000000000000000000000000000000000000000000000000000000000000000")
+        Map.put(log, :transaction_hash, nil)
       end)
 
     e_logs


### PR DESCRIPTION
As a temporary fix, I had added a transaction with hash "0x000..." that was associated to logs with no actual associated transaction. This transaction made tests harder, and also was weird in the web interface. Now shows `System transfer` for token transfers with no associated transaction.

Requires database hard reset.
