### PR TITLE
Enable polling in epoch fetcher

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/celo_epoch_rewards.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_epoch_rewards.ex
@@ -18,7 +18,12 @@ defmodule Indexer.Fetcher.CeloEpochRewards do
 
   @doc false
   def child_spec([init_options, gen_server_options]) do
-    Util.default_child_spec(init_options, gen_server_options, __MODULE__)
+    init_options_with_polling =
+      init_options
+      |> Keyword.put(:poll, true)
+      |> Keyword.put(:poll_intervall, :timer.minutes(60))
+
+    Util.default_child_spec(init_options_with_polling, gen_server_options, __MODULE__)
   end
 
   @impl BufferedTask

--- a/apps/indexer/lib/indexer/fetcher/celo_epoch_rewards.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_epoch_rewards.ex
@@ -21,7 +21,7 @@ defmodule Indexer.Fetcher.CeloEpochRewards do
     init_options_with_polling =
       init_options
       |> Keyword.put(:poll, true)
-      |> Keyword.put(:poll_intervall, :timer.minutes(60))
+      |> Keyword.put(:poll_interval, :timer.minutes(60))
 
     Util.default_child_spec(init_options_with_polling, gen_server_options, __MODULE__)
   end


### PR DESCRIPTION
### Description

`Indexer.Fetcher.CeloEpochRewards` knows which blocks to index by looking into the `celo_pending_epoch_operations` table. Without this PR, the fetcher only looks once at the beginning. By setting `poll` to true, it looks every 1 hour.

### Testing

Tested by 
- deploying to staging
- removing the last entry to `celo_epoch_rewards`
- inserting the deleted entry's `block_hash` to `celo_pending_epoch_operations`
- seeing that it was properly indexed