### PR TITLE
Redirect to commit when we are not deploying a tag

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -114,8 +114,11 @@ defmodule BlockScoutWeb.LayoutView do
           nil
 
         release_link_env_var == "" || release_link_env_var == nil ->
-          "https://github.com/celo-org/blockscout/releases/tag/" <> version
-
+          if String.length(version) == 40 do 
+            "https://github.com/celo-org/blockscout/commit/" <> version
+          else 
+            "https://github.com/celo-org/blockscout/releases/tag/" <> version
+          end
         true ->
           release_link_env_var
       end


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

We are redirecting to the release tag event when we hace deployed a commit.

## Changelog

### Enhancements
Check if we are deploying a commit, in that case redirect to the commit view.

