### PR TITLE
Set poll options on token fetcher.

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token.ex
+++ b/apps/indexer/lib/indexer/fetcher/token.ex
@@ -16,6 +16,8 @@ defmodule Indexer.Fetcher.Token do
 
   @defaults [
     flush_interval: 300,
+    poll_interval: :timer.seconds(60),
+    poll: true,
     max_batch_size: 1,
     max_concurrency: 10,
     task_supervisor: Indexer.Fetcher.Token.TaskSupervisor


### PR DESCRIPTION
### Description

Sets a poll config on the token fetcher to periodically stream uncataloged tokens from the database for reindexing. This is similar to how the internal transaction fetcher retrieves a list of unprocessed blocks to fetch transactions for.

### Tested

* Deployed to staging and changed some token values
    * Set `name` and `symbol` to placeholder values and `cataloged` to false
    * After 60 seconds they were reindexed with the previous (correct) values

### Issues

 - Relates to celo-org/data-services#46

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
