### PR TITLE
Display revert reason

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -121,7 +121,7 @@
             </dd>
           </dl>
           <!-- Revert reason -->
-          <%= if status == {:error, "Reverted"} do %>
+          <%= if status == {:error, "execution reverted"} do %>
           <dl class="row">
             <dt class="col-sm-3 col-lg-2 text-muted">
               <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
@@ -659,7 +659,7 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
         EthereumJSONRPC.Mox,
         :json_rpc,
         fn _json, [] ->
-          {:error, %{code: -32015, message: "VM execution error.", data: "revert: No credit of that type"}}
+          {:error, %{code: -32015, message: "revert: No credit of that type"}}
         end
       )
 
@@ -702,7 +702,7 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
       EthereumJSONRPC.Mox,
       :json_rpc,
       fn _json, [] ->
-        {:error, %{code: -32015, message: "VM execution error.", data: ""}}
+        {:error, %{code: -32015, message: ""}}
       end
     )
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -107,6 +107,7 @@ defmodule Explorer.Chain do
   @revert_msg_prefix_2 "revert: "
   @revert_msg_prefix_3 "reverted "
   @revert_msg_prefix_4 "Reverted "
+  @revert_msg_prefix_5 "execution reverted: "
   # keccak256("Error(string)")
   @revert_error_method_id "08c379a0"
 
@@ -3819,8 +3820,8 @@ defmodule Explorer.Chain do
 
     data =
       case EthereumJSONRPC.json_rpc(req, json_rpc_named_arguments) do
-        {:error, %{data: data}} ->
-          data
+        {:error, %{message: message}} ->
+          message
 
         _ ->
           ""
@@ -3850,6 +3851,9 @@ defmodule Explorer.Chain do
 
       @revert_msg_prefix_4 <> rest ->
         extract_revert_reason_message_wrapper(rest)
+
+      @revert_msg_prefix_5 <> rest ->
+        rest
 
       revert_reason_full ->
         revert_reason_full

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5659,7 +5659,7 @@ defmodule Explorer.ChainTest do
         EthereumJSONRPC.Mox,
         :json_rpc,
         fn _json, [] ->
-          {:error, %{code: -32015, message: "VM execution error.", data: "revert: No credit of that type"}}
+          {:error, %{code: -32015, message: "revert: No credit of that type"}}
         end
       )
 


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description
Blockscout doesn't display the revert reason although this functionality exists. The parsing function relies on the `data` field of the RPC response, while in geth `data` contains binary data:
```
curl -s --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x1c5a9d9c0000000000000000000000004da92da1afbf103f2b52dd29326e34c98ca1e78c","from":"0x4a4f08188b99baa1b98f8027da69e3a679c0578c","to":"0x8d6677192144292870907e3fa8a5527fe55a7ff6","gas":"0x33450","gasPrice":"0x1dcd6500","value":"0x0"},"0x978DA1"],"id":0}' http://127.0.0.1:8546  -H 'Content-type: application/json'

{
  "jsonrpc": "2.0",
  "id": 0,
  "error": {
    "code": 3,
    "message": "execution reverted: Pending vote epoch not passed",
    "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001d50656e64696e6720766f74652065706f6368206e6f7420706173736564000000"
  }
}
```

Before:
![image](https://user-images.githubusercontent.com/20768968/142424300-7274fe61-9b1d-4121-8c65-f8583bc6500c.png)


After:
![image](https://user-images.githubusercontent.com/20768968/142424142-494957ed-957e-4794-9f70-a67414c24821.png)

### Tested

This PR updates the unit test that checked this functionality to match geth expectations.

### Issues

Closes https://github.com/celo-org/data-services/issues/82.

 ### Backwards compatibility

 _Brief explanation of why these changes are/are not backwards compatible._

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
