### PR TITLE
Bugfix/more event fixes

### DIFF
--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -5,7 +5,6 @@ defmodule Explorer.Celo.ContractEvents.Common do
   alias Explorer.Chain.Hash.Address
   alias Explorer.Chain.{Data, Hash, Hash.Full}
 
-
   @doc "Decode a single point of event data of a given type from a given topic"
   def decode_event(topic, type) do
     topic
@@ -34,19 +33,23 @@ defmodule Explorer.Celo.ContractEvents.Common do
   end
 
   def extract_common_event_params(event) do
-    [:transaction_hash, :block_hash] #set full hashes
+    # set full hashes
+    [:transaction_hash, :block_hash]
     |> Enum.into(%{}, fn key ->
       case Map.get(event, key) do
-        nil -> {key, nil}
+        nil ->
+          {key, nil}
+
         v ->
           {:ok, hsh} = Full.cast(v)
           {key, hsh}
       end
     end)
-    |> then(fn map -> #set contract address hash
-       {:ok, hsh} = Address.cast(event.contract_address_hash)
-       Map.put(map, :contract_address_hash, hsh)
-     end)
+    # set contract address hash
+    |> then(fn map ->
+      {:ok, hsh} = Address.cast(event.contract_address_hash)
+      Map.put(map, :contract_address_hash, hsh)
+    end)
     |> Map.put(:name, event.name)
     |> Map.put(:log_index, event.log_index)
   end

--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -3,7 +3,8 @@ defmodule Explorer.Celo.ContractEvents.Common do
 
   alias ABI.TypeDecoder
   alias Explorer.Chain.Hash.Address
-  alias Explorer.Chain.{Data, Hash}
+  alias Explorer.Chain.{Data, Hash, Hash.Full}
+
 
   @doc "Decode a single point of event data of a given type from a given topic"
   def decode_event(topic, type) do
@@ -33,14 +34,19 @@ defmodule Explorer.Celo.ContractEvents.Common do
   end
 
   def extract_common_event_params(event) do
-    # set hashes explicitly to nil rather than empty string when they do not exist
-    [:transaction_hash, :contract_address_hash, :block_hash]
+    [:transaction_hash, :block_hash] #set full hashes
     |> Enum.into(%{}, fn key ->
       case Map.get(event, key) do
         nil -> {key, nil}
-        v -> {key, v}
+        v ->
+          {:ok, hsh} = Full.cast(v)
+          {key, hsh}
       end
     end)
+    |> then(fn map -> #set contract address hash
+       {:ok, hsh} = Address.cast(event.contract_address_hash)
+       Map.put(map, :contract_address_hash, hsh)
+     end)
     |> Map.put(:name, event.name)
     |> Map.put(:log_index, event.log_index)
   end

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -41,9 +41,12 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
 
       assert result.name == "ValidatorGroupVoteActivated"
       assert result.log_index == 8
-      assert result.transaction_hash == "0xb8960575a898afa8a124cd7414f1261109a119dba3bed4489393952a1556a5f0"
-      assert result.contract_address_hash == "0x765de816845861e75a25fca122bb6898b8b1282a"
-      assert result.block_hash == "0x42b21f09e9956d1a01195b1ca461059b2705fe850fc1977bd7182957e1b390d3"
+
+      assert result.transaction_hash |> to_string() ==
+               "0xb8960575a898afa8a124cd7414f1261109a119dba3bed4489393952a1556a5f0"
+
+      assert result.contract_address_hash |> to_string() == "0x765de816845861e75a25fca122bb6898b8b1282a"
+      assert result.block_hash |> to_string() == "0x42b21f09e9956d1a01195b1ca461059b2705fe850fc1977bd7182957e1b390d3"
 
       %{params: params} = result
 
@@ -58,10 +61,12 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
     test "Asserts factory functionality for events" do
       block = insert(:block)
       log = insert(:log, block: block)
