### PR TITLE
Changed default internal transactions settings

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -22,8 +22,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   @behaviour BufferedTask
 
-  @max_batch_size 8
-  @max_concurrency 10
+  @max_batch_size 1
+  @max_concurrency 45
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description

Changes internal transaction settings in a way that makes the indexer to process pending block operations faster. Larger batch sizes generate less load on the DB but take longer to process all the transactions in the batch that increases the time in the queue.
 
 ### Other changes

None.

### Tested

Tested in production.

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it - N/A
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again - N/A
  - [x] I added code comments for anything non trivial  - N/A
  - [x] I added documentation for my changes  - N/A
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars  - N/A
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools  - N/A
