### PR TITLE
Feature/jsonrpc timeout runtime

### DIFF
--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -34,6 +34,8 @@ config :logger_json, :ethereum_jsonrpc,
 
 config :logger, :ethereum_jsonrpc, backends: [LoggerJSON]
 
+config :ethereum_jsonrpc, :internal_transaction_timeout, "100s"
+
 # config :logger, :ethereum_jsonrpc,
 #  # keep synced with `config/config.exs`
 #  format: "$dateT$time $metadata[$level] $message\n",

--- a/apps/ethereum_jsonrpc/config/runtime.exs
+++ b/apps/ethereum_jsonrpc/config/runtime.exs
@@ -1,3 +1,0 @@
-import Config
-
-config :ethereum_jsonrpc, :internal_transaction_timeout, "100s"

--- a/apps/ethereum_jsonrpc/config/runtime.exs
+++ b/apps/ethereum_jsonrpc/config/runtime.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :ethereum_jsonrpc, :internal_transaction_timeout, "100s"

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -95,12 +95,14 @@ defmodule EthereumJSONRPC.Geth do
   @tracer File.read!(@tracer_path)
 
   defp debug_trace_transaction_request(%{id: id, hash_data: hash_data}) do
+    timeout = Application.get_env(:ethereum_jsonrpc, :internal_transaction_timeout)
+
     request(%{
       id: id,
       method: "debug_traceTransaction",
       params: [
         hash_data,
-        %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true, timeout: "100s"}
+        %{tracer: @tracer, disableStack: true, disableMemory: true, disableStorage: true, timeout: timeout}
       ]
     })
   end

--- a/apps/indexer/lib/indexer/celo/util.ex
+++ b/apps/indexer/lib/indexer/celo/util.ex
@@ -2,9 +2,12 @@
 defmodule Indexer.Celo.Util do
   @moduledoc "Runtime helper methods for concurrency tuning"
 
+  require Logger
+
   def set_internal_transaction_batch_size(size) do
     internal_transaction_fetcher_pid()
     |> :sys.replace_state(fn state ->
+      Logger.info("Setting internal transaction batch size from #{state[:max_batch_size]} to #{size}")
       %{state | max_batch_size: size}
     end)
   end
@@ -12,8 +15,16 @@ defmodule Indexer.Celo.Util do
   def set_internal_transaction_concurrency(size) do
     internal_transaction_fetcher_pid()
     |> :sys.replace_state(fn state ->
+      Logger.info("Setting internal transaction concurrency from #{state[:max_concurrency]} to #{size}")
       %{state | max_concurrency: size}
     end)
+  end
+
+  def set_internal_transaction_timeout(timeout) do
+    current = Application.get_env(:ethereum_jsonrpc, :internal_transaction_timeout)
+    Logger.info("Setting debug_traceTransaction rpc timeout from #{current} to #{timeout}")
+    Application.put_env(:ethereum_jsonrpc, :internal_transaction_timeout, timeout, persistent: true)
+    require IEx; IEx.pry
   end
 
   def get_internal_transaction_state() do

--- a/apps/indexer/lib/indexer/celo/util.ex
+++ b/apps/indexer/lib/indexer/celo/util.ex
@@ -24,7 +24,6 @@ defmodule Indexer.Celo.Util do
     current = Application.get_env(:ethereum_jsonrpc, :internal_transaction_timeout)
     Logger.info("Setting debug_traceTransaction rpc timeout from #{current} to #{timeout}")
     Application.put_env(:ethereum_jsonrpc, :internal_transaction_timeout, timeout, persistent: true)
-    require IEx; IEx.pry
   end
 
   def get_internal_transaction_state() do


### PR DESCRIPTION
* Add logs to runtime changes
* Add functionality to set `debug_traceTransaction` timeout parameter at runtime

> Note: the values for the timeout are to be provided in the golang `time` format, see - https://pkg.go.dev/time#ParseDuration