### PR TITLE
Changed the spec for build instances

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,5 +20,5 @@ steps:
           "--context", "dir://."]
     waitFor: ["-"]
 options:
-    machineType: 'N1_HIGHCPU_8'
+    machineType: 'N1_HIGHCPU_32'
 timeout: 1200s


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description

Changes the spec for Cloud Build instances to 32 core machines to avoid timeouts.
 
 ### Other changes

-

### Tested

-

### Issues

-

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it - N/A
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again - N/A
  - [x] I added code comments for anything non trivial - N/A
  - [x] I added documentation for my changes - N/A
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars - N/A
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools - N/A
