### PR TITLE
Quality of life test changes

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -427,7 +427,7 @@ jobs:
           mix ecto.migrate
           cd apps/explorer
           mix compile
-          mix test --no-start --exclude no_parity
+          mix test --no-start --exclude no_parity --exclude smart_contract_compiler
         env:
           MIX_ENV: "test"
           # match POSTGRES_PASSWORD for postgres image below

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -360,6 +360,12 @@ jobs:
           cd apps/ethereum_jsonrpc
           mix compile
           mix test --no-start --exclude no_parity
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: EthereumJSONRPC Test Results
+          path: _build/test/junit/ethereum_jsonrpc/*.xml
         env:
           MIX_ENV: "test"
           # match POSTGRES_PASSWORD for postgres image below
@@ -428,6 +434,12 @@ jobs:
           cd apps/explorer
           mix compile
           mix test --no-start --exclude no_parity --exclude smart_contract_compiler
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Explorer Test Results
+          path: _build/test/junit/explorer/*.xml
         env:
           MIX_ENV: "test"
           # match POSTGRES_PASSWORD for postgres image below
@@ -489,6 +501,12 @@ jobs:
           cd apps/indexer
           mix compile
           mix test --no-start --exclude no_parity
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Indexer Test Results
+          path: _build/test/junit/indexer/*.xml
         env:
           MIX_ENV: "test"
           # match POSTGRES_PASSWORD for postgres image below
@@ -576,6 +594,12 @@ jobs:
           cd apps/block_scout_web
           mix compile
           mix test --no-start --exclude no_parity
+      - name: Upload Unit Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Blockscout Web Test Results
+          path: _build/test/junit/block_scout_web/*.xml
         env:
           # match POSTGRES_PASSWORD for postgres image below
           MIX_ENV: "test"
@@ -585,3 +609,22 @@ jobs:
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Parity.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
           CHAIN_ID: "77"
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    runs-on: ubuntu-18.04
+    needs:
+      - test_parity_mox_ethereum_jsonrpc
+      - test_parity_mox_explorer
+      - test_parity_mox_indexer
+      - test_parity_mox_block_scout_web
+    if: success() || failure()
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: artifacts/**/*.xml

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -427,7 +427,7 @@ jobs:
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm
 
       - run: ./bin/install_chrome_headless.sh
-      - name: mix test --exclude no_parity
+      - name: mix test --exclude no_parity --exclude smart_contract_compiler
         run: |
           mix ecto.create --quiet
           mix ecto.migrate

--- a/apps/explorer/test/explorer/smart_contract/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/publisher_test.exs
@@ -11,6 +11,7 @@ defmodule Explorer.SmartContract.PublisherTest do
   alias Explorer.{Factory, Repo}
   alias Explorer.SmartContract.Publisher
 
+  @moduletag :smart_contract_compiler
   describe "publish/2" do
     test "with valid data creates a smart_contract" do
       contract_code_info = Factory.contract_code_info()

--- a/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
@@ -12,6 +12,7 @@ defmodule Explorer.SmartContract.Solidity.CodeCompilerTest do
                   |> File.read!()
                   |> Jason.decode!()
 
+  @moduletag :smart_contract_compiler
   describe "run/2" do
     setup do
       {:ok, contract_code_info: Factory.contract_code_info()}

--- a/apps/explorer/test/explorer/smart_contract/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/verifier_test.exs
@@ -3,6 +3,7 @@ defmodule Explorer.SmartContract.VerifierTest do
   use Explorer.DataCase
 
   @moduletag timeout: :infinity
+  @moduletag :smart_contract_compiler
 
   doctest Explorer.SmartContract.Verifier
 


### PR DESCRIPTION
* Exclude smart contract verifier tests by default
    * These tests each spin up an external nodejs process to run an external verification program
    * They do this sequentially
    * We don't use this feature in the Celo explorer (we rely entirely on Sourcify integration)
    * This brings the explorer test suite duration down from 12 minutes to ~3 minutes
* Add workflow action to collect junit files and display in a useful fashion
    * It turns out we already create junit test output but don't use it
    * Now we do