### PR TITLE
Avoid to encode the implementation address

### DIFF
--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -97,6 +97,7 @@ defmodule Explorer.Chain.Address do
              :celo_voted,
              :celo_claims,
              :decompiled_smart_contracts,
+             :implementation_contract,
              :token,
              :contracts_creation_internal_transaction,
              :contracts_creation_transaction,


### PR DESCRIPTION
Related with #287

Taking into  account the current error, we are going to avoid to encode the implementation contract in the address.