### PR TITLE
Token metadata update fix

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -41,7 +41,6 @@ defmodule EthereumJSONRPC.Log do
         address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
         block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
         block_number: 37,
-        block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
         data: "0x000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
         first_topic: "0x600bcf04a13e752d1e3670a5a9f1c21177ca2a93c6f5391d4f1298d098097c22",
         fourth_topic: nil,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3482,7 +3482,7 @@ defmodule Explorer.Chain do
       when is_function(reducer, 2) do
     seconds_ago_updated
     |> Token.cataloged_tokens()
-    |> order_by(asc: :updated_at)
+    |> order_by(asc: :metadata_updated)
     |> Repo.stream_reduce(initial, reducer)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -125,8 +125,6 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
       |> Enum.sort_by(& &1.contract_address_hash)
       |> Enum.dedup_by(& &1.contract_address_hash)
 
-    # IO.inspect(ordered_changes_list)
-
     {:ok, _} =
       Import.insert_changes_list(
         repo,

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -154,19 +154,20 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
           # `holder_count` is not updated as a pre-existing token means the `holder_count` is already initialized OR
           #   need to be migrated with `priv/repo/migrations/scripts/update_new_tokens_holder_count_in_batches.sql.exs`
           # Don't update `contract_address_hash` as it is the primary key and used for the conflict target
+          metadata_updated: fragment("GREATEST(?, EXCLUDED.metadata_updated)", token.metadata_updated),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", token.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", token.updated_at)
         ]
       ],
       where:
         fragment(
-          "(EXCLUDED.name, EXCLUDED.symbol, EXCLUDED.total_supply, EXCLUDED.decimals, EXCLUDED.type, EXCLUDED.updated_at, EXCLUDED.cataloged) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?)",
+          "(EXCLUDED.name, EXCLUDED.symbol, EXCLUDED.total_supply, EXCLUDED.decimals, EXCLUDED.type, EXCLUDED.metadata_updated, EXCLUDED.cataloged) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?)",
           token.name,
           token.symbol,
           token.total_supply,
           token.decimals,
           token.type,
-          token.updated_at,
+          token.metadata_updated,
           token.cataloged
         )
     )

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -125,6 +125,8 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
       |> Enum.sort_by(& &1.contract_address_hash)
       |> Enum.dedup_by(& &1.contract_address_hash)
 
+    # IO.inspect(ordered_changes_list)
+
     {:ok, _} =
       Import.insert_changes_list(
         repo,
@@ -158,13 +160,13 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
       ],
       where:
         fragment(
-          "(EXCLUDED.name, EXCLUDED.symbol, EXCLUDED.total_supply, EXCLUDED.decimals, EXCLUDED.type, EXCLUDED.cataloged) IS DISTINCT FROM (?, ?, ?, ?, ?, ?) AND ( EXCLUDED.cataloged OR NOT ? )",
+          "(EXCLUDED.name, EXCLUDED.symbol, EXCLUDED.total_supply, EXCLUDED.decimals, EXCLUDED.type, EXCLUDED.updated_at, EXCLUDED.cataloged) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?)",
           token.name,
           token.symbol,
           token.total_supply,
           token.decimals,
           token.type,
-          token.cataloged,
+          token.updated_at,
           token.cataloged
         )
     )

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -43,6 +43,7 @@ defmodule Explorer.Chain.Token do
           decimals: non_neg_integer(),
           type: String.t(),
           cataloged: boolean(),
+          metadata_updated: DateTime.t(),
           contract_address: %Ecto.Association.NotLoaded{} | Address.t(),
           contract_address_hash: Hash.Address.t(),
           holder_count: non_neg_integer() | nil
@@ -65,6 +66,7 @@ defmodule Explorer.Chain.Token do
     field(:type, :string)
     field(:cataloged, :boolean)
     field(:holder_count, :integer)
+    field(:metadata_updated, :utc_datetime_usec)
 
     belongs_to(
       :contract_address,
@@ -112,7 +114,7 @@ defmodule Explorer.Chain.Token do
     from(
       token in __MODULE__,
       select: token.contract_address_hash,
-      where: token.cataloged == true and token.updated_at <= ^seconds_ago_date
+      where: token.cataloged == true and token.metadata_updated <= ^seconds_ago_date
     )
   end
 end

--- a/apps/explorer/priv/repo/migrations/20210406091543_add_token_metadata_updated.exs
+++ b/apps/explorer/priv/repo/migrations/20210406091543_add_token_metadata_updated.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddTokenMetadataUpdated do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tokens) do
+      add(:metadata_updated, :utc_datetime_usec, null: false, default: fragment("now()"))
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/address/token_test.exs
+++ b/apps/explorer/test/explorer/chain/address/token_test.exs
@@ -314,9 +314,11 @@ defmodule Explorer.Chain.Address.TokenTest do
     end
 
     test "add more conditions to the query when PagingOptions.key is not nil" do
