### PR TITLE
Querying balance history

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/resolvers/coin_balances.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/coin_balances.ex
@@ -1,0 +1,29 @@
+defmodule BlockScoutWeb.Resolvers.CoinBalances do
+  #  import BlockScoutWeb.Chain, only: [paging_options: 1]
+
+  #  alias Explorer.Chain
+
+  alias Absinthe.Relay.Connection
+  alias Explorer.{GraphQL, Repo}
+
+  _ = """
+    def get_by(_, %{address: address_hash} = args, _) do
+      full_options = paging_options(args)
+      {:ok, Chain.address_to_coin_balances(address_hash, full_options)}
+    end
+  """
+
+  def get_by(_, %{address: address_hash} = args, _) do
+    connection_args = Map.take(args, [:after, :before, :first, :last])
+
+    address_hash
+    |> GraphQL.list_coin_balances_query()
+    |> Connection.from_query(&Repo.all/1, connection_args, options(args))
+  end
+
+  defp options(%{before: _}), do: []
+
+  defp options(%{count: count}), do: [count: count]
+
+  defp options(_), do: []
+end

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/coin_balances.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/coin_balances.ex
@@ -1,17 +1,7 @@
 defmodule BlockScoutWeb.Resolvers.CoinBalances do
-  #  import BlockScoutWeb.Chain, only: [paging_options: 1]
-
-  #  alias Explorer.Chain
 
   alias Absinthe.Relay.Connection
   alias Explorer.{GraphQL, Repo}
-
-  _ = """
-    def get_by(_, %{address: address_hash} = args, _) do
-      full_options = paging_options(args)
-      {:ok, Chain.address_to_coin_balances(address_hash, full_options)}
-    end
-  """
 
   def get_by(_, %{address: address_hash} = args, _) do
     connection_args = Map.take(args, [:after, :before, :first, :last])

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/coin_balances.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/coin_balances.ex
@@ -1,4 +1,5 @@
 defmodule BlockScoutWeb.Resolvers.CoinBalances do
+  @moduledoc false
 
   alias Absinthe.Relay.Connection
   alias Explorer.{GraphQL, Repo}

--- a/apps/block_scout_web/lib/block_scout_web/schema.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema.ex
@@ -15,6 +15,7 @@ defmodule BlockScoutWeb.Schema do
     CeloUtil,
     CeloValidator,
     CeloValidatorGroup,
+    CoinBalances,
     Competitor,
     InternalTransaction,
     TokenTransfer,
@@ -137,6 +138,13 @@ defmodule BlockScoutWeb.Schema do
         %{last: last}, child_complexity ->
           last * child_complexity
       end)
+    end
+
+    @desc "Gets coin balances by address hash"
+    connection field(:coin_balances, node_type: :coin_balance) do
+      arg(:address, non_null(:address_hash))
+      arg(:count, :integer)
+      resolve(&CoinBalances.get_by/3)
     end
 
     @desc "Gets a transaction by hash."

--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -26,6 +26,7 @@ defmodule BlockScoutWeb.Schema.Types do
   connection(node_type: :transaction)
   connection(node_type: :internal_transaction)
   connection(node_type: :token_transfer)
+  connection(node_type: :coin_balance)
 
   @desc """
   A stored representation of a Web3 address.
@@ -294,8 +295,22 @@ defmodule BlockScoutWeb.Schema.Types do
     end
   end
 
+  @desc """
+  Coin balance record
+  """
+  node object(:coin_balance, id_fetcher: &coin_balance_id_fetcher/2) do
+    field(:block_number, :integer)
+    field(:value, :wei)
+    field(:delta, :wei)
+    field(:block_timestamp, :datetime)
+  end
+
   def token_transfer_id_fetcher(%{transaction_hash: transaction_hash, log_index: log_index}, _) do
     Jason.encode!(%{transaction_hash: to_string(transaction_hash), log_index: log_index})
+  end
+
+  def coin_balance_id_fetcher(%{address_hash: address_hash, block_number: block_number}, _) do
+    Jason.encode!(%{address_hash: to_string(address_hash), block_number: block_number})
   end
 
   def transaction_id_fetcher(%{hash: hash}, _), do: to_string(hash)


### PR DESCRIPTION
Adds a GraphQL query for coin balance history.
Example query:
```
{
  coinBalances(address:"0x73b49DA41223585a650712363BA7878Ed60a964d", first: 100) {
    edges {
      node {
         blockTimestamp
         blockNumber
         value
      }
    }
  }
}
```
