### PR TITLE
Fix sourcify verification full_match path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,7 @@ ARG DISABLE_INDEXER="false"
 ARG DISABLE_WEBAPP="false"
 ARG ENABLE_SOURCIFY_INTEGRATION="true"
 ARG SOURCIFY_SERVER_URL="https://sourcify.dev/server"
-ARG SOURCIFY_REPO_URL="https://repo.sourcify.dev/contracts/full_match/"
+ARG SOURCIFY_REPO_URL="https://repo.sourcify.dev/contracts/"
 
 ENV DISABLE_WRITE_API=${DISABLE_WRITE_API} \
     DISABLE_INDEXER=${DISABLE_INDEXER} \

--- a/rel/commands/run_block_scout_web.sh
+++ b/rel/commands/run_block_scout_web.sh
@@ -15,6 +15,6 @@
     DATABASE_URL=postgresql://postgres@localhost:5432/explorer \
     ENABLE_SOURCIFY_INTEGRATION=true \
     SOURCIFY_SERVER_URL=https://sourcify.dev/server \
-    SOURCIFY_REPO_URL=https://repo.sourcify.dev/contracts/full_match/ \
+    SOURCIFY_REPO_URL=https://repo.sourcify.dev/contracts/ \
     CHAIN_ID=44787 \
     mix cmd --app block_scout_web "mix phx.server"


### PR DESCRIPTION
### Description

The link has an extra '/full_match' in it that breaks it.


### Issues

 - Fixes https://github.com/celo-org/blockscout/issues/427
