### PR TITLE
Optimise github actions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -36,7 +36,7 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
 
@@ -55,7 +55,7 @@ jobs:
         id: explorer-npm-cache
         with:
           path: apps/explorer/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
 
@@ -69,7 +69,7 @@ jobs:
         id: blockscoutweb-npm-cache
         with:
           path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 
@@ -95,7 +95,7 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
@@ -240,7 +240,7 @@ jobs:
         id: explorer-npm-cache
         with:
           path: apps/explorer/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
 
@@ -249,7 +249,7 @@ jobs:
         id: blockscoutweb-npm-cache
         with:
           path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 
@@ -288,7 +288,7 @@ jobs:
         id: blockscoutweb-npm-cache
         with:
           path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 
@@ -404,7 +404,7 @@ jobs:
         id: explorer-npm-cache
         with:
           path: apps/explorer/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm
 
@@ -531,7 +531,7 @@ jobs:
         id: explorer-npm-cache
         with:
           path: apps/explorer/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
 
@@ -540,7 +540,7 @@ jobs:
         id: blockscoutweb-npm-cache
         with:
           path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -36,7 +36,7 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('**/mix.lock')) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -79,22 +79,7 @@ jobs:
         if: steps.blockscoutweb-npm-cache.outputs.cache-hit != 'true'
         run: npm install
         working-directory: apps/block_scout_web/assets
