### PR TITLE
Force cache miss on mix.compile step

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We would like to thank the [EthPrize foundation](http://ethprize.io/) for their 
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution and pull request protocol. We expect contributors to follow our [code of conduct](CODE_OF_CONDUCT.md) when submitting code or comments.
 
-## License
+## License 
 
 [![License: GPL v3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,8 +2,7 @@ steps:
   - name: "gcr.io/kaniko-project/executor:latest"
     args: [
           "--cache=true",
-          "--cache-ttl=6h",
-          "--verbosity=debug",
+          "--build-arg", "FORCE_MIX_COMPILE_CACHE_MISS=$COMMIT_SHA",
           "--destination=gcr.io/$PROJECT_ID/blockscout:$COMMIT_SHA",
           "--dockerfile", "docker/Dockerfile",
           "--context", "dir://."]
@@ -12,10 +11,9 @@ steps:
   - name: "gcr.io/kaniko-project/executor:latest"
     args: [
           "--cache=true",
-          "--cache-ttl=6h",
-          "--verbosity=debug",
           "--destination=gcr.io/$PROJECT_ID/blockscout:api-$COMMIT_SHA",
           "--dockerfile", "docker/Dockerfile",
+          "--build-arg", "FORCE_MIX_COMPILE_CACHE_MISS=$COMMIT_SHA",
           "--build-arg", "DISABLE_WRITE_API=true",
           "--build-arg", "DISABLE_INDEXER=true",
           "--build-arg", "DISABLE_WEBAPP=true",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,8 @@ steps:
   - name: "gcr.io/kaniko-project/executor:latest"
     args: [
           "--cache=true",
+          "--cache-ttl=6h",
+          "--verbosity=debug",
           "--destination=gcr.io/$PROJECT_ID/blockscout:$COMMIT_SHA",
           "--dockerfile", "docker/Dockerfile",
           "--context", "dir://."]
@@ -10,8 +12,9 @@ steps:
   - name: "gcr.io/kaniko-project/executor:latest"
     args: [
           "--cache=true",
+          "--cache-ttl=6h",
+          "--verbosity=debug",
           "--destination=gcr.io/$PROJECT_ID/blockscout:api-$COMMIT_SHA",
-
           "--dockerfile", "docker/Dockerfile",
           "--build-arg", "DISABLE_WRITE_API=true",
           "--build-arg", "DISABLE_INDEXER=true",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,5 +58,3 @@ RUN if [ "$COIN" != "" ]; then sed -i s/"POA"/"${COIN}"/g apps/block_scout_web/p
 
 # Run foreground build and phoenix digest
 RUN mix compile && mix phx.digest
-
-RUN mix phx.digest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,11 @@ ADD apps/indexer/mix.exs ./apps/indexer/
 
 RUN mix do deps.get, local.rebar --force, deps.compile
 
+# Update base image npm
+RUN npm install -g npm@7.24.1
+
 # Cache npm deps before application code
+
 ADD apps/block_scout_web/assets/ ./apps/block_scout_web/assets/
 ADD apps/explorer/package*.json ./apps/explorer/
 
@@ -56,5 +60,6 @@ ENV DISABLE_WRITE_API=${DISABLE_WRITE_API} \
 
 RUN if [ "$COIN" != "" ]; then sed -i s/"POA"/"${COIN}"/g apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po; fi
 
-# Run foreground build and phoenix digest
+# Invalidate cache via modifying build args on compilation
+ARG FORCE_MIX_COMPILE_CACHE_MISS
 RUN mix compile && mix phx.digest


### PR DESCRIPTION
closes data-services#53

### Description

Compilation stages don't appear to be taking the correct cache layer on CI. This PR sets an argument on the `mix compile` step which [should force a cache miss for the compile step](https://docs.docker.com/engine/reference/builder/#impact-on-build-caching) and result in the appropriate build files being cached on each run.
 
 ### Other changes

* Removed additional phx.digest call
* Upgraded npm in build image 

### Tested

Pulled images from cloud build and checked startup times.