-      token1 = insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA", metadata_updated: DateTime.utc_now())
+      token1 =
+        insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA", metadata_updated: DateTime.utc_now())
 
-      token2 = insert(:token, name: "token-c", type: "ERC-721", decimals: 0, symbol: "TC", metadata_updated: DateTime.utc_now())
+      token2 =
+        insert(:token, name: "token-c", type: "ERC-721", decimals: 0, symbol: "TC", metadata_updated: DateTime.utc_now())
 
       options = %PagingOptions{key: {token2.name, token2.type, token2.inserted_at}}
 
@@ -328,9 +330,11 @@ defmodule Explorer.Chain.Address.TokenTest do
     end
 
     test "tokens with nil name come after other tokens of same type" do
-      token1 = insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA", metadata_updated: DateTime.utc_now())
+      token1 =
+        insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA", metadata_updated: DateTime.utc_now())
 
-      token2 = insert(:token, name: nil, type: "ERC-20", decimals: 0, symbol: "TC", metadata_updated: DateTime.utc_now())
+      token2 =
+        insert(:token, name: nil, type: "ERC-20", decimals: 0, symbol: "TC", metadata_updated: DateTime.utc_now())
 
       options = %PagingOptions{key: {token1.name, token1.type, token1.inserted_at}}
 

--- a/apps/explorer/test/explorer/chain/address/token_test.exs
+++ b/apps/explorer/test/explorer/chain/address/token_test.exs
@@ -314,9 +314,9 @@ defmodule Explorer.Chain.Address.TokenTest do
     end
 
     test "add more conditions to the query when PagingOptions.key is not nil" do
-      token1 = insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA")
+      token1 = insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA", metadata_updated: DateTime.utc_now())
 
-      token2 = insert(:token, name: "token-c", type: "ERC-721", decimals: 0, symbol: "TC")
+      token2 = insert(:token, name: "token-c", type: "ERC-721", decimals: 0, symbol: "TC", metadata_updated: DateTime.utc_now())
 
       options = %PagingOptions{key: {token2.name, token2.type, token2.inserted_at}}
 
@@ -328,9 +328,9 @@ defmodule Explorer.Chain.Address.TokenTest do
     end
 
     test "tokens with nil name come after other tokens of same type" do
-      token1 = insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA")
+      token1 = insert(:token, name: "token-a", type: "ERC-20", decimals: 0, symbol: "TA", metadata_updated: DateTime.utc_now())
 
-      token2 = insert(:token, name: nil, type: "ERC-20", decimals: 0, symbol: "TC")
+      token2 = insert(:token, name: nil, type: "ERC-20", decimals: 0, symbol: "TC", metadata_updated: DateTime.utc_now())
 
       options = %PagingOptions{key: {token1.name, token1.type, token1.inserted_at}}
 

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -7,8 +7,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
   alias Ecto.Multi
   alias Explorer.Chain.Import.Runner.{Blocks, Transactions}
-  alias Explorer.Chain.{Address, Block, Log, Transaction, TokenTransfer}
-  # alias Explorer.Chain.{Address, Block, Transaction, TokenTransfer}
+  alias Explorer.Chain.{Address, Block, Transaction}
   alias Explorer.{Chain, Repo}
 
   describe "run/1" do

--- a/apps/explorer/test/explorer/chain/token_test.exs
+++ b/apps/explorer/test/explorer/chain/token_test.exs
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.TokenTest do
     test "filters only cataloged tokens" do
       {:ok, date} = DateTime.now("Etc/UTC")
       hours_ago_date = DateTime.add(date, -:timer.hours(60), :millisecond)
-      token = insert(:token, cataloged: true, updated_at: hours_ago_date)
+      token = insert(:token, cataloged: true, metadata_updated: hours_ago_date)
       insert(:token, cataloged: false)
 
       assert Repo.all(Token.cataloged_tokens()) == [token.contract_address_hash]
@@ -20,7 +20,7 @@ defmodule Explorer.Chain.TokenTest do
       {:ok, date} = DateTime.now("Etc/UTC")
       hours_ago_date = DateTime.add(date, -:timer.hours(60), :millisecond)
 
