### PR TITLE
Added total transactions stats endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -58,6 +58,11 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
     render(conn, "ethprice.json", rates: rates)
   end
 
+  def totaltransactions(conn, _params) do
+    transaction_estimated_count = Chain.transaction_estimated_count()
+    render(conn, "totaltransactions.json", count: transaction_estimated_count)
+  end
+
   defp fetch_contractaddress(params) do
     {:contractaddress_param, Map.fetch(params, "contractaddress")}
   end

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -289,6 +289,12 @@ defmodule BlockScoutWeb.Etherscan do
     }
   }
 
+  @stats_totaltransactions_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => "2387845"
+  }
+
   @block_getblockreward_example_value %{
     "status" => "1",
     "message" => "OK",
@@ -1909,6 +1915,32 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @stats_totaltransactions_action %{
+    name: "totaltransactions",
+    description: "Get estimated total number of transactions.",
+    required_params: [],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@stats_totaltransactions_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "integer",
+              description: "The estimated total number of transactions",
+              example: ~s("2387845")
+            }
+          }
+        }
+      }
+    ]
+  }
+
   @block_eth_block_number_action %{
     name: "eth_block_number",
     description: "Mimics Ethereum JSON RPC's eth_blockNumber. Returns the lastest block number",
@@ -2405,7 +2437,8 @@ defmodule BlockScoutWeb.Etherscan do
       @stats_ethsupplyexchange_action,
       @stats_ethsupply_action,
       @stats_coinsupply_action,
-      @stats_ethprice_action
+      @stats_ethprice_action,
+      @stats_totaltransactions_action
     ]
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -23,6 +23,10 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
     RPCView.render("show.json", data: prepare_rates(rates))
   end
 
+  def render("totaltransactions.json", %{count: count}) do
+    RPCView.render("show.json", data: count)
+  end
+
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
   end


### PR DESCRIPTION
## Motivation

celo.org needs an API endpoint that would return the total number of transactions on the chain.

## Changelog

### Enhancements
This PR adds a new action `totaltransactions` to the `stats` API module, https://alfajores-blockscout.celo-testnet.org/api?module=stats&action=totaltransactions.