### PR TITLE
Speed up the tokentx query

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -25,7 +25,8 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
     with {:required_params, {:ok, fetched_params}} <- fetch_required_params(params),
          {:format, {:ok, validated_params}} <- to_valid_format(fetched_params),
          {:token, {:ok, _}} <- {:token, Chain.token_from_address_hash(validated_params.address_hash)},
-         {:ok, token_transfers} <- list_token_transfers(validated_params) do
+         params = validated_params |> Map.put_new(:limit, 1_000),
+         {:ok, token_transfers} <- list_token_transfers(params) do
       render(conn, :tokentx, %{token_transfers: token_transfers})
     else
       {:required_params, {:error, missing_params}} ->

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -323,6 +323,37 @@ defmodule BlockScoutWeb.Etherscan do
     "result" => nil
   }
 
+  @token_tokentx_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => [
+      %{
+        "address" => "0x0000000000000000000000000000000000000001",
+        "amount" => "1",
+        "blockNumber" => "0",
+        "data" => "0x02",
+        "feeCurrency" => "",
+        "fromAddressHash" => "0x0000000000000000000000000000000000000001",
+        "gasPrice" => "16B969D00",
+        "gasUsed" => "12A71",
+        "gatewayFee" => "",
+        "gatewayFeeRecipient" => "",
+        "logIndex" => "2",
+        "timeStamp" => "61E67BBB",
+        "toAddressHash" => "0x0000000000000000000000000000000000000003",
+        "topics" => [nil, nil, nil, nil],
+        "transactionHash" => "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "transactionIndex" => "0"
+      }
+    ]
+  }
+
+  @token_tokentx_example_value_error %{
+    "status" => "0",
+    "message" => "Invalid contract address format",
+    "result" => nil
+  }
+
   @stats_tokensupply_example_value %{
     "status" => "1",
     "message" => "OK",
@@ -733,6 +764,18 @@ defmodule BlockScoutWeb.Etherscan do
     example: ~s("No credit of that type")
   }
 
+  @data_type %{
+    type: "data",
+    definition: "Non-indexed log parameters.",
+    example: ~s("0x")
+  }
+
+  @topics_type %{
+    type: "topics",
+    definition: "An array including the topics for the log.",
+    example: ~s(["0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"])
+  }
+
   @logs_details %{
     name: "Log Detail",
     fields: %{
@@ -742,11 +785,7 @@ defmodule BlockScoutWeb.Etherscan do
         definition: "An array including the topics for the log.",
         example: ~s(["0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"])
       },
-      data: %{
-        type: "data",
-        definition: "Non-indexed log parameters.",
-        example: ~s("0x")
-      },
+      data: @data_type,
       blockNumber: %{
         type: "block number",
         definition: "A nonnegative number used to identify blocks.",
@@ -818,6 +857,35 @@ defmodule BlockScoutWeb.Etherscan do
       cumulativeGasUsed: @gas_type,
       gasUsed: @gas_type,
       confirmations: @confirmation_type
+    }
+  }
+
+  @token_transfer_tx_model %{
+    name: "Token Transfer Transaction",
+    fields: %{
+      address: @address_hash_type,
+      amount: @wei_type,
+      blockNumber: @block_number_type,
+      data: @data_type,
+      feeCurrency: @address_hash_type,
+      fromAddressHash: @address_hash_type,
+      gasPrice: @wei_type,
+      gasUsed: @gas_type,
+      gatewayFee: @wei_type,
+      gatewayFeeRecipient: @address_hash_type,
+      logIndex: %{
+        type: "hexadecimal",
+        example: ~s("0x")
+      },
+      timeStamp: %{
+        type: "timestamp",
+        definition: "The transaction's block-timestamp.",
+        example: ~s("1439232889")
+      },
+      toAddressHash: @address_hash_type,
+      topics: @topics_type,
+      transactionHash: @transaction_hash_type,
+      transactionIndex: @transaction_index_type
     }
   }
 
