### PR TITLE
Duplicates of pending blocks in the queue

### DIFF
--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -73,6 +73,7 @@ defmodule Indexer.BufferedTask do
             max_batch_size: nil,
             max_concurrency: nil,
             poll: false,
+            dedup_entries: false,
             metadata: [],
             current_buffer: [],
             bound_queue: %BoundQueue{},
@@ -209,6 +210,7 @@ defmodule Indexer.BufferedTask do
              | {:poll_interval, timeout()}
              | {:max_batch_size, pos_integer()}
              | {:max_concurrency, pos_integer()}
+             | {:dedup_entries, boolean()}
              | {:memory_monitor, GenServer.name()}
              | {:name, GenServer.name()}
              | {:task_supervisor, GenServer.name()}
@@ -237,6 +239,7 @@ defmodule Indexer.BufferedTask do
       task_supervisor: Keyword.fetch!(opts, :task_supervisor),
       flush_interval: Keyword.fetch!(opts, :flush_interval),
       poll_interval: Keyword.get(opts, :poll_interval, :timer.seconds(3)),
+      dedup_entries: Keyword.get(opts, :dedup_entries, false),
       max_batch_size: Keyword.fetch!(opts, :max_batch_size),
       max_concurrency: Keyword.fetch!(opts, :max_concurrency),
       metadata: metadata
@@ -402,8 +405,10 @@ defmodule Indexer.BufferedTask do
   end
 
   defp push_back(%BufferedTask{bound_queue: bound_queue} = state, entries) when is_list(entries) do
+    entries_to_push = dedup_entries(state, entries)
+
     new_bound_queue =
-      case BoundQueue.push_back_until_maximum_size(bound_queue, entries) do
+      case BoundQueue.push_back_until_maximum_size(bound_queue, entries_to_push) do
         {new_bound_queue, []} ->
           new_bound_queue
 
@@ -418,6 +423,19 @@ defmodule Indexer.BufferedTask do
       end
 
     %BufferedTask{state | bound_queue: new_bound_queue}
+  end
+
+  defp dedup_entries(%BufferedTask{dedup_entries: false}, entries), do: entries
+
+  defp dedup_entries(
+         %BufferedTask{dedup_entries: true, task_ref_to_batch: task_ref_to_batch, bound_queue: bound_queue},
+         entries
+       ) do
+    running_entries = Enum.uniq(List.flatten(Map.values(task_ref_to_batch)))
+
+    entries
+    |> Enum.filter(fn e -> not Enum.member?(running_entries, e) end)
+    |> Enum.filter(fn e -> not Enum.member?(bound_queue, e) end)
   end
 
   defp take_batch(%BufferedTask{bound_queue: bound_queue, max_batch_size: max_batch_size} = state) do

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -29,6 +29,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
     poll_interval: :timer.seconds(3),
     max_concurrency: @max_concurrency,
     max_batch_size: @max_batch_size,
+    dedup_entries: true,
     poll: true,
     task_supervisor: Indexer.Fetcher.InternalTransaction.TaskSupervisor,
     metadata: [fetcher: :internal_transaction]


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description

BufferedTask is the behavior used by fetchers (and the internal transactions fetcher, in particular). It's an abstraction built around `BoundQueue` that can be used for creating a long-running process that periodically fetches new units of work from the source, enqueues them and then processes in batches with configured batch size and concurrency.

When it starts, it calls the `init` method that provides the initial list of units of work that gets immediately enqueued into the `bound_queue`. If the `poll` parameter is `true`, the `init` method will be called with the `poll_interval` periodicity. Items from this queue get dequeued with the `flush_interval` periodicity, get combined in batches of `max_batch_size` size and get passed to asynchronous tasks that actually do the processing. Internally there is a map called `task_ref_to_batch` that keeps references to currently running asynchronous tasks, up to `max_concurrency` items.  Every item's value is a batch of `max_batch_size` size of units of work.

The flow looks like the following:
1. Call `init` that returns the initial list of units of work.
2. Put those units in the `bound_queue`.
3. Dequeue `max_batch_size` elements into a `batch`, start an async task and pass the batch for processing, keep the reference in the `task_ref_to_batch` map.
4. If the size of the map < `max_concurrency`, repeat step 3.
5. When task finishes successfully, remove the reference from the `task_ref_to_batch` map.
6. Every `poll_interval` repeat 1.

Now, here is what happens when there is a small backlog of pending block operations.
Whenever the fetcher's `init` method is called, it checks the `pending_block_operations` table and returns block numbers for every row that has `fetch_internal_transactions` flag set to true (all of them, currently). If processing of blocks (tracing internal transactions) longer than `poll_interval` (set to 3 seconds currently), the `init` method would return block numbers that are still being traced currently. They will be repeatedly added to the queue, eventually resulting in multiple async tasks tracing the same block multiple times.

Here is how it looks like:
![duplicates](https://user-images.githubusercontent.com/20768968/143232850-61a2db52-787f-4b6e-bd42-a1e0437555a0.png)

For example on the screenshot above, blocks 9935341, 9935356, 9935359, 9935364, 9935365, 9935366, 9935367, and 9935369 are enqueued twice.
This leads to unnecessary load on archive nodes.

This PR adds a deduplication step that checks both `bound_queue` and `task_ref_to_batch` and filters out items that are being processed at the moment or already enqueued.

By default, deduplication is turned off as it might be not desired in some use cases when units of work represent a repeatable action with the same identifier.

 ### Other changes

No.

### Tested

A new test added that checks that deduplication removes repeated units of work that are currently either being processed or already enqueued.

### Issues

 - Fixes [#[issue number here]](https://github.com/celo-org/data-services/issues/83)

 ### Backwards compatibility

Yes, by default, deduplication is turned off.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars - N/A
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools - N/A
