### PR TITLE
Fix coinsupply fetching

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2647,7 +2647,10 @@ defmodule Explorer.Chain do
         select: last_fetched_counter.value
       )
 
-    Repo.one!(query) || Decimal.new(0)
+    case Repo.one(query) do
+      {:ok, result} -> result
+      _ -> Decimal.new(0)
+    end
   end
 
   defp block_status({number, timestamp}) do
@@ -2759,7 +2762,7 @@ defmodule Explorer.Chain do
         right_join:
           missing_range in fragment(
             """
-              (SELECT distinct b1.number 
+              (SELECT distinct b1.number
               FROM generate_series((?)::integer, (?)::integer) AS b1(number)
               WHERE NOT EXISTS
                 (SELECT 1 FROM blocks b2 WHERE b2.number=b1.number AND b2.consensus))


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

The way fetching coinsupply was written, it would throw an error if there was no value set for `sum_coin_total_supply_minus_burnt` in the `last_fetched_counters` table. With this change, we return 0 instead of throwing an error.

Fixes #284 