### PR TITLE
Leave out gasPrice when using `eth_call`

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
@@ -80,7 +80,7 @@ defmodule EthereumJSONRPC.Contract do
     request(%{
       id: id,
       method: "eth_call",
-      params: [%{to: contract_address, data: data, gasPrice: "0x1000000000000000000"}, block]
+      params: [%{to: contract_address, data: data}, block]
     })
   end
 

--- a/apps/explorer/lib/explorer/token/balance_reader.ex
+++ b/apps/explorer/lib/explorer/token/balance_reader.ex
@@ -46,8 +46,7 @@ defmodule Explorer.Token.BalanceReader do
       contract_address: token_contract_address_hash,
       function_name: "balanceOf",
       args: [address_hash],
-      block_number: block_number,
-      gasprice: "1000000000000000000"
+      block_number: block_number
     }
   end
 


### PR DESCRIPTION
## Motivation

This fixes #222, making blockscout work with the current master of celo-blockchain.

Note: we tested this on testnets with celo-blockchain master and with an older version from before the relevant changes.  However, as I have no developed on blockscout before and don't have the dev environment set up, I did not do the usual set of checks that you would do. 

### Bug Fixes
* `eth_call` and `Explorer.Token.BalanceReader` (which uses `eth_call`) have been updated to not specify the `gasPrice`.  With v1.2.x and earlier of celo-blockchain, the node will set the gas price itself, while with newer versions (current master), it will default gas to gas price of 0, which is allowed for `eth_call` and for gas estimation.

Some context regarding this change: older versions of geth, and celo-blockchain up to v1.2.x included a hack which sets the sender's balance to a very larger number before `eth_call` and `eth_estimateGas`, to allow it to work even if the account has no funds to pay for gas.  This was removed upstream and in celo-blockchain master.  Instead, we allow using gasPrice of zero and default to gas price of zero.  However, if a nonzero gas price is explicitly specified by the user, and they can't afford to pay for gas, we return an error as if the call was a real transaction.  This broke the existing blockscout code which was specifying a nonzero gas price.  The fix is to leave out the gas price and let the node default to zero.
