### PR TITLE
Get correct accounts for signers when using GraphQL

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3928,9 +3928,10 @@ defmodule Explorer.Chain do
     query
     |> Repo.one()
     |> case do
-      nil ->  {:error, :not_found}
+      nil ->
+        {:error, :not_found}
+
       data ->
-        IO.inspect(%{data: data})
         {:ok, data}
     end
   end


### PR DESCRIPTION
Sample:
```
{
  address(hash:"0x6a1b8c919ec3cfb37070b5b9a1b3872c05b1681c") {
    hash
    celoAccount {
      address
      name
    }
  }
}
```