-
-      - name: Restore Dialyzer Cache
-        uses: actions/cache@v2
-        id: dialyzer-cache
-        with:
-          path: priv/plts
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash-${{ hashFiles('mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-"
-
-      - name: Conditionally build Dialyzer Cache
-        if: steps.dialyzer-cache.output.cache-hit != 'true'
-        run: |
-          mkdir -p priv/plts
-          mix dialyzer --plt
-
+        
   credo:
     runs-on: ubuntu-18.04
     needs: build-and-cache
@@ -169,6 +154,12 @@ jobs:
           key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-"
+
+      - name: Conditionally build Dialyzer Cache
+        if: steps.dialyzer-cache.output.cache-hit != 'true'
+        run: |
+          mkdir -p priv/plts
+          mix dialyzer --plt
 
       - run: mix dialyzer --halt-exit-status
         name: Run Dialyzer

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -88,8 +88,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -112,8 +112,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -135,8 +135,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -175,8 +175,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -201,8 +201,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Mix Deps Cache
         uses: actions/cache@v2
@@ -229,8 +229,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Mix Deps Cache
         uses: actions/cache@v2
@@ -278,8 +278,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Mix Deps Cache
         uses: actions/cache@v2
@@ -338,8 +338,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 
@@ -394,8 +394,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 
@@ -461,8 +461,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 
@@ -522,8 +522,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: ${{ env.OTP_VERSION }
-          elixir-version: ${{ env.ELIXIR_VERSION }
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -80,6 +80,21 @@ jobs:
         run: npm install
         working-directory: apps/block_scout_web/assets
 
+      - name: Restore Dialyzer Cache
+        uses: actions/cache@v2
+        id: dialyzer-cache
+        with:
+          path: priv/plts
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-"
+
+      - name: Conditionally build Dialyzer Cache
+        if: steps.dialyzer-cache.output.cache-hit != 'true'
+        run: |
+          mkdir -p priv/plts
+          mix dialyzer --plt
+
   credo:
     runs-on: ubuntu-18.04
     needs: build-and-cache
@@ -154,12 +169,6 @@ jobs:
           key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-"
-
-      - name: Conditionally build Dialyzer Cache
-        if: steps.dialyzer-cache.output.cache-hit != 'true'
-        run: |
-          mkdir -p priv/plts
-          mix dialyzer --plt
 
       - run: mix dialyzer --halt-exit-status
         name: Run Dialyzer

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -145,7 +145,7 @@ jobs:
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
       - name: Restore Dialyzer Cache
-      - uses: actions/cache@v2
+        uses: actions/cache@v2
         id: dialyzer-cache
         with:
           path: priv/plts

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feature/optimise_github_actions
   pull_request:
     branches:
       - master
@@ -13,7 +14,7 @@ env:
   MIX_ENV: test
 
 jobs:
-  build:
+  build-and-cache:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -21,13 +22,34 @@ jobs:
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
+
       - name: "ELIXIR_VERSION.lock"
         run: echo "${ELIXIR_VERSION}" > ELIXIR_VERSION.lock
+
       - name: "OTP_VERSION.lock"
         run: echo "${OTP_VERSION}" > OTP_VERSION.lock
-      - run: mix deps.get
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
+
+      - name: Install and Compile Mix deps
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+          mix deps.compile
+          cd deps/libsecp256k1
+          make
+
       - run: npm install
         working-directory: apps/explorer
       - run: npm install
@@ -35,55 +57,74 @@ jobs:
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
       - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
   credo:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+      
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: mix credo
   check_formatted:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: mix format --check-formatted
   dialyzer:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - name: Unpack PLT cache
         run: |
           mkdir -p _build/test
@@ -99,37 +140,50 @@ jobs:
       - run: mix dialyzer --halt-exit-status
   gettext:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: |
           mix gettext.extract --merge | tee stdout.txt
           ! grep "Wrote " stdout.txt
         working-directory: "apps/block_scout_web"
   sobelow:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix deps.compile
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - name: Scan explorer for vulnerabilities
         run: mix sobelow --config
         working-directory: "apps/explorer"
@@ -138,24 +192,31 @@ jobs:
         working-directory: "apps/block_scout_web"
   eslint:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: npm install
         working-directory: apps/explorer
       - run: npm install
         working-directory: apps/block_scout_web/assets
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
@@ -163,24 +224,31 @@ jobs:
         working-directory: apps/block_scout_web/assets
   jest:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: npm install
         working-directory: apps/explorer
       - run: npm install
         working-directory: apps/block_scout_web/assets
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
@@ -188,6 +256,7 @@ jobs:
         working-directory: apps/block_scout_web/assets
   test_parity_mox_ethereum_jsonrpc:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -215,18 +284,24 @@ jobs:
           elixir-version: '1.11.4'
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: npm install
         working-directory: apps/explorer
       - run: npm install
         working-directory: apps/block_scout_web/assets
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
@@ -245,6 +320,7 @@ jobs:
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
   test_parity_mox_explorer:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -272,9 +348,18 @@ jobs:
           elixir-version: '1.11.4'
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: npm install
         working-directory: apps/explorer
       - run: npm install
@@ -282,8 +367,6 @@ jobs:
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
       - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
@@ -304,6 +387,7 @@ jobs:
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
   test_parity_mox_indexer:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -331,9 +415,18 @@ jobs:
           elixir-version: '1.11.4'
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: npm install
         working-directory: apps/explorer
       - run: npm install
@@ -341,8 +434,6 @@ jobs:
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
       - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
@@ -363,6 +454,7 @@ jobs:
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
   test_parity_mox_block_scout_web:
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -390,9 +482,18 @@ jobs:
           elixir-version: '1.11.4'
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: npm install
         working-directory: apps/explorer
       - run: npm install
@@ -400,8 +501,6 @@ jobs:
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
       - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feature/optimise_github_actions
   pull_request:
     branches:
       - master

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -29,18 +29,18 @@ jobs:
       - name: "OTP_VERSION.lock"
         run: echo "${OTP_VERSION}" > OTP_VERSION.lock
 
-      - name: Mix Deps Cache
+      - name: Restore Mix Deps Cache
         uses: actions/cache@v2
         id: deps-cache
         with:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('**/mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock')) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
 
-      - name: Install and Compile Mix deps
+      - name: Conditionally build Mix deps cache
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: |
           mix local.hex --force
@@ -50,16 +50,34 @@ jobs:
           cd deps/libsecp256k1
           make
 
-      - run: npm install
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
+
+      - name: Conditionally build Explorer NPM Cache
+        if: steps.explorer-npm-cache.outputs.cache-hit != 'true'
+        run: npm install
         working-directory: apps/explorer
-      - run: npm install
+
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
+      - name: Conditionally build Blockscout Web NPM Cache
+        if: steps.blockscoutweb-npm-cache.outputs.cache-hit != 'true'
+        run: npm install
         working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
+
   credo:
     runs-on: ubuntu-18.04
     needs: build-and-cache
@@ -70,18 +88,19 @@ jobs:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
       
-      - name: Mix Deps Cache
+      - name: Restore Mix Deps Cache
         uses: actions/cache@v2
         id: deps-cache
         with:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock')) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
       - run: mix credo
+
   check_formatted:
     runs-on: ubuntu-18.04
     needs: build-and-cache
@@ -92,14 +111,14 @@ jobs:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
 
-      - name: Mix Deps Cache
+      - name: Restore Mix Deps Cache
         uses: actions/cache@v2
         id: deps-cache
         with:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
@@ -114,30 +133,35 @@ jobs:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
 
-      - name: Mix Deps Cache
+      - name: Restore Mix Deps Cache
         uses: actions/cache@v2
         id: deps-cache
         with:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
-      - name: Unpack PLT cache
+      - name: Restore Dialyzer Cache
+      - uses: actions/cache@v2
+        id: dialyzer-cache
+        with:
+          path: priv/plts
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-"
+
+      - name: Conditionally build Dialyzer Cache
+        if: steps.dialyzer-cache.output.cache-hit != 'true'
         run: |
-          mkdir -p _build/test
-          cp plts/dialyxir*.plt _build/test/ || true
-          mkdir -p ~/.mix
-          cp plts/dialyxir*.plt ~/.mix/ || true
-      - run: mix dialyzer --plt
-      - name: Pack PLT cache
-        run: |
-          mkdir -p plts
-          cp _build/test/dialyxir*.plt plts/
-          cp ~/.mix/dialyxir*.plt plts/
+          mkdir -p priv/plts
+          mix dialyzer --plt
+
       - run: mix dialyzer --halt-exit-status
+        name: Run Dialyzer
+
   gettext:
     runs-on: ubuntu-18.04
     needs: build-and-cache
@@ -148,14 +172,14 @@ jobs:
           otp-version: '23.3.4.1'
           elixir-version: '1.11.4'
 
-      - name: Mix Deps Cache
+      - name: Restore Mix Deps Cache
         uses: actions/cache@v2
         id: deps-cache
         with:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
@@ -180,7 +204,7 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
@@ -207,19 +231,35 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
+
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
+
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
+
       - run: ./node_modules/.bin/eslint --format=junit --output-file="test/eslint/junit.xml" js/**
         working-directory: apps/block_scout_web/assets
   jest:
@@ -239,21 +279,29 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
+
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
+
       - run: ./node_modules/.bin/jest
         working-directory: apps/block_scout_web/assets
+
   test_parity_mox_ethereum_jsonrpc:
     runs-on: ubuntu-18.04
     needs: build-and-cache
@@ -292,19 +340,10 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
       - run: ./bin/install_chrome_headless.sh
       - name: mix test --exclude no_parity
         run: |
@@ -356,20 +395,19 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm
+
       - run: ./bin/install_chrome_headless.sh
       - name: mix test --exclude no_parity
         run: |
@@ -423,21 +461,13 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
+
       - run: ./bin/install_chrome_headless.sh
+
       - name: mix test --exclude no_parity
         run: |
           mix ecto.create --quiet
@@ -452,6 +482,7 @@ jobs:
           PGUSER: postgres
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Parity.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
+
   test_parity_mox_block_scout_web:
     runs-on: ubuntu-18.04
     needs: build-and-cache
@@ -490,21 +521,38 @@ jobs:
           path: | 
             deps
             _build
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles(format('{0}{1}', github.workspace, 'mix.lock')) }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
 
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
+
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
+
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
-      - run: mix compile
+
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
+
       - run: ./bin/install_chrome_headless.sh
+
       - name: mix test --exclude no_parity
         run: |
           mix ecto.create --quiet

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: "ELIXIR_VERSION.lock"
         run: echo "${ELIXIR_VERSION}" > ELIXIR_VERSION.lock
@@ -88,8 +88,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
       
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -112,8 +112,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
 
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -135,8 +135,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
 
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -175,8 +175,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
 
       - name: Restore Mix Deps Cache
         uses: actions/cache@v2
@@ -201,8 +201,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
 
       - name: Mix Deps Cache
         uses: actions/cache@v2
@@ -229,8 +229,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
 
       - name: Mix Deps Cache
         uses: actions/cache@v2
@@ -278,8 +278,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
 
       - name: Mix Deps Cache
         uses: actions/cache@v2
@@ -338,8 +338,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 
@@ -394,8 +394,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 
@@ -461,8 +461,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 
@@ -522,8 +522,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }
+          elixir-version: ${{ env.ELIXIR_VERSION }
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   MIX_ENV: test
+  OTP_VERSION: '23.3.4.1'
+  ELIXIR_VERSION: '1.11.4'
 
 jobs:
   build-and-cache:
@@ -68,8 +70,8 @@ jobs:
         uses: actions/cache@v2
         id: blockscoutweb-npm-cache
         with:
-          path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 
@@ -248,8 +250,8 @@ jobs:
         uses: actions/cache@v2
         id: blockscoutweb-npm-cache
         with:
-          path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 
@@ -287,8 +289,8 @@ jobs:
         uses: actions/cache@v2
         id: blockscoutweb-npm-cache
         with:
-          path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 
@@ -539,8 +541,8 @@ jobs:
         uses: actions/cache@v2
         id: blockscoutweb-npm-cache
         with:
-          path: apps/block_scout_web/node_modules
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/package-lock.json') }}
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   build-and-cache:
+    name: Build and Cache deps
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -79,8 +80,9 @@ jobs:
         if: steps.blockscoutweb-npm-cache.outputs.cache-hit != 'true'
         run: npm install
         working-directory: apps/block_scout_web/assets
-        
+
   credo:
+    name: Credo
     runs-on: ubuntu-18.04
     needs: build-and-cache
     steps:
@@ -104,6 +106,7 @@ jobs:
       - run: mix credo
 
   check_formatted:
+    name: Code formatting checks
     runs-on: ubuntu-18.04
     needs: build-and-cache
     steps:
@@ -126,6 +129,7 @@ jobs:
 
       - run: mix format --check-formatted
   dialyzer:
+    name: Dialyzer static analysis
     runs-on: ubuntu-18.04
     needs: build-and-cache
     steps:
@@ -165,6 +169,7 @@ jobs:
         name: Run Dialyzer
 
   gettext:
+    name: Missing translation keys check
     runs-on: ubuntu-18.04
     needs: build-and-cache
     steps:
@@ -190,6 +195,7 @@ jobs:
           ! grep "Wrote " stdout.txt
         working-directory: "apps/block_scout_web"
   sobelow:
+    name: Sobelow security analysis
     runs-on: ubuntu-18.04
     needs: build-and-cache
     steps:
@@ -217,6 +223,7 @@ jobs:
         run: mix sobelow --config
         working-directory: "apps/block_scout_web"
   eslint:
+    name: ESLint
     runs-on: ubuntu-18.04
     needs: build-and-cache
     steps:
@@ -265,6 +272,7 @@ jobs:
       - run: ./node_modules/.bin/eslint --format=junit --output-file="test/eslint/junit.xml" js/**
         working-directory: apps/block_scout_web/assets
   jest:
+    name: JS Tests
     runs-on: ubuntu-18.04
     needs: build-and-cache
     steps:
@@ -305,6 +313,7 @@ jobs:
         working-directory: apps/block_scout_web/assets
 
   test_parity_mox_ethereum_jsonrpc:
+    name: EthereumJSONRPC Tests
     runs-on: ubuntu-18.04
     needs: build-and-cache
     services:
@@ -360,6 +369,7 @@ jobs:
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Parity.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
   test_parity_mox_explorer:
+    name: Explorer Tests
     runs-on: ubuntu-18.04
     needs: build-and-cache
     services:
@@ -426,6 +436,7 @@ jobs:
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Parity.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
   test_parity_mox_indexer:
+    name: Indexer Tests
     runs-on: ubuntu-18.04
     needs: build-and-cache
     services:
@@ -486,6 +497,7 @@ jobs:
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
 
   test_parity_mox_block_scout_web:
+    name: Blockscout Web Tests
     runs-on: ubuntu-18.04
     needs: build-and-cache
     services:

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
@@ -104,8 +104,6 @@ defmodule EthereumJSONRPC.RollingWindow do
 
   # Public for testing
   defp sweep(table, delete_match_spec, replace_match_spec) do
-    Logger.debug(fn -> "Sweeping windows" end)
-
     # Delete any rows where all windows empty
     :ets.match_delete(table, delete_match_spec)
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,11 +10,7 @@ defmodule BlockScout.Mixfile do
       version: "2.0",
       apps_path: "apps",
       deps: deps(),
-      dialyzer: [
-        plt_add_deps: :transitive,
-        plt_add_apps: ~w(ex_unit mix)a,
-        ignore_warnings: ".dialyzer-ignore"
-      ],
+      dialyzer: dialyzer(),
       elixir: "~> 1.10",
       preferred_cli_env: [
         credo: :test,
@@ -35,6 +31,16 @@ defmodule BlockScout.Mixfile do
   end
 
   ## Private Functions
+
+  defp dialyzer() do
+    [
+      plt_add_deps: :transitive,
+      plt_add_apps: ~w(ex_unit mix)a,
+      ignore_warnings: ".dialyzer-ignore",
+      plt_core_path: "priv/plts",
+      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+    ]
+  end
 
   defp aliases(env) do
     [


### PR DESCRIPTION
Optimises the workflow by aggressively caching dependencies. 

Notably :

* Cache elixir dependencies
* Cache npm node_modules
* Cache dialyzer persistent lookup table (plt)

These caches are keyed on their respective lock files, for npm this is the `package-lock.json` files in `explorer` and `block_scout_web` apps, for dialyzer and elixir dependencies this is `mix.lock`. These caches will be rebuilt upon changes to npm modules or elixir dependencies, which will result in an initially longer build time but will be persisted across test runs.

Initial results seem to show a reduction in test run time from ~23 minutes to around 14 minutes. Currently the test runs are bounded by the `explorer` test suite, specifically smart contract verification functionality. Further reductions would likely involve significant code level changes which will come in further pull requests.