+      contract = insert(:contract_address)
 
       event = %ValidatorGroupActiveVoteRevokedEvent{
         block_hash: block.hash,
         log_index: log.index,
+        contract_address_hash: contract.hash,
         account: address_hash(),
         group: address_hash(),
         units: 6_969_696_969,

--- a/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
@@ -82,17 +82,19 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
       assert result.group |> to_string() == "0x47b2db6af05a55d42ed0f3731735f9479abf0673"
       assert result.log_index == 8
 
-      #explictly setting timestamps as insert_all doesn't do this
-      r = result
-          |> EventMap.event_to_contract_event_params()
-          |> Map.put(:inserted_at, Timex.now())
-          |> Map.put(:updated_at, Timex.now())
+      # explictly setting timestamps as insert_all doesn't do this
+      r =
+        result
+        |> EventMap.event_to_contract_event_params()
+        |> Map.put(:inserted_at, Timex.now())
+        |> Map.put(:updated_at, Timex.now())
 
-      {1,_} = Explorer.Repo.insert_all(CeloContractEvent, [r])
+      {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [r])
 
-      [result] = ValidatorGroupVoteActivatedEvent.query()
-                 |> Repo.all()
-                 |> EventMap.celo_contract_event_to_concrete_event()
+      [result] =
+        ValidatorGroupVoteActivatedEvent.query()
+        |> Repo.all()
+        |> EventMap.celo_contract_event_to_concrete_event()
 
       assert result.value == 66_980_000_000_000_000_000
       assert result.units == 6_136_281_451_163_456_507_329_304_650_157_103_347_504

--- a/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
@@ -1,8 +1,10 @@
 defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
   use Explorer.DataCase, async: true
 
+  alias Explorer.Chain.CeloContractEvent
   alias Explorer.Chain.Log
   alias Explorer.Celo.ContractEvents.EventTransformer
+  alias Explorer.Celo.ContractEvents.EventMap
   alias Explorer.Celo.ContractEvents.Election.ValidatorGroupVoteActivatedEvent
 
   describe "Test conversion" do
@@ -48,7 +50,16 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
       assert result.log_index == 8
     end
 
-    test "converts from ethjsonrpc log to event type" do
+    test "converts from ethjsonrpc log to event type and insert into db" do
+      {:ok, hsh} = Explorer.Chain.Hash.Full.cast("0x42b21f09e9956d1a01195b1ca461059b2705fe850fc1977bd7182957e1b390d3")
+      insert(:block, hash: hsh)
+
+      {:ok, hsh} = Explorer.Chain.Hash.Full.cast("0xb8960575a898afa8a124cd7414f1261109a119dba3bed4489393952a1556a5f0")
+      insert(:transaction, hash: hsh)
+
+      {:ok, add} = Explorer.Chain.Hash.Address.cast("0x765de816845861e75a25fca122bb6898b8b1282a")
+      insert(:contract_address, hash: add)
+
       test_params = %{
         address_hash: "0x765de816845861e75a25fca122bb6898b8b1282a",
         block_hash: "0x42b21f09e9956d1a01195b1ca461059b2705fe850fc1977bd7182957e1b390d3",
@@ -64,6 +75,24 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
       }
 
       result = %ValidatorGroupVoteActivatedEvent{} |> EventTransformer.from_params(test_params)
+
+      assert result.value == 66_980_000_000_000_000_000
+      assert result.units == 6_136_281_451_163_456_507_329_304_650_157_103_347_504
+      assert result.account |> to_string() == "0x88c1c759600ec3110af043c183a2472ab32d099c"
+      assert result.group |> to_string() == "0x47b2db6af05a55d42ed0f3731735f9479abf0673"
+      assert result.log_index == 8
+
+      #explictly setting timestamps as insert_all doesn't do this
+      r = result
+          |> EventMap.event_to_contract_event_params()
+          |> Map.put(:inserted_at, Timex.now())
+          |> Map.put(:updated_at, Timex.now())
+
+      {1,_} = Explorer.Repo.insert_all(CeloContractEvent, [r])
+
+      [result] = ValidatorGroupVoteActivatedEvent.query()
+                 |> Repo.all()
+                 |> EventMap.celo_contract_event_to_concrete_event()
 
       assert result.value == 66_980_000_000_000_000_000
       assert result.units == 6_136_281_451_163_456_507_329_304_650_157_103_347_504

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -2314,7 +2314,9 @@ defmodule Explorer.Chain.ImportTest do
 
     test "inserts celo contract events " do
       %Block{number: block_number} = insert(:block, consensus: true)
-      %Address{hash: address_hash} = address = insert(:address)
+      %Address{hash: address_hash} = insert(:address)
+      %Transaction{hash: transaction_hash } = insert(:transaction)
+
 
       miner_hash_after = address_hash()
       from_address_hash_after = address_hash()
@@ -2331,7 +2333,7 @@ defmodule Explorer.Chain.ImportTest do
         index: 8,
         second_topic: "0x00000000000000000000000088c1c759600ec3110af043c183a2472ab32d099c",
         third_topic: "0x00000000000000000000000047b2db6af05a55d42ed0f3731735f9479abf0673",
-        transaction_hash: nil
+        transaction_hash: transaction_hash
       }
 
       events = EventMap.rpc_to_event_params([log])

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -2315,8 +2315,7 @@ defmodule Explorer.Chain.ImportTest do
     test "inserts celo contract events " do
       %Block{number: block_number} = insert(:block, consensus: true)
       %Address{hash: address_hash} = insert(:address)
-      %Transaction{hash: transaction_hash } = insert(:transaction)
-
+      %Transaction{hash: transaction_hash} = insert(:transaction)
 
       miner_hash_after = address_hash()
       from_address_hash_after = address_hash()

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -23,7 +23,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
   @behaviour BufferedTask
 
   @max_batch_size 1
-  @max_concurrency 45
+  @max_concurrency 1
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -23,7 +23,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
   @behaviour BufferedTask
 
   @max_batch_size 1
-  @max_concurrency 1
+  @max_concurrency 45
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),


### PR DESCRIPTION
### Description

Some issues were preventing events being ingested on staging, notably the hash was in the wrong format for transactions - `Hash.Full` vs `Hash.Address`. Epoch events don't contain transaction hashes so they were ingested correctly. This PR adds a test for this + fixes the issue.
 
 ### Other changes

Massaged the ecto query to transform logs into events because composite keys suck so much in this schema and aren't usable without heroic measures.

### Tested

 _An explanation of how the changes were tested or an explanation as to why they don't need to be._
 _Add any artifacts (links, screenshots) you can include to increase the reviewers' confidence in the change._

### Issues

 - relates to celo-org/data-services#150

