### PR TITLE
Add Cloudbuild step for building API docker image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,14 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-f", "docker/Dockerfile", "-t", "gcr.io/$PROJECT_ID/blockscout:$COMMIT_SHA", "."]
     waitFor: ["-"]
+  - name: "gcr.io/cloud-builders/docker"
+    args: ["build", "-f", "docker/Dockerfile",
+           "--build-arg", "DISABLE_WRITE_API=true",
+           "--build-arg", "DISABLE_INDEXER=true",
+           "--build-arg", "DISABLE_WEBAPP=true",
+           "-t", "gcr.io/$PROJECT_ID/blockscout:api-$COMMIT_SHA", "."]
+    waitFor: ["-"]
 timeout: 1200s
 images:
   - "gcr.io/$PROJECT_ID/blockscout:$COMMIT_SHA"
+  - "gcr.io/$PROJECT_ID/blockscout:api-$COMMIT_SHA"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,3 +13,5 @@ timeout: 1200s
 images:
   - "gcr.io/$PROJECT_ID/blockscout:$COMMIT_SHA"
   - "gcr.io/$PROJECT_ID/blockscout:api-$COMMIT_SHA"
+
+timeout: 1800s

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,9 @@ RUN mix do deps.get, deps.compile
 ADD . .
 
 ARG COIN
+ARG DISABLE_WRITE_API="false"
+ARG DISABLE_INDEXER="false"
+ARG DISABLE_WEBAPP="false"
 RUN if [ "$COIN" != "" ]; then sed -i s/"POA"/"${COIN}"/g apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po; fi
 
 # Run forderground build and phoenix digest


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

Adds a new docker image (tagged as `api-$hash`) built with `DISABLE_WRITE_API=true` as defined in https://docs.blockscout.com/for-developers/information-and-settings/env-variables.