### PR TITLE
Reduced the size of js bundles

### DIFF
--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -17,10 +17,8 @@ import 'bootstrap'
 // paths "./socket" or full ones "web/static/js/socket".
 
 import './locale'
-// import './pages/address/signed'
 import './pages/layout'
 import './pages/dark-mode-switcher'
-import './pages/stakes'
 
 import './lib/clipboard_buttons'
 import './lib/currency'

--- a/apps/block_scout_web/assets/js/lib/analytics.js
+++ b/apps/block_scout_web/assets/js/lib/analytics.js
@@ -2,8 +2,8 @@ import { connectElements, createStore } from './redux_helpers.js'
 
 import $ from 'jquery'
 import Analytics from 'analytics'
-import segmentPlugin from '@analytics/segment'
 import omit from 'lodash/omit'
+import segmentPlugin from '@analytics/segment'
 import uniqid from 'uniqid'
 
 let analytics
@@ -97,7 +97,7 @@ function getPageName (path) {
       return 'transactionInternalTransaction'
     case path.includes('/tx') && path.includes('/logs'):
       return 'transactionLogs'
-    case path.includes('/tx') && path.includes('/raw_trace'):
+    case path.includes('/tx') && path.includes('/raw-trace'):
       return 'transactionRawTrace'
     case path.includes('/tx') && path.includes('/token_transfers'):
       return 'transactionTokenTransfers'

--- a/apps/block_scout_web/assets/js/view_specific/raw-trace/code_highlighting.js
+++ b/apps/block_scout_web/assets/js/view_specific/raw-trace/code_highlighting.js
@@ -1,7 +1,7 @@
 import hljs from 'highlight.js/lib/core'
-import json from 'highlight.js/lib/languages/json';
+import json from 'highlight.js/lib/languages/json'
 
-hljs.registerLanguage('json', json);
+hljs.registerLanguage('json', json)
 
 // only activate highlighting on pages with this selector
 if (document.querySelectorAll('[data-activate-highlight]').length > 0) {

--- a/apps/block_scout_web/assets/js/view_specific/raw-trace/code_highlighting.js
+++ b/apps/block_scout_web/assets/js/view_specific/raw-trace/code_highlighting.js
@@ -1,7 +1,7 @@
 import hljs from 'highlight.js/lib/core'
-import hljsDefineSolidity from 'highlightjs-solidity'
+import json from 'highlight.js/lib/languages/json';
 
-hljsDefineSolidity(hljs)
+hljs.registerLanguage('json', json);
 
 // only activate highlighting on pages with this selector
 if (document.querySelectorAll('[data-activate-highlight]').length > 0) {

--- a/apps/block_scout_web/assets/js/view_specific/raw_trace/code_highlighting.js
+++ b/apps/block_scout_web/assets/js/view_specific/raw_trace/code_highlighting.js
@@ -1,7 +1,0 @@
-import $ from 'jquery'
-import hljs from 'highlight.js'
-
-// only activate highlighting on pages with this selector
-if ($('[data-activate-highlight]').length > 0) {
-  hljs.initHighlightingOnLoad()
-}


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description

Including the staking page to the app.js bloats all the js bundles with unnecessary web3 dependency.

Before:
![image](https://user-images.githubusercontent.com/20768968/134514286-7c47ffd5-74f7-42e5-bb55-0174470a263c.png)

After:
![image](https://user-images.githubusercontent.com/20768968/134514376-f9a9a7bd-031d-47d4-908a-8c3be874d86b.png)
 
 ### Other changes

Optimizes the size of the code highlighting script by removing unnecessary dependencies and including only relevant languages to the build. And fixes the 404 issue for the script on the raw traces tab.

### Tested

Tested in the browser.

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it - N/A.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again - N/A.
  - [x] I added code comments for anything non trivial - N/A.
  - [x] I added documentation for my changes - N/A.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars - N/A.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools - N/A.
