### PR TITLE
Fixed an issue with internal transaction of CREATE type

### DIFF
--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -64,12 +64,7 @@ defmodule Indexer.Transform.TokenTransfers do
   end
 
   defp do_parse_itx(tx, %{token_transfers: token_transfers, gold_token: gold_token}) do
-    to_hash =
-      if not Map.has_key?(tx, :to_address_hash) || tx.to_address_hash == nil do
-        tx.created_contract_address_hash
-      else
-        tx.to_address_hash
-      end
+    to_hash = Map.get(tx, :to_address_hash, tx.created_contract_address_hash)
 
     token_transfer = %{
       amount: Decimal.new(tx.value),

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -65,7 +65,7 @@ defmodule Indexer.Transform.TokenTransfers do
 
   defp do_parse_itx(tx, %{token_transfers: token_transfers, gold_token: gold_token}) do
     to_hash =
-      if tx.to_address_hash == nil do
+      if not Map.has_key?(tx, :to_address_hash) || tx.to_address_hash == nil do
         tx.created_contract_address_hash
       else
         tx.to_address_hash

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -59,7 +59,7 @@ defmodule Indexer.Transform.TokenTransfers do
     txs
     |> Enum.filter(fn a -> a.value > 0 end)
     |> Enum.filter(fn a -> a.index > 0 end)
-    |> Enum.filter(fn a -> a.call_type != "delegatecall" end)
+    |> Enum.filter(fn a -> not Map.has_key?(a, :call_type) || a.call_type != "delegatecall" end)
     |> Enum.reduce(initial_acc, &do_parse_itx/2)
   end
 

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -64,7 +64,7 @@ defmodule Indexer.Transform.TokenTransfers do
   end
 
   defp do_parse_itx(tx, %{token_transfers: token_transfers, gold_token: gold_token}) do
-    to_hash = Map.get(tx, :to_address_hash, tx.created_contract_address_hash)
+    to_hash = Map.get(tx, :to_address_hash, nil) || Map.get(tx, :created_contract_address_hash, nil)
 
     token_transfer = %{
       amount: Decimal.new(tx.value),


### PR DESCRIPTION
## Motivation

When an internal transaction creates a contract, the parser fails with an error:
```
 {"error":{"initial_call":null,"reason":"** (KeyError) key :call_type not found in: %{block_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<69, 115, 67, 163, 195, 102, 136, 70, 7, 240, 27, 54, 144, 200, 138, 81, 142, 147, 241, 173, 54, 73, 86, 201, 176, 213, 100, 239, 164, 172, 92, 152>>}, block_number: 4561476, created_contract_address_hash: \"0x1733ed9570c574e2c4b54fc06415d7c5def5a71c\", created_contract_code: \"0x608060405234801561001057600080fd5b50600436106100935760003560e01c8063674f220f11610066578063674f220f146101225780638da5cb5b1461016" <> ..., trace_address: [0], transaction_hash: \"0x060590514b5ec2fc5933be947b35757733447fc2e45394a253cef8eca6d7ca15\", transaction_index: 1, type: \"create\", value: 10000000000000000}\n    (indexer) lib/indexer/transform/token_transfers.ex:63: anonymous fn/1 in Indexer.Transform.TokenTransfers.parse_itx/2\n    (elixir) lib/enum.ex:2942: Enum.filter_list/2\n    (indexer) lib/indexer/transform/token_transfers.ex:63: Indexer.Transform.TokenTransfers.parse_itx/2\n    (indexer) lib/indexer/fetcher/internal_transaction.ex:224: Indexer.Fetcher.InternalTransaction.import_internal_transaction/2\n    (indexer) lib/indexer/fetcher/internal_transaction.ex:117: Indexer.Fetcher.InternalTransaction.run/2\n    (elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2\n    (elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5\n    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3\n"},"logging.googleapis.com/sourceLocation":{"file":null,"line":0,"function":null},"message":"Task #PID<0.4447.0> started from Indexer.Fetcher.InternalTransaction terminating\n** (KeyError) key :call_type not found in: %{block_hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<69, 115, 67, 163, 195, 102, 136, 70, 7, 240, 27, 54, 144, 200, 138, 81, 142, 147, 241, 173, 54, 73, 86, 201, 176, 213, 100, 239, 164, 172, 92, 152>>}, block_number: 4561476, created_contract_address_hash: \"0x1733ed9570c574e2c4b54fc06415d7c5def5a71c\", created_contract_code: \"0x608060405234801561001057600080fd5b50600436106100935760003560e01c8063674f220f11610066578063674f220f146101225780638da5cb5b146101 (truncated)","severity":"ERROR","time":"2021-05-04T18:30:34.938Z"}
```

becase there is no `call_type` in CREATE transactions:
```
%{
    block_hash: %Explorer.Chain.Hash{
      byte_count: 32,
      bytes: <<69, 115, 67, 163, 195, 102, 136, 70, 7, 240, 27, 54, 144, 200,
        138, 81, 142, 147, 241, 173, 54, 73, 86, ...>>
    },
    block_number: 4561476,
    created_contract_address_hash: "0x959568d91a4578fca60daaa788ef24124a3aafb1",
    created_contract_code: "0x608060405234801561001057600080fd5b50600436106100935760003560e01c8063674f220f11610066578063674f220f146101225780638da5cb5b1461016c578063b0c80972146101b6578063bbe42771146101f0578063faab9d391461021e57610093565b806305b34410146100985780630b5ab3d5146100b657806313af4035146100c05780633fa4f24514610104575b600080fd5b6100a0610262565b6040518082815260200191505060405180910390f35b6100be610267565b005b610102600480360360208110156100d657600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff",
    from_address_hash: "0x6fe7cbd672a66d4282e3668963c82ba4b3ff9219",
    gas: 5852164,
    gas_used: 101355,
    index: 1,
    init: "0x60806040526040516108cd3803806108cd8339818101604052602081101561002657600080fd5b8101908080519060200190929190505050806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1" <> ...,
    trace_address: [0],
    transaction_hash: "0x90cacfa86827d732a980be606251ab4d70266e8ac9e625c5341c2e381a61d9fe",
    transaction_index: 0,
    type: "create",
    value: 10000000000000000
  }
```
