### PR TITLE
Added more data accessible from GraphQL

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
@@ -34,8 +34,9 @@ defmodule BlockScoutWeb.AddressContractController do
         render(
           conn,
           "index.html",
-          address: implementation_contract,
+          address: address,
           proxy: address,
+          implementation: implementation_contract,
           is_proxy: true,
           coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
           exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/address.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/address.ex
@@ -11,6 +11,13 @@ defmodule BlockScoutWeb.Resolvers.Address do
     end
   end
 
+  def get_by(_, %{block_number: num}, _) do
+    case Chain.get_elected_validators(num) do
+      [] -> {:error, "Addresses not found."}
+      result -> {:ok, result}
+    end
+  end
+
   def get_by(_, %{hash: hash}, _) do
     case Chain.hash_to_address(hash) do
       {:error, :not_found} -> {:error, "Address not found."}

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/celo_account.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/celo_account.ex
@@ -1,8 +1,9 @@
 defmodule BlockScoutWeb.Resolvers.CeloAccount do
   @moduledoc false
 
-  alias Explorer.Chain
-  alias Explorer.Chain.{Address, CeloClaims, CeloValidator, CeloValidatorGroup}
+  alias Absinthe.Relay.Connection
+  alias Explorer.{Chain, GraphQL, Repo}
+  alias Explorer.Chain.{Address, CeloAccount, CeloClaims, CeloValidator, CeloValidatorGroup}
 
   def get_by(_, %{hash: hash}, _) do
     case Chain.get_celo_account(hash) do
@@ -45,5 +46,11 @@ defmodule BlockScoutWeb.Resolvers.CeloAccount do
 
   def get_claims(%{address: hash}, _, _) do
     {:ok, Chain.get_celo_claims(hash)}
+  end
+
+  def get_voted(%CeloAccount{address: hash}, args, _) do
+    hash
+    |> GraphQL.account_voted_query()
+    |> Connection.from_query(&Repo.all/1, args, [])
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/celo_validator_group.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/celo_validator_group.ex
@@ -1,8 +1,9 @@
 defmodule BlockScoutWeb.Resolvers.CeloValidatorGroup do
   @moduledoc false
 
-  alias Explorer.Chain
-  alias Explorer.Chain.{Address, CeloAccount, CeloValidator}
+  alias Absinthe.Relay.Connection
+  alias Explorer.{Chain, GraphQL, Repo}
+  alias Explorer.Chain.{Address, CeloAccount, CeloValidator, CeloValidatorGroup}
 
   def get_by(_, %{hash: hash}, _) do
     case Chain.get_celo_validator_group(hash) do
@@ -37,5 +38,11 @@ defmodule BlockScoutWeb.Resolvers.CeloValidatorGroup do
       {:error, :not_found} -> {:error, "Celo validator group query failed."}
       {:ok, _} = result -> result
     end
+  end
+
+  def get_voters(%CeloValidatorGroup{address: hash}, args, _) do
+    hash
+    |> GraphQL.group_voters_query()
+    |> Connection.from_query(&Repo.all/1, args, [])
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/schema.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema.ex
@@ -118,6 +118,12 @@ defmodule BlockScoutWeb.Schema do
       resolve(&CeloValidatorGroup.get_by/3)
     end
 
+    @desc "Gets all elected validator signers."
+    field :celo_elected_validators, list_of(:address) do
+      arg(:block_number, non_null(:integer))
+      resolve(&Address.get_by/3)
+    end
+
     @desc "Gets Celo network parameters"
     field :celo_parameters, :celo_parameters do
       resolve(&CeloParameters.get_by/3)

--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -42,6 +42,7 @@ defmodule BlockScoutWeb.Schema.Types do
     field(:fetched_coin_balance, :wei)
     field(:fetched_coin_balance_block_number, :integer)
     field(:contract_code, :data)
+    field(:online, :boolean)
 
     field :smart_contract, :smart_contract do
       resolve(dataloader(:db, :smart_contract))
@@ -81,6 +82,7 @@ defmodule BlockScoutWeb.Schema.Types do
     field(:account_type, :string)
     field(:nonvoting_locked_gold, :wei)
     field(:locked_gold, :wei)
+    field(:votes, :wei)
 
     field(:usd, :wei)
 
@@ -103,6 +105,10 @@ defmodule BlockScoutWeb.Schema.Types do
 
     connection field(:claims, node_type: :celo_claims) do
       resolve(&CeloClaim.get_by/3)
+    end
+
+    connection field(:voted, node_type: :celo_account) do
+      resolve(&CeloAccount.get_voted/3)
     end
   end
 
@@ -172,6 +178,10 @@ defmodule BlockScoutWeb.Schema.Types do
 
     connection field(:affiliates, node_type: :celo_validator) do
       resolve(&CeloValidator.get_by/3)
+    end
+
+    connection field(:voters, node_type: :celo_account) do
+      resolve(&CeloValidatorGroup.get_voters/3)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
@@ -36,9 +36,9 @@
             <dd class="col-md-4"><%= @is_proxy %></dd>
             <div class="d-none d-sm-block d-md-none"></br></br></div>
             <div class="d-block d-sm-none"></br></br></div>
-            <%= if @proxy.smart_contract &&  @proxy.smart_contract.name do %>
-              <dt class="col-md-2 text-muted"><%= gettext "Proxy Name:" %></dt>
-              <dd class="col-md-4"><%= @proxy.smart_contract.name %></dd>
+            <%= if @implementation.smart_contract &&  @implementation.smart_contract.name do %>
+              <dt class="col-md-2 text-muted"><%= gettext "Implementation Name:" %></dt>
+              <dd class="col-md-4"><%= @implementation.smart_contract.name %></dd>
             <% end %>
             </dl>
           <% end %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1170,11 +1170,6 @@ msgid "Proxy Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:40
-msgid "Proxy Name:"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:33
 #: lib/block_scout_web/templates/address/overview.html.eex:131
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:51
@@ -1961,4 +1956,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/_metatags.html.eex:2
 msgid "%{network} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_contract/index.html.eex:40
+msgid "Implementation Name:"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1171,11 +1171,6 @@ msgid "Proxy Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:40
-msgid "Proxy Name:"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:33
 #: lib/block_scout_web/templates/address/overview.html.eex:131
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:51
@@ -1959,7 +1954,12 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/block_scout_web/templates/chain/_metatags.html.eex:2
 msgid "%{network} Explorer"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address_contract/index.html.eex:40
+msgid "Implementation Name:"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1133,6 +1133,21 @@ defmodule Explorer.Chain do
     Repo.all(query)
   end
 
+  def get_elected_validators(num) do
+    query =
+      from(
+        address in Address,
+        join: sel in CeloValidatorHistory,
+        on: sel.address == address.hash,
+        where: sel.block_number == ^num,
+        select_merge: %{
+          online: sel.online
+        }
+      )
+
+    Repo.all(query)
+  end
+
   @doc """
   Returns the balance of the given address and block combination.
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3059,6 +3059,8 @@ defmodule Explorer.Chain do
         where: smart_contract.address_hash == ^address_hash
       )
 
+    IO.inspect(%{get_contract: address_hash})
+
     Repo.one(query)
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3059,8 +3059,6 @@ defmodule Explorer.Chain do
         where: smart_contract.address_hash == ^address_hash
       )
 
-    IO.inspect(%{get_contract: address_hash})
-
     Repo.one(query)
   end
 

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -90,6 +90,7 @@ defmodule Explorer.Chain.Address do
     field(:verified, :boolean, default: false)
     field(:has_decompiled_code?, :boolean, virtual: true)
     field(:stale?, :boolean, virtual: true)
+    field(:online, :boolean, virtual: true)
 
     has_one(:smart_contract, SmartContract)
     has_one(:token, Token, foreign_key: :contract_address_hash)

--- a/apps/explorer/lib/explorer/chain/celo_account.ex
+++ b/apps/explorer/lib/explorer/chain/celo_account.ex
@@ -172,6 +172,8 @@ defmodule Explorer.Chain.CeloAccount do
     field(:locked_gold, Wei)
     field(:usd, Wei)
 
+    field(:votes, Wei, virtual: true)
+
     field(:attestations_requested, :integer)
     field(:attestations_fulfilled, :integer)
 

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -19,6 +19,7 @@ defmodule Explorer.GraphQL do
     CeloAccount,
     CeloClaims,
     CeloParams,
+    CeloVoters,
     Hash,
     InternalTransaction,
     Token,
@@ -136,6 +137,36 @@ defmodule Explorer.GraphQL do
       order_by: [desc: tt.block_number, desc: t.index, asc: tt.log_index],
       select: tt
     )
+  end
+
+  def group_voters_query(group_address) do
+    query =
+      from(addr in CeloAccount,
+        join: account in CeloVoters,
+        on: account.group_address_hash == addr.address,
+        where: account.group_address_hash == ^group_address,
+        where: account.total > ^0,
+        select_merge: %{
+          votes: account.total
+        }
+      )
+
+    query
+  end
+
+  def account_voted_query(account_address) do
+    query =
+      from(addr in CeloAccount,
+        join: account in CeloVoters,
+        on: account.voter_address_hash == addr.address,
+        where: account.voter_address_hash == ^account_address,
+        where: account.total > ^0,
+        select_merge: %{
+          votes: account.total
+        }
+      )
+
+    query
   end
 
   def list_gold_transfers_query do

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -138,9 +138,7 @@ defmodule Explorer.SmartContract.Reader do
 
     impl_abi =
       with {:ok, implementation_address} <- Chain.get_proxied_address(contract_address_hash),
-           IO.inspect(implementation_address),
            implementation_contract <- Chain.address_hash_to_smart_contract(implementation_address) do
-        IO.inspect(implementation_contract)
         implementation_contract.abi
       else
         _ -> nil


### PR DESCRIPTION
Added a way to get info about signers, for example
```
{
  celoElectedValidators(blockNumber: 500000) {
    hash
    online
  }
}
```

Added `voters` connection to `celoValidatorGroup` and `voted` connection to `celoAccount`.

Changing how proxy contracts are shown
* Show the code for proxy, not implementation
* In read contract, read from the proxy
