### PR TITLE
Increase debug trace transaction calls timeout to 100secs

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -94,7 +94,7 @@ defmodule EthereumJSONRPC.Geth do
       method: "debug_traceTransaction",
       params: [
         hash_data,
-        %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true, timeout: "30s"}
+        %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true, timeout: "100s"}
       ]
     })
   end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -92,7 +92,10 @@ defmodule EthereumJSONRPC.Geth do
     request(%{
       id: id,
       method: "debug_traceTransaction",
-      params: [hash_data, %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true}]
+      params: [
+        hash_data,
+        %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true, timeout: "30s"}
+      ]
     })
   end
 


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

We keep watching some timeouts on the `debug_traceTransaction` calls. 
Increased the timeout to 100 seconds.  

