### PR TITLE
Fix fetch_coin_balance query: coin balance delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2918](https://github.com/poanetwork/blockscout/pull/2918) - Add tokenID for tokentx API action explicitly
 
 ### Fixes
+- [#3284](https://github.com/poanetwork/blockscout/pull/3284) - Fix fetch_coin_balance query: coin balance delta
 - [#2934](https://github.com/poanetwork/blockscout/pull/2934) - RSK release 1.2.0 breaking changes support
 - [#2933](https://github.com/poanetwork/blockscout/pull/2933) - Get rid of deadlock in the query to address_current_token_balance table
 - [#2932](https://github.com/poanetwork/blockscout/pull/2932) - fix duplicate websocket connection


### PR DESCRIPTION
## Motivation

Current query in fetch_coin_balance function causes performance issues.

## Changelog
In order to address the performance of the query replace

```
SELECT a0."block_number", a0."value", a0."value_fetched_at", a0."inserted_at", a0."updated_at", a0."address_hash", value - coalesce(lag(value, 1) over (order by block_number), 0), b1."timestamp" FROM "address_coin_balances" AS a0 INNER JOIN "blocks" AS b1 ON a0."block_number" = b1."number" WHERE (a0."address_hash" = '\...') AND (a0."block_number" <= ...) ORDER BY a0."block_number" DESC LIMIT 1;
```
with

```
SELECT c."block_number", c."value", c."value_fetched_at", c."inserted_at", c."updated_at", c."address_hash", value - coalesce(lag(value, 1) over (order by block_number), 0) from (select a0."block_number", a0."value", a0."value_fetched_at", a0."inserted_at", a0."updated_at", a0."address_hash" FROM "address_coin_balances" AS a0  WHERE (a0."address_hash" = '\x...') AND (a0."block_number" <= ...) ORDER BY a0."block_number" DESC LIMIT 2) as c ORDER BY c."block_number" DESC LIMIT 1;
```

See https://github.com/poanetwork/blockscout/pull/3284

