### PR TITLE
Buffered task issue

### DIFF
--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -376,7 +376,8 @@ defmodule Indexer.BufferedTask do
           )
           |> catchup_remaining(max_batch_size, parent)
         rescue
-          _ ->
+          err ->
+            Logger.warn(fn -> "Failed to initialize buffered task '#{err}'." end)
             :ok
         end
       end)

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -149,6 +149,7 @@ defmodule Indexer.Supervisor do
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
         {PendingOpsCleaner, [[], []]}
       ],
+      max_restarts: 10,
       strategy: :one_for_one
     )
   end


### PR DESCRIPTION
For some reason, the process handling internal transactions couldn't recover when the initial state had errors.