### PR TITLE
Speed up the query

### DIFF
--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -328,7 +328,7 @@ defmodule Explorer.GraphQL do
       left_join: wf in CeloWalletAccounts,
       on: tt.from_address_hash == wf.wallet_address_hash,
       left_join: wt in CeloWalletAccounts,
-      on: tt.to_address_hash == wf.wallet_address_hash,
+      on: tt.to_address_hash == wt.wallet_address_hash,
       select: %{
         gas_used: tx.gas_used,
         gas_price: tx.gas_price,


### PR DESCRIPTION
## Motivation

The query that resolves the account address is very slow as it uses the nested loop strategy. This fixes a typo that caused that suboptimal fix.
Query plan before: https://explain.depesz.com/s/y7vRJ
Query plan after: https://explain.depesz.com/s/A0Ms

## Changelog

### Enhancements
Speed up of the transfers query, the fix will reduce the db CPU utilization.