### PR TITLE
Added gateway fee recipient information

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -98,7 +98,11 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "contractAddress" => "#{transaction.created_contract_address_hash}",
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
       "gasUsed" => "#{transaction.gas_used}",
-      "confirmations" => "#{transaction.confirmations}"
+      "confirmations" => "#{transaction.confirmations}",
+      "gatewayFeeRecipient" =>
+        if(transaction.gas_fee_recipient_hash !== nil, do: "#{transaction.gas_fee_recipient_hash}", else: nil),
+      "gatewayFee" => "#{transaction.gateway_fee}",
+      "feeCurrency" => if(transaction.fee_currency == "stableToken", do: "cUSD", else: "CELO")
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -99,8 +99,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
       "gasUsed" => "#{transaction.gas_used}",
       "confirmations" => "#{transaction.confirmations}",
-      "gatewayFeeRecipient" =>
-        if(transaction.gas_fee_recipient_hash !== nil, do: "#{transaction.gas_fee_recipient_hash}", else: nil),
+      "gatewayFeeRecipient" => "#{transaction.gas_fee_recipient_hash}",
       "gatewayFee" => "#{transaction.gateway_fee}",
       "feeCurrency" => if(transaction.fee_currency == "stableToken", do: "cUSD", else: "CELO")
     }

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -583,7 +583,10 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
           "contractAddress" => "#{transaction.created_contract_address_hash}",
           "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
           "gasUsed" => "#{transaction.gas_used}",
-          "confirmations" => "0"
+          "confirmations" => "0",
+          "gatewayFee" => "",
+          "gatewayFeeRecipient" => "",
+          "feeCurrency" => "CELO"
         }
       ]
 

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Etherscan do
   alias Explorer.Etherscan.Logs
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Address.TokenBalance
-  alias Explorer.Chain.{Block, Hash, InternalTransaction, TokenTransfer, Transaction}
+  alias Explorer.Chain.{Block, CeloParams, Hash, InternalTransaction, TokenTransfer, Transaction}
 
   @default_options %{
     order_by_direction: :desc,
@@ -341,12 +341,15 @@ defmodule Explorer.Etherscan do
     query =
       from(
         t in Transaction,
+        left_join: p in CeloParams,
+        on: t.gas_currency_hash == p.address_value,
         inner_join: b in assoc(t, :block),
         order_by: [{^options.order_by_direction, t.block_number}],
         limit: ^options.page_size,
         offset: ^offset(options),
         select:
           merge(map(t, ^@transaction_fields), %{
+            fee_currency: p.name,
             block_timestamp: b.timestamp,
             confirmations: fragment("? - ?", ^max_block_number, t.block_number)
           })


### PR DESCRIPTION
## Motivation

Fixes #167.

## Changelog

### Enhancements

Adds 3 additional fields to the txlist `API` response:
* `feeCurrency`. String, not nullable, one of `cUSD`, `CELO`.
* `gatewayFee`. String, not nullable.
* `gatewayFeeRecipient`. String, if there is no gateway fee, returns an empty string.