### PR TITLE
fix z-indexes

### DIFF
--- a/apps/block_scout_web/assets/css/components/_cookie_banner.scss
+++ b/apps/block_scout_web/assets/css/components/_cookie_banner.scss
@@ -1,7 +1,7 @@
 .cookie-banner {
   position: fixed;
   bottom: 0;
-  z-index: 2;
+  z-index: 120;
   width: 100%;
   background: $celo-blue;
   color: #fff;

--- a/apps/block_scout_web/assets/css/components/_network-selector.scss
+++ b/apps/block_scout_web/assets/css/components/_network-selector.scss
@@ -24,7 +24,7 @@ $network-selector-item-icon-dimensions: 30px !default;
   position: fixed;
   right: 0;
   top: 0;
-  z-index: 123;
+  z-index: 110;
 }
 
 .network-selector-overlay-close {


### PR DESCRIPTION
## Motivation

Items in the dashboard banner overlapped the cookie banner

## Changelog

Adjusted z-indexes
Navbar: 100
Network Selector: 110
Cookie Banner: 120

## Screenshots

<img width="1157" alt="Screen Shot 2021-03-18 at 10 09 58 AM" src="https://user-images.githubusercontent.com/36751902/111658729-3bbc2500-87d2-11eb-8190-cbcc18990c87.png">
<img width="441" alt="Screen Shot 2021-03-18 at 10 10 31 AM" src="https://user-images.githubusercontent.com/36751902/111658747-3e1e7f00-87d2-11eb-8383-4fdb059ed516.png">