### PR TITLE
Increased timeout for debug_traceTransaction calls

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -92,7 +92,10 @@ defmodule EthereumJSONRPC.Geth do
     request(%{
       id: id,
       method: "debug_traceTransaction",
-      params: [hash_data, %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true}]
+      params: [
+        hash_data,
+        %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true, timeout: "30s"}
+      ]
     })
   end
 


### PR DESCRIPTION
Increase the timeout for `debug_traceTransaction` rpc calls to 30 seconds (default is 10s which is not enough in some cases). 