### PR TITLE
Updated the list of networks

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -115,10 +115,6 @@
             <%= for %{url: url, title: title} <- test_nets(dropdown_nets()) do %> 
               <a class="dropdown-item" href="<%= url%>"><%= title %></a>  
             <% end %> 
-            <a class="dropdown-item header division">Other Networks</a> 
-            <%= for %{url: url, title: title} <- dropdown_other_nets() do %>  
-              <a class="dropdown-item" href="<%= url%>"><%= title %></a>  
-            <% end %> 
           </div>
         </li>
       </ul>

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -7,13 +7,13 @@ defmodule BlockScoutWeb.LayoutView do
   @issue_url "https://github.com/celo-org/celo-monorepo/issues/new"
   @default_other_networks [
     %{
-      title: "Celo Alfajores",
-      url: "https://alfajores-blockscout.celo-testnet.org/",
-      test_net?: true
+      title: "Celo Mainnet",
+      url: "https://explorer.celo.org",
+      test_net?: false
     },
     %{
-      title: "Celo Integration",
-      url: "https://integration-blockscout.celo-testnet.org/",
+      title: "Celo Alfajores",
+      url: "https://alfajores-blockscout.celo-testnet.org/",
       test_net?: true
     },
     %{

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1244,14 +1244,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:141
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:158
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:137
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
 msgid "Search"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:131
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:135
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:139
 msgid "Search by address, token symbol name, transaction hash, or block number"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -997,10 +997,12 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:30
 #: lib/block_scout_web/templates/layout/app.html.eex:73
 #: lib/block_scout_web/views/address_view.ex:189
+#: lib/block_scout_web/views/address_view.ex:189
 msgid "Market Cap"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:169
 #: lib/block_scout_web/views/transaction_view.ex:169
 msgid "Max of"
 msgstr ""
@@ -1243,14 +1245,14 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/index.html.eex:14
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:141
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:158
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:137
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
 msgid "Search"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:131
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:135
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:139
 msgid "Search by address, token symbol name, transaction hash, or block number"
 msgstr ""
 
@@ -1821,6 +1823,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:29
 #: lib/block_scout_web/templates/transaction/overview.html.eex:221
 #: lib/block_scout_web/templates/transaction/overview.html.eex:256
+#: lib/block_scout_web/views/transaction_view.ex:303
 #: lib/block_scout_web/views/transaction_view.ex:303
 #: lib/block_scout_web/views/wei_helpers.ex:78
 msgid "CELO"


### PR DESCRIPTION
## Motivation

Removes unused links to networks and adds the mainnet link. Resolves https://github.com/celo-org/blockscout/issues/147 and https://github.com/celo-org/celo-monorepo/issues/5879.