### PR TITLE
Fixing some problems with gold token

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -123,6 +123,7 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
       |> Stream.map(&Map.put_new(&1, :holder_count, 0))
       # Enforce Token ShareLocks order (see docs: sharelocks.md)
       |> Enum.sort_by(& &1.contract_address_hash)
+      |> Enum.dedup_by(& &1.contract_address_hash)
 
     {:ok, _} =
       Import.insert_changes_list(

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -105,7 +105,7 @@ defmodule Explorer.Chain.Token do
 
   These are tokens with cataloged field set to true and updated_at is earlier or equal than an hour ago.
   """
-  def cataloged_tokens(hours \\ 48) do
+  def cataloged_tokens(hours \\ 48*3600) do
     date_now = DateTime.utc_now()
     hours_ago_date = DateTime.add(date_now, -:timer.hours(hours), :millisecond)
 

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -105,7 +105,7 @@ defmodule Explorer.Chain.Token do
 
   These are tokens with cataloged field set to true and updated_at is earlier or equal than an hour ago.
   """
-  def cataloged_tokens(hours \\ 48*3600) do
+  def cataloged_tokens(hours \\ 48) do
     date_now = DateTime.utc_now()
     hours_ago_date = DateTime.add(date_now, -:timer.hours(hours), :millisecond)
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -127,7 +127,7 @@ defmodule Indexer.Block.Fetcher do
     e_logs
   end
 
-  defp add_gold_token_balances(gold_token, addresses, acc) do
+  def add_gold_token_balances(gold_token, addresses, acc) do
     Enum.reduce(addresses, acc, fn
       %{fetched_coin_balance_block_number: bn, hash: hash}, acc ->
         MapSet.put(acc, %{address_hash: hash, token_contract_address_hash: gold_token, block_number: bn})
@@ -186,9 +186,7 @@ defmodule Indexer.Block.Fetcher do
             else
               {:ok, nil}
             end},
-         # TODO: handle non-gold transaction fees
-         # %{token_transfers: fee_token_transfers, tokens: fee_tokens} =
-         # TokenTransfers.parse_fees(transactions_with_receipts),
+         # Non gold fees should be handled by events
          fee_tokens = [],
          fee_token_transfers = [],
          %{
@@ -280,7 +278,7 @@ defmodule Indexer.Block.Fetcher do
                account_names: %{params: account_names},
                celo_signers: %{params: signers},
                token_transfers: %{params: token_transfers},
-               tokens: %{on_conflict: :nothing, params: tokens},
+               tokens: %{params: tokens},
                transactions: %{params: transactions_with_receipts},
                exchange_rate: %{params: exchange_rates}
              }

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -127,7 +127,7 @@ defmodule Indexer.Block.Fetcher do
     e_logs
   end
 
-  def add_gold_token_balances(gold_token, addresses, acc) do
+  defp add_gold_token_balances(gold_token, addresses, acc) do
     Enum.reduce(addresses, acc, fn
       %{fetched_coin_balance_block_number: bn, hash: hash}, acc ->
         MapSet.put(acc, %{address_hash: hash, token_contract_address_hash: gold_token, block_number: bn})

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -147,7 +147,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
     end)
   end
 
-  defp decode("0x"<>str) do
+  defp decode("0x" <> str) do
     %{bytes: Base.decode16!(str, case: :mixed)}
   end
 
@@ -168,7 +168,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
       Addresses.extract_addresses(%{
         internal_transactions: internal_transactions_params_without_failed_creations
       })
-    
+
     # Gold token special updates
     with true <- Application.get_env(:indexer, Indexer.Block.Fetcher, [])[:enable_gold_token],
          {:ok, gold_token} <- AccountReader.get_address("GoldToken") do

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -12,10 +12,12 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   import Indexer.Block.Fetcher, only: [async_import_coin_balances: 2]
 
+  alias Explorer.Celo.AccountReader
   alias Explorer.Chain
   alias Explorer.Chain.Block
   alias Explorer.Chain.Cache.{Accounts, Blocks}
   alias Indexer.{BufferedTask, Tracer}
+  alias Indexer.Fetcher.TokenBalance
   alias Indexer.Transform.Addresses
 
   @behaviour BufferedTask
@@ -145,6 +147,20 @@ defmodule Indexer.Fetcher.InternalTransaction do
     end)
   end
 
+  defp decode("0x"<>str) do
+    %{bytes: Base.decode16!(str, case: :mixed)}
+  end
+
+  defp add_gold_token_balances(gold_token, addresses, acc) do
+    Enum.reduce(addresses, acc, fn
+      %{fetched_coin_balance_block_number: bn, hash: hash}, acc ->
+        MapSet.put(acc, %{address_hash: decode(hash), token_contract_address_hash: decode(gold_token), block_number: bn})
+
+      _, acc ->
+        acc
+    end)
+  end
+
   defp import_internal_transaction(internal_transactions_params, unique_numbers) do
     internal_transactions_params_without_failed_creations = remove_failed_creations(internal_transactions_params)
 
@@ -152,6 +168,13 @@ defmodule Indexer.Fetcher.InternalTransaction do
       Addresses.extract_addresses(%{
         internal_transactions: internal_transactions_params_without_failed_creations
       })
+    
+    # Gold token special updates
+    with true <- Application.get_env(:indexer, Indexer.Block.Fetcher, [])[:enable_gold_token],
+         {:ok, gold_token} <- AccountReader.get_address("GoldToken") do
+      set = add_gold_token_balances(gold_token, addresses_params, MapSet.new())
+      TokenBalance.async_fetch(MapSet.to_list(set))
+    end
 
     address_hash_to_block_number =
       Enum.into(addresses_params, %{}, fn %{fetched_coin_balance_block_number: block_number, hash: hash} ->


### PR DESCRIPTION
Update gold tokens balances when internal transactions have made changes.
Keep updating info about tokens such as `totalSupply`.
