### PR TITLE
Changed parsing of the HEALTHY_BLOCKS_PERIOD env var

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -15,7 +15,11 @@ config :explorer,
       "homestead,tangerineWhistle,spuriousDragon,byzantium,constantinople,petersburg,default",
   include_uncles_in_average_block_time:
     if(System.get_env("UNCLES_IN_AVERAGE_BLOCK_TIME") == "true", do: true, else: false),
-  healthy_blocks_period: System.get_env("HEALTHY_BLOCKS_PERIOD") || :timer.minutes(5),
+  healthy_blocks_period:
+    (case Integer.parse(System.get_env("HEALTHY_BLOCKS_PERIOD", "")) do
+       {secs, ""} -> :timer.seconds(secs)
+       _ -> :timer.minutes(5)
+     end),
   realtime_events_sender:
     if(System.get_env("DISABLE_WEBAPP") != "true",
       do: Explorer.Chain.Events.SimpleSender,

--- a/bin/install_chrome_headless.sh
+++ b/bin/install_chrome_headless.sh
@@ -1,6 +1,6 @@
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
-export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE_83`
+export CHROMEDRIVER_VERSION=`curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE`
 curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
 unzip chromedriver_linux64.zip
 sudo chmod +x chromedriver


### PR DESCRIPTION
The health endpoint wasn't working correctly when the `HEALTHY_BLOCKS_PERIOD` was passed.
