### PR TITLE
Use named binding for transaction in celo_tx_transfers_query.

### DIFF
--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -280,7 +280,7 @@ defmodule Explorer.GraphQL do
   def celo_tx_transfers_query_by_address(address_hash) do
     celo_tx_transfers_query()
     |> where([t], t.from_address_hash == ^address_hash or t.to_address_hash == ^address_hash)
-    |> order_by([t, _, tx], desc: t.block_number, asc: tx.nonce)
+    |> order_by([transaction: t], desc: t.block_number, asc: t.nonce)
   end
 
   def txtransfers_query do
@@ -342,6 +342,7 @@ defmodule Explorer.GraphQL do
         ),
       on: t.name == tkn.contract_name,
       inner_join: tx in Transaction,
+      as: :transaction,
       on: tx.hash == tt.transaction_hash,
       inner_join: b in Block,
       on: tt.block_number == b.number,


### PR DESCRIPTION
Positional bindings in this query are incorrect due to a new fragment being added. This PR changes it to use named bindings for this statement and avoid positional errors.

closes #296 