### PR TITLE
Fixing vote query mix up

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -107,7 +107,7 @@ defmodule BlockScoutWeb.Schema.Types do
       resolve(&CeloClaim.get_by/3)
     end
 
-    connection field(:voted, node_type: :celo_account) do
+    connection field(:voted, node_type: :celo_validator_group) do
       resolve(&CeloAccount.get_voted/3)
     end
   end

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -143,7 +143,7 @@ defmodule Explorer.GraphQL do
     query =
       from(addr in CeloAccount,
         join: account in CeloVoters,
-        on: account.group_address_hash == addr.address,
+        on: account.voter_address_hash == addr.address,
         where: account.group_address_hash == ^group_address,
         where: account.total > ^0,
         select_merge: %{
@@ -155,10 +155,12 @@ defmodule Explorer.GraphQL do
   end
 
   def account_voted_query(account_address) do
+    group = Chain.celo_validator_group_query()
+
     query =
-      from(addr in CeloAccount,
+      from(addr in subquery(group),
         join: account in CeloVoters,
-        on: account.voter_address_hash == addr.address,
+        on: account.group_address_hash == addr.address,
         where: account.voter_address_hash == ^account_address,
         where: account.total > ^0,
         select_merge: %{


### PR DESCRIPTION
`voted` query returned the account info for the voter and `voters` returned account info for groups.