### PR TITLE
Feature/internal transaction logging

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -127,8 +127,9 @@ defmodule Indexer.Fetcher.InternalTransaction do
       {:error, :block_not_indexed_properly = reason} ->
         Logger.debug(
           fn ->
+            block_numbers = unique_numbers |> inspect(charlists: :as_lists)
             [
-              "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{inspect(unique_numbers)} reason: ",
+              "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{block_numbers} reason: ",
               inspect(reason)
             ]
           end,
@@ -140,8 +141,9 @@ defmodule Indexer.Fetcher.InternalTransaction do
       {:error, reason} ->
         Logger.error(
           fn ->
+            block_numbers = unique_numbers |> inspect(charlists: :as_lists)
             [
-              "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{inspect(unique_numbers)} reason: ",
+              "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{block_numbers} reason: ",
               inspect(reason)
             ]
           end,

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -128,6 +128,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
         Logger.debug(
           fn ->
             block_numbers = unique_numbers |> inspect(charlists: :as_lists)
+
             [
               "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{block_numbers} reason: ",
               inspect(reason)
@@ -142,6 +143,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
         Logger.error(
           fn ->
             block_numbers = unique_numbers |> inspect(charlists: :as_lists)
+
             [
               "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{block_numbers} reason: ",
               inspect(reason)

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -125,14 +125,26 @@ defmodule Indexer.Fetcher.InternalTransaction do
         import_internal_transaction(internal_transactions_params, unique_numbers)
 
       {:error, :block_not_indexed_properly = reason} ->
-        Logger.debug(fn -> ["failed to fetch internal transactions for blocks: ", inspect(reason)] end,
+        Logger.debug(
+          fn ->
+            [
+              "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{inspect(unique_numbers)} reason: ",
+              inspect(reason)
+            ]
+          end,
           error_count: unique_numbers_count
         )
 
         :ok
 
       {:error, reason} ->
-        Logger.error(fn -> ["failed to fetch internal transactions for blocks: ", inspect(reason)] end,
+        Logger.error(
+          fn ->
+            [
+              "failed to fetch internal transactions for #{unique_numbers_count} blocks: #{inspect(unique_numbers)} reason: ",
+              inspect(reason)
+            ]
+          end,
           error_count: unique_numbers_count
         )
 


### PR DESCRIPTION
Include failed block count and block numbers in `failed to fetch internal transactions` log 