### PR TITLE
Implemented token transfers with logs endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.RPC.TokenController do
   use BlockScoutWeb, :controller
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, Etherscan}
 
   def gettoken(conn, params) do
     with {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
@@ -20,11 +20,123 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
     end
   end
 
+  def tokentx(conn, params) do
+    with {:required_params, {:ok, fetched_params}} <- fetch_required_params(params),
+         {:format, {:ok, validated_params}} <- to_valid_format(fetched_params),
+         {:token, {:ok, _}} <- {:token, Chain.token_from_address_hash(validated_params.address_hash)},
+         {:ok, token_transfers} <- list_token_transfers(validated_params) do
+      render(conn, :tokentx, %{token_transfers: token_transfers})
+    else
+      {:required_params, {:error, missing_params}} ->
+        error = "Required query parameters missing: #{Enum.join(missing_params, ", ")}"
+        render(conn, :error, error: error)
+
+      {:format, {:error, param}} ->
+        render(conn, :error, error: "Invalid #{param} format")
+
+      {:token, {:error, :not_found}} ->
+        render(conn, :error, error: "contractaddress not found")
+    end
+  end
+
+  @required_params %{
+    # all_of: all of these parameters are required
+    all_of: ["fromBlock", "toBlock", "contractaddress"]
+  }
+
+  @doc """
+  Fetches required params. Returns error tuple if required params are missing.
+
+  """
+  @spec fetch_required_params(map()) :: {:required_params, {:ok, map()} | {:error, [String.t(), ...]}}
+  def fetch_required_params(params) do
+    fetched_params = Map.take(params, @required_params.all_of)
+
+    if all_of_required_keys_found?(fetched_params) do
+      {:required_params, {:ok, fetched_params}}
+    else
+      missing_params = get_missing_required_params(fetched_params)
+      {:required_params, {:error, missing_params}}
+    end
+  end
+
+  defp get_missing_required_params(fetched_params) do
+    fetched_keys = fetched_params |> Map.keys() |> MapSet.new()
+
+    @required_params.all_of
+    |> MapSet.new()
+    |> MapSet.difference(fetched_keys)
+    |> MapSet.to_list()
+  end
+
+  defp all_of_required_keys_found?(fetched_params) do
+    Enum.all?(@required_params.all_of, &Map.has_key?(fetched_params, &1))
+  end
+
+  @doc """
+  Prepares params for processing. Returns error tuple if invalid format is
+  found.
+
+  """
+  @spec to_valid_format(map()) :: {:format, {:ok, map()} | {:error, String.t()}}
+  def to_valid_format(params) do
+    result =
+      with {:ok, from_block} <- to_block_number(params, "fromBlock"),
+           {:ok, to_block} <- to_block_number(params, "toBlock"),
+           {:ok, address_hash} <- to_address_hash(params["contractaddress"]) do
+        validated_params = %{
+          from_block: from_block,
+          to_block: to_block,
+          address_hash: address_hash
+        }
+
+        {:ok, validated_params}
+      else
+        {:error, param_key} ->
+          {:error, param_key}
+      end
+
+    {:format, result}
+  end
+
+  defp to_block_number(params, param_key) do
+    case params[param_key] do
+      "latest" ->
+        Chain.max_consensus_block_number()
+
+      _ ->
+        to_integer(params, param_key)
+    end
+  end
+
+  defp to_integer(params, param_key) do
+    case Integer.parse(params[param_key]) do
+      {integer, ""} ->
+        {:ok, integer}
+
+      _ ->
+        {:error, param_key}
+    end
+  end
+
   defp fetch_contractaddress(params) do
     {:contractaddress_param, Map.fetch(params, "contractaddress")}
   end
 
   defp to_address_hash(address_hash_string) do
-    {:format, Chain.string_to_address_hash(address_hash_string)}
+    case Chain.string_to_address_hash(address_hash_string) do
+      :error ->
+        {:error, "address"}
+
+      {:ok, address_hash} ->
+        {:ok, address_hash}
+    end
+  end
+
+  defp list_token_transfers(params) do
+    case Etherscan.list_token_transfers(params) do
+      [] -> {:error, :not_found}
+      token_transfers -> {:ok, token_transfers}
+    end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -68,7 +68,7 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
   found.
 
   """
-  # @spec to_valid_format(map()) :: {:format, {:ok, map()} | {:error, String.t()}}
+  @spec to_valid_format(map()) :: {:format, {:ok, map()} | {:error, String.t()}}
   def to_valid_format(params) do
     result =
       with {:ok, from_block} <- to_block_number(params, "fromBlock"),

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
@@ -28,11 +28,6 @@ defmodule BlockScoutWeb.API.RPC.TokenView do
     }
   end
 
-  # {
-
-  #     "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
-  #   }
-
   defp prepare_token_transfer(token_transfer) do
     %{
       "blockNumber" => integer_to_hex(token_transfer.block_number),

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
@@ -7,6 +7,11 @@ defmodule BlockScoutWeb.API.RPC.TokenView do
     RPCView.render("show.json", data: prepare_token(token))
   end
 
+  def render("tokentx.json", %{token_transfers: token_transfers}) do
+    data = Enum.map(token_transfers, &prepare_token_transfer/1)
+    RPCView.render("show.json", data: data)
+  end
+
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
   end
@@ -21,5 +26,51 @@ defmodule BlockScoutWeb.API.RPC.TokenView do
       "contractAddress" => to_string(token.contract_address_hash),
       "cataloged" => token.cataloged
     }
+  end
+
+  # {
+
+  #     "data": "0x0000000000000000000000000000000000000000000000000000000000000001",
+  #   }
+
+  defp prepare_token_transfer(token_transfer) do
+    %{
+      "blockNumber" => integer_to_hex(token_transfer.block_number),
+      "timeStamp" => datetime_to_hex(token_transfer.block_timestamp),
+      "transactionHash" => "#{token_transfer.transaction_hash}",
+      "address" => "#{token_transfer.token_contract_address_hash}",
+      "transactionIndex" => integer_to_hex(token_transfer.transaction_index),
+      "logIndex" => integer_to_hex(token_transfer.log_index),
+      "gasPrice" => decimal_to_hex(token_transfer.gas_price.value),
+      "gasUsed" => decimal_to_hex(token_transfer.gas_used),
+      "feeCurrency" => "#{token_transfer.gas_currency_hash}",
+      "gatewayFeeRecipient" => "#{token_transfer.gas_fee_recipient_hash}",
+      "gatewayFee" => "#{token_transfer.gateway_fee}",
+      "topics" => get_topics(token_transfer),
+      "data" => "#{token_transfer.data}"
+    }
+  end
+
+  defp integer_to_hex(integer), do: Integer.to_string(integer, 16)
+
+  defp decimal_to_hex(decimal) do
+    decimal
+    |> Decimal.to_integer()
+    |> integer_to_hex()
+  end
+
+  defp datetime_to_hex(datetime) do
+    datetime
+    |> DateTime.to_unix()
+    |> integer_to_hex()
+  end
+
+  defp get_topics(%{
+         first_topic: first_topic,
+         second_topic: second_topic,
+         third_topic: third_topic,
+         fourth_topic: fourth_topic
+       }) do
+    [first_topic, second_topic, third_topic, fourth_topic]
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
@@ -30,6 +30,9 @@ defmodule BlockScoutWeb.API.RPC.TokenView do
 
   defp prepare_token_transfer(token_transfer) do
     %{
+      "amount" => "#{token_transfer.amount}",
+      "fromAddressHash" => "#{token_transfer.from_address_hash}",
+      "toAddressHash" => "#{token_transfer.to_address_hash}",
       "blockNumber" => integer_to_hex(token_transfer.block_number),
       "timeStamp" => datetime_to_hex(token_transfer.block_timestamp),
       "transactionHash" => "#{token_transfer.transaction_hash}",

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
@@ -49,6 +49,7 @@ defmodule BlockScoutWeb.API.RPC.TokenView do
     }
   end
 
+  defp integer_to_hex(nil), do: ""
   defp integer_to_hex(integer), do: Integer.to_string(integer, 16)
 
   defp decimal_to_hex(decimal) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
   use BlockScoutWeb.ConnCase
 
+  alias Explorer.Chain.{Log, Transaction}
+
   describe "gettoken" do
     test "with missing contract address", %{conn: conn} do
       params = %{
@@ -83,5 +85,248 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
       assert response["status"] == "1"
       assert response["message"] == "OK"
     end
+  end
+
+  describe "tokentx" do
+    test "with missing required parameters", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokentx"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Required query parameters missing: contractaddress, fromBlock, toBlock"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid contractaddress hash", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokentx",
+        "fromBlock" => "1",
+        "toBlock" => "3",
+        "contractaddress" => "badhash"
+      }
+
+      assert response =
+              conn
+              |> get("/api", params)
+              |> json_response(200)
+
+      assert response["message"] =~ "Invalid address format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid fromBlock value", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokentx",
+        "fromBlock" => "invalid",
+        "toBlock" => "3",
+        "contractaddress" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      }
+
+      assert response =
+              conn
+              |> get("/api", params)
+              |> json_response(200)
+
+      assert response["message"] =~ "Invalid fromBlock format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid toBlock value", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokentx",
+        "fromBlock" => "1",
+        "toBlock" => "invalid",
+        "contractaddress" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      }
+
+      assert response =
+              conn
+              |> get("/api", params)
+              |> json_response(200)
+
+      assert response["message"] =~ "Invalid toBlock format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with a contractaddress that doesn't exist", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokentx",
+        "fromBlock" => "1",
+        "toBlock" => "3",
+        "contractaddress" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      }
+
+      assert response =
+              conn
+              |> get("/api", params)
+              |> json_response(200)
+
+      assert response["message"] =~ "contractaddress not found"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "successful case with logs", %{conn: conn} do
+      contract_address = insert(:contract_address)
+      insert(:token, contract_address: contract_address)
+      address = insert(:address)
+
+      transaction =
+        %Transaction{block: block} =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block()
+
+      insert(:token_transfer,
+        transaction: transaction,
+        from_address: contract_address,
+        to_address: address,
+        token_contract_address: contract_address,
+        block: transaction.block,
+        token_id: 10
+      )
+
+      log = insert(:log, address: contract_address, transaction: transaction)
+
+      params = %{
+        "module" => "token",
+        "action" => "tokentx",
+        "fromBlock" => "0",
+        "toBlock" => "latest",
+        "contractaddress" => "#{contract_address.hash}"
+      }
+
+      expected_result = [
+        %{
+          "address" => "#{contract_address.hash}",
+          "topics" => get_topics(log),
+          "data" => "#{log.data}",
+          "blockNumber" => integer_to_hex(transaction.block_number),
+          "timeStamp" => datetime_to_hex(block.timestamp),
+          "gasPrice" => decimal_to_hex(transaction.gas_price.value),
+          "gasUsed" => decimal_to_hex(transaction.gas_used),
+          "gatewayFeeRecipient" => "",
+          "gatewayFee" => "",
+          "feeCurrency" => "",
+          "logIndex" => integer_to_hex(log.index),
+          "transactionHash" => "#{transaction.hash}",
+          "transactionIndex" => integer_to_hex(transaction.index),
+          "amount" => "1",
+          "fromAddressHash" => "#{contract_address.hash}",
+          "toAddressHash" => "#{address.hash}"
+        }
+      ]
+
+      assert response =
+              conn
+              |> get("/api", params)
+              |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+
+    test "successful case without logs", %{conn: conn} do
+      contract_address = insert(:contract_address)
+      insert(:token, contract_address: contract_address)
+      address = insert(:address)
+
+      transaction =
+        %Transaction{block: block} =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block()
+
+      insert(:token_transfer,
+        transaction: transaction,
+        from_address: contract_address,
+        to_address: address,
+        token_contract_address: contract_address,
+        block: transaction.block,
+        token_id: 10
+      )
+
+      params = %{
+        "module" => "token",
+        "action" => "tokentx",
+        "fromBlock" => "0",
+        "toBlock" => "latest",
+        "contractaddress" => "#{contract_address.hash}"
+      }
+
+      expected_result = [
+        %{
+          "address" => "#{contract_address.hash}",
+          "topics" => [nil, nil, nil, nil],
+          "data" => "",
+          "blockNumber" => integer_to_hex(transaction.block_number),
+          "timeStamp" => datetime_to_hex(block.timestamp),
+          "gasPrice" => decimal_to_hex(transaction.gas_price.value),
+          "gasUsed" => decimal_to_hex(transaction.gas_used),
+          "gatewayFeeRecipient" => "",
+          "gatewayFee" => "",
+          "feeCurrency" => "",
+          "logIndex" => "",
+          "transactionHash" => "#{transaction.hash}",
+          "transactionIndex" => integer_to_hex(transaction.index),
+          "amount" => "1",
+          "fromAddressHash" => "#{contract_address.hash}",
+          "toAddressHash" => "#{address.hash}"
+        }
+      ]
+
+      assert response =
+              conn
+              |> get("/api", params)
+              |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+  end
+
+  defp get_topics(%Log{
+      first_topic: first_topic,
+      second_topic: second_topic,
+      third_topic: third_topic,
+      fourth_topic: fourth_topic
+    }) do
+    [first_topic, second_topic, third_topic, fourth_topic]
+  end
+
+  defp integer_to_hex(nil), do: ""
+  defp integer_to_hex(integer), do: Integer.to_string(integer, 16)
+
+  defp decimal_to_hex(decimal) do
+    decimal
+    |> Decimal.to_integer()
+    |> integer_to_hex()
+  end
+
+  defp datetime_to_hex(datetime) do
+    datetime
+    |> DateTime.to_unix()
+    |> integer_to_hex()
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
@@ -115,9 +115,9 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
       }
 
       assert response =
-              conn
-              |> get("/api", params)
-              |> json_response(200)
+               conn
+               |> get("/api", params)
+               |> json_response(200)
 
       assert response["message"] =~ "Invalid address format"
       assert response["status"] == "0"
@@ -135,9 +135,9 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
       }
 
       assert response =
-              conn
-              |> get("/api", params)
-              |> json_response(200)
+               conn
+               |> get("/api", params)
+               |> json_response(200)
 
       assert response["message"] =~ "Invalid fromBlock format"
       assert response["status"] == "0"
@@ -155,9 +155,9 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
       }
 
       assert response =
-              conn
-              |> get("/api", params)
-              |> json_response(200)
+               conn
+               |> get("/api", params)
+               |> json_response(200)
 
       assert response["message"] =~ "Invalid toBlock format"
       assert response["status"] == "0"
@@ -175,9 +175,9 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
       }
 
       assert response =
-              conn
-              |> get("/api", params)
-              |> json_response(200)
+               conn
+               |> get("/api", params)
+               |> json_response(200)
 
       assert response["message"] =~ "contractaddress not found"
       assert response["status"] == "0"
@@ -237,9 +237,9 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
       ]
 
       assert response =
-              conn
-              |> get("/api", params)
-              |> json_response(200)
+               conn
+               |> get("/api", params)
+               |> json_response(200)
 
       assert response["result"] == expected_result
       assert response["status"] == "1"
@@ -296,9 +296,9 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
       ]
 
       assert response =
-              conn
-              |> get("/api", params)
-              |> json_response(200)
+               conn
+               |> get("/api", params)
+               |> json_response(200)
 
       assert response["result"] == expected_result
       assert response["status"] == "1"
@@ -307,11 +307,11 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
   end
 
   defp get_topics(%Log{
-      first_topic: first_topic,
-      second_topic: second_topic,
-      third_topic: third_topic,
-      fourth_topic: fourth_topic
-    }) do
+         first_topic: first_topic,
+         second_topic: second_topic,
+         third_topic: third_topic,
+         fourth_topic: fourth_topic
+       }) do
     [first_topic, second_topic, third_topic, fourth_topic]
   end
 

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -255,14 +255,15 @@ defmodule Explorer.Etherscan do
   def list_token_transfers(params) do
     query =
       from(
-        t in Transaction,
-        inner_join: tt in TokenTransfer,
-        on: tt.transaction_hash == t.hash and tt.block_number == t.block_number and tt.block_hash == t.block_hash,
-        inner_join: b in assoc(t, :block),
+        b in Block,
+        left_join: t in Transaction,
+        on: t.block_number == b.number,
         left_join: l in Log,
-        on: l.transaction_hash == tt.transaction_hash and l.index == tt.log_index,
+        on: l.transaction_hash == t.hash and l.address_hash == ^params.address_hash,
+        inner_join: tt in TokenTransfer,
+        on: tt.transaction_hash == t.hash,
         where:
-          tt.block_number >= ^params.from_block and tt.block_number <= ^params.to_block and
+          b.number >= ^params.from_block and b.number <= ^params.to_block and
             tt.token_contract_address_hash == ^params.address_hash,
         order_by: [
           {:asc, tt.block_number},


### PR DESCRIPTION
## Motivation

Currently, there is no way to fetch native CELO transfers in the given block range, while it's possible for cUSD. The Notification service misses native transfers and doesn't notify users because of that.

The endpoint call looks like `curl --silent "https://explorer.celo.org/api?module=token&action=tokentx&fromBlock=3282183&toBlock=3282286&contractaddress=0x471ece3750da237f93b8e339c536989b8978a438"`.
There are 3 required parameters:
- `fromBlock`, integer, starting block.
- `toBlock`, integer or `latest`, end block.
- `contractaddress` - contract address of the token, works for both CELO and cUSD.

Example output:
```
{
  "status": "1",
  "result": [
    {
      "transactionIndex": "7",
      "transactionHash": "0xe36c8ca582643165094fd9f589002433c708d566786194d3c32b797183463f4d",
      "topics": [
        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
        "0x00000000000000000000000039fab206a209db6e1735183f678711d78eed9b57",
        "0x000000000000000000000000bda473e9f79529bb033e3ed8c64f275a888e5ec4",
        null
      ],
      "toAddressHash": "0xbda473e9f79529bb033e3ed8c64f275a888e5ec4",
      "timeStamp": "60070CED",
      "logIndex": "E",
      "gatewayFeeRecipient": "",
      "gatewayFee": "0",
      "gasUsed": "FFE1",
      "gasPrice": "5F5E100",
      "fromAddressHash": "0x39fab206a209db6e1735183f678711d78eed9b57",
      "feeCurrency": "",
      "data": "0x0000000000000000000000000000000000000000000000000000016e0348cd1c",
      "blockNumber": "30417C",
      "amount": "1572013133084",
      "address": "0x471ece3750da237f93b8e339c536989b8978a438"
    },
    {
      "transactionIndex": "2",
      "transactionHash": "0x48dbfda3bda5c66f19e8eabdc7bd2591c986df9b5e2643af079f37fe1bcd9f5f",
      "topics": [
        null,
        null,
        null,
        null
      ],
      "toAddressHash": "0xb108378aabacab8f0efa55776dc601c084c02079",
      "timeStamp": "60070F0D",
      "logIndex": "B",
      "gatewayFeeRecipient": "",
      "gatewayFee": "0",
      "gasUsed": "FFAC",
      "gasPrice": "5F5E100",
      "fromAddressHash": "0x3066505c7d215161b4a8377818bad04f33bca6f7",
      "feeCurrency": "",
      "data": null,
      "blockNumber": "30417C",
      "amount": "40000000000000000",
      "address": "0x471ece3750da237f93b8e339c536989b8978a438"
    },
    ...
  ],
  "message": "OK"
}
```

The output is compatible with the response of the `/api?module=logs&action=getLogs&fromBlock=3282183&toBlock=3282286&address=0x471ece3750da237f93b8e339c536989b8978a438` calls but includes native CELO transfers and contains additional fields `toAddressHash`, `fromAddressHash` and `amount` to simplify processing of both types of transfers (CELO and cUSD). Notice, that log-related fields are nulls in the second response as they don't exist for native transfers.

## Changelog

### Enhancements
This PR adds a new RPC API endpoint that returns token transfers by the contract address in the given block range.