-      token = insert(:token, cataloged: true, updated_at: hours_ago_date)
+      token = insert(:token, cataloged: true, metadata_updated: hours_ago_date)
       insert(:token, cataloged: true)
 
       assert Repo.all(Token.cataloged_tokens()) == [token.contract_address_hash]

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4018,7 +4018,7 @@ defmodule Explorer.ChainTest do
     test "reduces with given reducer and accumulator" do
       today = DateTime.utc_now()
       yesterday = Timex.shift(today, days: -1)
-      %Token{contract_address_hash: catalog_address} = insert(:token, cataloged: true, updated_at: yesterday)
+      %Token{contract_address_hash: catalog_address} = insert(:token, cataloged: true, metadata_updated: yesterday)
       insert(:token, cataloged: false)
       assert Chain.stream_cataloged_token_contract_address_hashes([], &[&1 | &2], 1) == {:ok, [catalog_address]}
     end
@@ -4028,12 +4028,12 @@ defmodule Explorer.ChainTest do
       yesterday = Timex.shift(today, days: -1)
       two_days_ago = Timex.shift(today, days: -2)
 
-      token1 = insert(:token, %{cataloged: true, updated_at: yesterday})
-      token2 = insert(:token, %{cataloged: true, updated_at: two_days_ago})
+      token1 = insert(:token, %{cataloged: true, metadata_updated: yesterday})
+      token2 = insert(:token, %{cataloged: true, metadata_updated: two_days_ago})
 
       expected_response =
         [token1, token2]
-        |> Enum.sort(&(Timex.to_unix(&1.updated_at) < Timex.to_unix(&2.updated_at)))
+        |> Enum.sort(&(Timex.to_unix(&1.metadata_updated) < Timex.to_unix(&2.metadata_updated)))
         |> Enum.map(& &1.contract_address_hash)
 
       assert Chain.stream_cataloged_token_contract_address_hashes([], &(&2 ++ [&1]), 12) == {:ok, expected_response}

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.TokenUpdater do
   @max_batch_size 10
   @max_concurrency 4
   @defaults [
-    poll_interval: :timer.seconds(3600),
+    poll_interval: :timer.seconds(20),
     flush_interval: :timer.seconds(3),
     max_concurrency: @max_concurrency,
     max_batch_size: @max_batch_size,
@@ -53,7 +53,8 @@ defmodule Indexer.Fetcher.TokenUpdater do
 
   @impl BufferedTask
   def run(entries, _json_rpc_named_arguments) do
-    Logger.debug("updating tokens")
+    Logger.info("updating tokens")
+    IO.inspect(entries)
 
     entries
     |> Enum.map(&to_string/1)
@@ -86,6 +87,7 @@ defmodule Indexer.Fetcher.TokenUpdater do
   end
 
   def update_metadata(%Token{} = token, metadata) do
+    IO.inspect({:updating, token})
     Chain.update_token(%{token | updated_at: DateTime.utc_now()}, metadata)
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -88,6 +88,6 @@ defmodule Indexer.Fetcher.TokenUpdater do
 
   def update_metadata(%Token{} = token, metadata) do
     IO.inspect({:updating, token})
-    Chain.update_token(%{token | updated_at: DateTime.utc_now()}, metadata)
+    Chain.update_token(%{token | updated_at: DateTime.utc_now(), metadata_updated: DateTime.utc_now()}, metadata)
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -54,7 +54,6 @@ defmodule Indexer.Fetcher.TokenUpdater do
   @impl BufferedTask
   def run(entries, _json_rpc_named_arguments) do
     Logger.info("updating tokens")
-    IO.inspect(entries)
 
     entries
     |> Enum.map(&to_string/1)
@@ -87,7 +86,6 @@ defmodule Indexer.Fetcher.TokenUpdater do
   end
 
   def update_metadata(%Token{} = token, metadata) do
-    IO.inspect({:updating, token})
     Chain.update_token(%{token | updated_at: DateTime.utc_now(), metadata_updated: DateTime.utc_now()}, metadata)
   end
 end

--- a/apps/indexer/test/indexer/fetcher/token_updater_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_updater_test.exs
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.TokenUpdaterTest do
       symbol: nil,
       decimals: 10,
       cataloged: true,
-      updated_at: DateTime.add(DateTime.utc_now(), -:timer.hours(50), :millisecond)
+      metadata_updated: DateTime.add(DateTime.utc_now(), -:timer.hours(50), :millisecond)
     )
 
     expect(


### PR DESCRIPTION
When token holders are updated, the `updated_at` field is bumped, so it's possible that it's metadata is never updated.