@@ -937,16 +1005,8 @@ defmodule BlockScoutWeb.Etherscan do
     name: "Log",
     fields: %{
       address: @address_hash_type,
-      topics: %{
-        type: "topics",
-        definition: "An array including the topics for the log.",
-        example: ~s(["0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"])
-      },
-      data: %{
-        type: "data",
-        definition: "Non-indexed log parameters.",
-        example: ~s("0x")
-      },
+      topics: @topics_type,
+      data: @data_type,
       blockNumber: %{
         type: "block number",
         definition: "A nonnegative number used to identify blocks.",
@@ -2085,6 +2145,57 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @token_tokentx_action %{
+    name: "tokentx",
+    description: "Get token token transfers for the given contract address.",
+    required_params: [
+      %{
+        key: "contractaddress",
+        placeholder: "contractAddressHash",
+        type: "string",
+        description: "A 160-bit code used for identifying contracts."
+      },
+      %{
+        key: "fromBlock",
+        placeholder: "blockNumber",
+        type: "integer",
+        description:
+          "A nonnegative integer that represents the starting block number. The use of 'latest' is also supported."
+      },
+      %{
+        key: "toBlock",
+        placeholder: "blockNumber",
+        type: "integer",
+        description:
+          "A nonnegative integer that represents the ending block number. The use of 'latest' is also supported."
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@token_tokentx_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "array",
+              array_type: @token_transfer_tx_model
+            }
+          }
+        }
+      },
+      %{
+        code: "200",
+        description: "error",
+        example_value: Jason.encode!(@token_tokentx_example_value_error)
+      }
+    ]
+  }
+
   @stats_tokensupply_action %{
     name: "tokensupply",
     description:
@@ -2991,7 +3102,8 @@ defmodule BlockScoutWeb.Etherscan do
     name: "token",
     actions: [
       @token_gettoken_action,
-      @token_gettokenholders_action
+      @token_gettokenholders_action,
+      @token_tokentx_action
     ]
   }
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
@@ -205,6 +205,7 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
         to_address: address,
         token_contract_address: contract_address,
         block: transaction.block,
+        block_number: transaction.block_number,
         token_id: 10
       )
 
@@ -260,17 +261,24 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
 
       expected_result =
         for i <- 0..3, i > 0 do
-          log = insert(:log, address: contract_address, transaction: transaction)
+          log =
+            insert(:log,
+              address: contract_address,
+              transaction: transaction,
+              block: transaction.block
+            )
 
