### PR TITLE
Bugfix/parameter changes

### DIFF
--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -3,7 +3,7 @@ use Mix.Config
 config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
   rolling_window_opts: [
     window_count: 12,
-    duration: :timer.minutes(1),
+    duration: :timer.seconds(30),
     table: EthereumJSONRPC.RequestCoordinator.TimeoutCounter
   ],
   wait_per_timeout: :timer.seconds(20),

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -34,7 +34,7 @@ config :logger_json, :ethereum_jsonrpc,
 
 config :logger, :ethereum_jsonrpc, backends: [LoggerJSON]
 
-config :ethereum_jsonrpc, :internal_transaction_timeout, "100s"
+config :ethereum_jsonrpc, :internal_transaction_timeout, "360s"
 
 # config :logger, :ethereum_jsonrpc,
 #  # keep synced with `config/config.exs`

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -22,8 +22,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   @behaviour BufferedTask
 
-  @max_batch_size 20
-  @max_concurrency 8
+  @max_batch_size 8
+  @max_concurrency 10
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),


### PR DESCRIPTION
### Description

Due to recent archive node changes, we now get error messages representing the failure reason instead of just `:closed`. To utilise this we need to increase the timeout for trace requests and allow more requests to timeout within a given period (we get timeouts now, instead of socket closed notifications).

Put simply:

* Increase `debug_traceTransaction` timeout from 1m 40s to 6m
* Double the amount of requests that can timeout before being throttled by the request coordinator
* Decrease batch size and increase concurrency for internal transaction fetching
    * Given that all blocks are not equal and we timeout on expensive blocks, the worst case time complexity for importing a batch is `n log n * timeout` due to recursively splitting failed requests that contain an unindexable internal transaction
    * This PR decreases `n` from 20 to 8 and increases concurrency slightly, with the intention of importing more small batches vs fewer large batches


### Tested

* Build and ran locally
* Entirely changes to existing configurable values

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
