### PR TITLE
Indexer health check endpoint

### DIFF
--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -13,6 +13,13 @@ block_transformers = %{
 # Compile time environment variable access requires recompilation.
 configured_transformer = System.get_env("BLOCK_TRANSFORMER") || "celo"
 
+port =
+  case System.get_env("PORT") && Integer.parse(System.get_env("PORT")) do
+    {port, _} -> port
+    :error -> nil
+    nil -> nil
+  end
+
 block_transformer =
   case Map.get(block_transformers, configured_transformer) do
     nil ->
@@ -46,6 +53,7 @@ config :indexer,
     String.to_integer(System.get_env("TOKEN_METADATA_UPDATE_INTERVAL") || "#{10 * 60 * 60}"),
   # bytes
   memory_limit: 1 <<< 32,
+  health_check_port: port || 4000,
   first_block: System.get_env("FIRST_BLOCK") || "0",
   last_block: System.get_env("LAST_BLOCK") || "",
   max_skipping_distance: max_skipping_distance

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -5,8 +5,7 @@ defmodule Indexer.Application do
 
   use Application
 
-  alias Indexer.Memory
-  alias Indexer.Health
+  alias Indexer.{Health, Memory}
 
   @impl Application
   def start(_type, _args) do
@@ -20,7 +19,8 @@ defmodule Indexer.Application do
 
     base_children = [
       {Memory.Monitor, [memory_monitor_options, [name: memory_monitor_name]]},
-      {Plug.Cowboy, scheme: :http, plug: Health.Plug, options: [port: Application.get_env(:indexer, :health_check_port)]}
+      {Plug.Cowboy,
+       scheme: :http, plug: Health.Plug, options: [port: Application.get_env(:indexer, :health_check_port)]}
     ]
 
     children =

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -6,6 +6,7 @@ defmodule Indexer.Application do
   use Application
 
   alias Indexer.Memory
+  alias Indexer.Health
 
   @impl Application
   def start(_type, _args) do
@@ -18,7 +19,8 @@ defmodule Indexer.Application do
     memory_monitor_name = Memory.Monitor
 
     base_children = [
-      {Memory.Monitor, [memory_monitor_options, [name: memory_monitor_name]]}
+      {Memory.Monitor, [memory_monitor_options, [name: memory_monitor_name]]},
+      {Plug.Cowboy, scheme: :http, plug: Health.Plug, options: [port: Application.get_env(:indexer, :health_check_port)]}
     ]
 
     children =

--- a/apps/indexer/lib/indexer/health.ex
+++ b/apps/indexer/lib/indexer/health.ex
@@ -1,0 +1,16 @@
+defmodule Indexer.Health do
+  @moduledoc """
+  Check various health attributes of the application
+  """
+
+
+  @doc """
+  Check if app is alive and working, by making a simple
+  request to the DB
+  """
+  def is_alive? do
+    !!Ecto.Adapters.SQL.query!(Explorer.Repo, "SELECT 1")
+  rescue
+    _e -> false
+  end
+end

--- a/apps/indexer/lib/indexer/health.ex
+++ b/apps/indexer/lib/indexer/health.ex
@@ -3,13 +3,15 @@ defmodule Indexer.Health do
   Check various health attributes of the application
   """
 
+  alias Ecto.Adapters.SQL
 
   @doc """
   Check if app is alive and working, by making a simple
   request to the DB
   """
-  def is_alive? do
-    !!Ecto.Adapters.SQL.query!(Explorer.Repo, "SELECT 1")
+  def alive? do
+    SQL.query!(Explorer.Repo, "SELECT 1")
+    true
   rescue
     _e -> false
   end

--- a/apps/indexer/lib/indexer/health.ex
+++ b/apps/indexer/lib/indexer/health.ex
@@ -6,10 +6,63 @@ defmodule Indexer.Health do
   alias Ecto.Adapters.SQL
 
   @doc """
-  Check if app is alive and working, by making a simple
-  request to the DB
+  Check if app is ready
+  """
+  def ready? do
+    database_connection_alive?() &&
+      fullnode_ready?()
+  end
+
+  @doc """
+  Check if app is alive and working
   """
   def alive? do
+    database_connection_alive?() &&
+      fullnode_connection_alive?()
+  end
+
+  @doc """
+  Check if app can connect to the fullnode and
+  the latest block is fresh
+  """
+  def fullnode_ready? do
+    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+    healthy_blocks_period = Application.get_env(:explorer, :healthy_blocks_period)
+
+    case EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments) do
+      {:ok, number} ->
+        case EthereumJSONRPC.fetch_blocks_by_range(number..number, json_rpc_named_arguments) do
+          {:ok, blocks} ->
+            diff = DateTime.diff(DateTime.utc_now(), Enum.at(blocks.blocks_params, 0).timestamp) * 1000
+            diff <= healthy_blocks_period
+
+          {:error, _} ->
+            false
+        end
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  @doc """
+  Check if app can connect to the fullnode
+  """
+  def fullnode_connection_alive? do
+    case EthereumJSONRPC.fetch_net_version(Application.get_env(:explorer, :json_rpc_named_arguments)) do
+      {:ok, _} ->
+        true
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  @doc """
+  Check if DB connection is alive, by making a simple
+  request
+  """
+  def database_connection_alive? do
     SQL.query!(Explorer.Repo, "SELECT 1")
     true
   rescue

--- a/apps/indexer/lib/indexer/health/plug.ex
+++ b/apps/indexer/lib/indexer/health/plug.ex
@@ -1,0 +1,39 @@
+defmodule Indexer.Health.Plug do
+  import Plug.Conn
+  alias Indexer.Health
+
+  @behaviour Plug
+
+  @path_liveness  "/health/liveness"
+
+
+  # Plug Callbacks
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%Plug.Conn{} = conn, _opts) do
+    case conn.request_path do
+      @path_liveness  -> health_response(conn, Health.is_alive?())
+      _other          -> not_found_response(conn)
+    end
+  end
+
+  defp not_found_response(conn) do
+    conn
+    |> send_resp(404, "Not Found")
+    |> halt()
+  end
+
+  defp health_response(conn, true) do
+    conn
+    |> send_resp(200, "OK")
+    |> halt()
+  end
+
+  defp health_response(conn, false) do
+    conn
+    |> send_resp(503, "Service Unavailable")
+    |> halt()
+  end
+end

--- a/apps/indexer/lib/indexer/health/plug.ex
+++ b/apps/indexer/lib/indexer/health/plug.ex
@@ -1,11 +1,14 @@
 defmodule Indexer.Health.Plug do
+  @moduledoc """
+  Plug that exposes health checks as web endpoints.
+  """
+
   import Plug.Conn
   alias Indexer.Health
 
   @behaviour Plug
 
-  @path_liveness  "/health/liveness"
-
+  @path_liveness "/health/liveness"
 
   # Plug Callbacks
   @impl true
@@ -14,8 +17,8 @@ defmodule Indexer.Health.Plug do
   @impl true
   def call(%Plug.Conn{} = conn, _opts) do
     case conn.request_path do
-      @path_liveness  -> health_response(conn, Health.is_alive?())
-      _other          -> not_found_response(conn)
+      @path_liveness -> health_response(conn, Health.alive?())
+      _other -> not_found_response(conn)
     end
   end
 

--- a/apps/indexer/lib/indexer/health/plug.ex
+++ b/apps/indexer/lib/indexer/health/plug.ex
@@ -8,6 +8,7 @@ defmodule Indexer.Health.Plug do
 
   @behaviour Plug
 
+  @path_readiness "/health/readiness"
   @path_liveness "/health/liveness"
 
   # Plug Callbacks
@@ -18,6 +19,7 @@ defmodule Indexer.Health.Plug do
   def call(%Plug.Conn{} = conn, _opts) do
     case conn.request_path do
       @path_liveness -> health_response(conn, Health.alive?())
+      @path_readiness -> health_response(conn, Health.ready?())
       _other -> not_found_response(conn)
     end
   end


### PR DESCRIPTION
Adds health check endpoints `/health/liveness` and `/health/readiness` that can be used in k8s probes.