-          insert(:token_transfer,
-            log_index: log.index,
-            transaction: transaction,
-            from_address: contract_address,
-            to_address: address,
-            token_contract_address: contract_address,
-            block: transaction.block,
-            token_id: 10
-          )
+          transfer =
+            insert(:token_transfer,
+              log_index: log.index,
+              transaction: transaction,
+              from_address: contract_address,
+              to_address: address,
+              token_contract_address: contract_address,
+              block: transaction.block,
+              block_number: transaction.block_number,
+              token_id: 10
+            )
 
           %{
             "address" => "#{contract_address.hash}",
@@ -327,6 +335,7 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
         to_address: address,
         token_contract_address: contract_address,
         block: transaction.block,
+        block_number: transaction.block_number,
         token_id: 10
       )
 

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -255,7 +255,7 @@ defmodule Explorer.Etherscan do
     subquery =
       from(
         tt in TokenTransfer,
-        left_join: t in Transaction,
+        inner_join: t in Transaction,
         on: t.hash == tt.transaction_hash,
         left_join: l in Log,
         on: l.transaction_hash == t.hash and l.address_hash == ^params.address_hash and l.index == tt.log_index,

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -252,46 +252,61 @@ defmodule Explorer.Etherscan do
   """
   @spec list_token_transfers(map()) :: [map()]
   def list_token_transfers(params) do
-    query =
+    subquery =
       from(
-        b in Block,
+        tt in TokenTransfer,
         left_join: t in Transaction,
-        on: t.block_number == b.number,
-        left_join: tt in TokenTransfer,
-        on: tt.transaction_hash == t.hash,
+        on: t.hash == tt.transaction_hash,
         left_join: l in Log,
         on: l.transaction_hash == t.hash and l.address_hash == ^params.address_hash and l.index == tt.log_index,
+        left_join: b in Block,
+        on: b.number == t.block_number,
         where:
-          b.number >= ^params.from_block and b.number <= ^params.to_block and
+          tt.block_number >= ^params.from_block and tt.block_number <= ^params.to_block and
             tt.token_contract_address_hash == ^params.address_hash,
-        order_by: [
-          {:asc, tt.block_number},
-          {:asc, t.index}
-        ],
-        select: %{
-          token_contract_address_hash: tt.token_contract_address_hash,
-          transaction_hash: tt.transaction_hash,
-          from_address_hash: tt.from_address_hash,
-          to_address_hash: tt.to_address_hash,
-          amount: tt.amount,
+        order_by: tt.block_number,
+        limit: ^params.limit * 2,
+        select:
+          map(tt, [
+            :token_contract_address_hash,
+            :transaction_hash,
+            :from_address_hash,
+            :to_address_hash,
+            :amount,
+            :block_number
+          ]),
+        select_merge:
+          map(l, [
+            :data,
+            :first_topic,
+            :second_topic,
+            :third_topic,
+            :fourth_topic
+          ]),
+        select_merge: %{
           block_timestamp: b.timestamp,
           transaction_index: t.index,
-          log_index: l.index,
-          data: l.data,
-          first_topic: l.first_topic,
-          second_topic: l.second_topic,
-          third_topic: l.third_topic,
-          fourth_topic: l.fourth_topic
+          log_index: l.index
         },
         select_merge:
           map(t, [
-            :block_number,
             :gas_price,
             :gas_currency_hash,
             :gas_fee_recipient_hash,
             :gas_used,
             :gateway_fee
           ])
+      )
+
+    query =
+      from(
+        s in subquery(subquery),
+        order_by: [
+          {:asc, s.block_number},
+          {:asc, s.transaction_index},
+          {:asc, s.log_index}
+        ],
+        limit: ^params.limit
       )
 
     Repo.all(query)


### PR DESCRIPTION
### Description

The following query is super slow:
https://explorer.celo.org/api?module=token&action=tokentx&contractaddress=0x765de816845861e75a25fca122bb6898b8b1282a&fromBlock=7013880&toBlock=latest

The underlying SQL query is:
```
SELECT
  t2."token_contract_address_hash",
  t2."transaction_hash",
  t2."from_address_hash",
  t2."to_address_hash",
  t2."amount",
  b0."timestamp",
  t1."index",
  l3."index",
  l3."data",
  l3."first_topic",
  l3."second_topic",
  l3."third_topic",
  l3."fourth_topic",
  t1."block_number",
  t1."gas_price",
  t1."gas_currency_hash",
  t1."gas_fee_recipient_hash",
  t1."gas_used",
  t1."gateway_fee"
FROM "blocks" AS b0
LEFT OUTER JOIN "transactions" AS t1
ON t1."block_number" = b0."number"
LEFT OUTER JOIN "token_transfers" AS t2
ON t2."transaction_hash" = t1."hash"
LEFT OUTER JOIN "logs" AS l3
ON(
  (l3."transaction_hash" = t1."hash") AND
  (l3."address_hash" = '\x765de816845861e75a25fca122bb6898b8b1282a')) AND
  (l3."index" = t2."log_index")
WHERE (
  ((b0."number" >= 7013880) AND (b0."number" <= 10504814)) AND
  (t2."token_contract_address_hash" = '\x765de816845861e75a25fca122bb6898b8b1282a'))
ORDER BY t2."block_number", t1."index";
 ```
it is so slow, it times out. It applies conditions to 4 different tables which makes the query plan too complex while almost all of them can be applied to the `token_transfers` table using existing indexes on that table which would speed up the query.

This PR replaces the slow query with an optimized one:
```
SELECT s1.*
FROM (
  SELECT
    t2."token_contract_address_hash",
    t2."transaction_hash",
    t2."from_address_hash",
    t2."to_address_hash",
    t2."amount",
    t2."block_number",
    t1."index" AS "transaction_index",
    t1."gas_price",
    t1."gas_currency_hash",
    t1."gas_fee_recipient_hash",
    t1."gas_used",
    t1."gateway_fee",
    l3."index" AS "log_index",
    l3."data",
    l3."first_topic",
    l3."second_topic",
    l3."third_topic",
    l3."fourth_topic",
    b0."timestamp"
  FROM "token_transfers" AS t2
  LEFT OUTER JOIN "transactions" as t1
  ON t1."hash" = t2."transaction_hash"
  LEFT OUTER JOIN "logs" AS l3
  ON l3."transaction_hash" = t1."hash" AND l3."address_hash" = '\x765de816845861e75a25fca122bb6898b8b1282a'
  LEFT JOIN "blocks" AS b0 ON b0."number" = t1."block_number"
  WHERE t2."block_number" >= 7003880 AND t2."block_number" <= 10504814 AND t2."token_contract_address_hash" = '\x765de816845861e75a25fca122bb6898b8b1282a'
  ORDER BY t2."block_number"
  LIMIT 2000
) AS s1
ORDER BY s1."block_number", s1."transaction_index", s1. "log_index"
LIMIT 1000;
```

[Query plan](https://explain.depesz.com/s/lCJkr).

 ### Other changes
Additionally, it applies a default limit of 1000 records (following etherscan implementation) to reduce the scope of the query for very broad block ranges.

### Tested

Existing tests still pass with the updated query.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/126.

 ### Backwards compatibility

It produces a similar result set.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
