### PR TITLE
Wrap coin balances delta in map with key "value"

### DIFF
--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -379,7 +379,7 @@ defmodule Explorer.GraphQL do
       inner_join: b in Block,
       on: cb.block_number == b.number,
       order_by: [desc: :block_number],
-      select_merge: %{delta: fragment("value - coalesce(lag(value, 1) over (order by block_number), 0)")},
+      select_merge: %{delta: %{value: fragment("value - coalesce(lag(value, 1) over (order by block_number), 0)")}},
       select_merge: %{block_timestamp: b.timestamp}
     )
   end


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

The coinBalances query was causing an internal server error. That's because the custom scalar :wei is expecting a map with a "value" key in its serialize function. The way the code was written, the delta field of coinBalances was just a Decimal and that led to the error.
