### PR TITLE
Mitigation error when a contract output is an array of addresses

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -81,11 +81,11 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
         else
           case Chain.get_proxied_address(address_hash) do
             {:ok, proxy_contract} ->
-              Logger.debug("Implementation address FOUND in proxy table")
+              Logger.debug("Implementation address found in proxy table")
               Chain.address_hash_to_address_with_source_code(proxy_contract)
 
             {:error, :not_found} ->
-              Logger.debug("Implementation address NOT found in proxy table")
+              Logger.debug("Implementation address not found in proxy table")
               Chain.address_hash_to_address_with_source_code(address_hash)
           end
         end
@@ -183,8 +183,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   defp contracts_filter(filter), do: {:error, contracts_filter_error_message(filter)}
 
   defp contracts_filter_error_message(filter) do
-    "#{filter} is not a valid value for `filter`.
-    Please use one of: verified, decompiled, unverified, not_decompiled, 1, 2, 3, 4."
+    "#{filter} is not a valid value for `filter`. Please use one of: verified, decompiled, unverified, not_decompiled, 1, 2, 3, 4."
   end
 
   defp fetch_address(params) do

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -11,9 +11,14 @@ defmodule BlockScoutWeb.SmartContractView do
   def named_argument?(_), do: false
 
   def values(addresses, type) when type == "address[]" do
-    addresses
-    |> Enum.map(&values(&1, "address"))
-    |> Enum.join(", ")
+    try do
+      addresses
+      |> Enum.map(&values(&1, "address"))
+      |> Enum.join(", ")
+    rescue
+      _ ->
+        ""
+    end
   end
 
   def values(value, type) when type in ["address", "address payable"] do

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -12,8 +12,8 @@ defmodule BlockScoutWeb.SmartContractView do
 
   def values(addresses, type) when type == "address[]" do
     addresses
-      |> Enum.map(&values(&1, "address"))
-      |> Enum.join(", ")
+    |> Enum.map(&values(&1, "address"))
+    |> Enum.join(", ")
   rescue
     _ ->
       ""

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -11,14 +11,12 @@ defmodule BlockScoutWeb.SmartContractView do
   def named_argument?(_), do: false
 
   def values(addresses, type) when type == "address[]" do
-    try do
-      addresses
+    addresses
       |> Enum.map(&values(&1, "address"))
       |> Enum.join(", ")
-    rescue
-      _ ->
-        ""
-    end
+  rescue
+    _ ->
+      ""
   end
 
   def values(value, type) when type in ["address", "address payable"] do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -13,9 +13,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         |> get("/api", Map.put(params, "filter", "invalid"))
         |> json_response(400)
 
-      assert response["message"] ==
-               "invalid is not a valid value for `filter`.
-               Please use one of: verified, decompiled, unverified, not_decompiled, 1, 2, 3, 4."
+      assert String.contains?(response["message"], "invalid is not a valid value for `filter`")
 
       assert response["status"] == "0"
       assert :ok = ExJsonSchema.Validator.validate(listcontracts_schema(), response)


### PR DESCRIPTION
There is an error in Blockscout when some verified contract methods return an array of addresses:
https://github.com/poanetwork/blockscout/issues/2907

This change mitigates that error returning an empty array when that happens.
It's necessary to monitor the underlying error in blockscout and apply the patch when it's ready in upstream.