### PR TITLE
Treat closed errors like timeouts.

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
@@ -70,6 +70,9 @@ defmodule EthereumJSONRPC.HTTP do
           chunked_json_rpc(tail, options, [decoded_body | decoded_response_bodies])
         end
 
+      {:error, :closed} ->
+        rechunk_json_rpc(chunks, options, :closed, decoded_response_bodies)
+
       {:error, :timeout} ->
         rechunk_json_rpc(chunks, options, :timeout, decoded_response_bodies)
 


### PR DESCRIPTION
### Description

An investigation to test treating `:closed` errors as `:timeout` errors, and force a smaller batching of requests. In theory this should rebatch failed `:closed` requests until either 1. they are small enough to be processed correctly or 2. they fails as before.

I wish to try this against rc1-1 and see if this helps us process more blocks
 
 ### Other changes

N/A

### Tested

Tested locally against staging and saw that rechunk was triggered for `:closed` errors


 ### Backwards compatibility

N/a

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
