### PR TITLE
Persisted cached TX count

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3615,6 +3615,7 @@ defmodule Explorer.Chain do
 
         _ ->
           count
+          |> Decimal.to_integer()
       end
     else
       cached_value

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3609,10 +3609,12 @@ defmodule Explorer.Chain do
       case count do
         nil ->
           %Postgrex.Result{rows: [[rows]]} =
-          SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
+            SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
 
           rows
-        _ -> count
+
+        _ ->
+          count
       end
     else
       cached_value

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3118,10 +3118,7 @@ defmodule Explorer.Chain do
         select: last_fetched_counter.value
       )
 
-    case Repo.one(query) do
-      {:ok, result} -> result
-      _ -> Decimal.new(0)
-    end
+    Repo.one(query) || Decimal.new(0)
   end
 
   defp block_status({number, timestamp}) do
@@ -3607,10 +3604,16 @@ defmodule Explorer.Chain do
     cached_value = TransactionCount.get_count()
 
     if is_nil(cached_value) do
-      %Postgrex.Result{rows: [[rows]]} =
-        SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
+      count = Chain.get_last_fetched_counter("total_transaction_count")
 
-      rows
+      case count do
+        nil ->
+          %Postgrex.Result{rows: [[rows]]} =
+          SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
+
+          rows
+        _ -> count
+      end
     else
       cached_value
     end

--- a/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
@@ -15,9 +15,8 @@ defmodule Explorer.Chain.Cache.TransactionCount do
 
   require Logger
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Transaction
-  alias Explorer.Repo
 
   defp handle_fallback(:count) do
     # This will get the task PID if one exists and launch a new task if not

--- a/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction_count.ex
@@ -15,6 +15,7 @@ defmodule Explorer.Chain.Cache.TransactionCount do
 
   require Logger
 
+  alias Explorer.Chain
   alias Explorer.Chain.Transaction
   alias Explorer.Repo
 
@@ -33,6 +34,13 @@ defmodule Explorer.Chain.Cache.TransactionCount do
       Task.start(fn ->
         try do
           result = Repo.aggregate(Transaction, :count, :hash, timeout: :infinity)
+
+          params = %{
+            counter_type: "total_transaction_count",
+            value: result
+          }
+
+          Chain.upsert_last_fetched_counter(params)
 
           set_count(result)
         rescue

--- a/apps/explorer/test/explorer/chain/cache/transaction_count_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/transaction_count_test.exs
@@ -2,6 +2,7 @@ defmodule Explorer.Chain.Cache.TransactionCountTest do
   use Explorer.DataCase
 
   alias Explorer.Chain.Cache.TransactionCount
+  alias Explorer.Counters.LastFetchedCounter
 
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, TransactionCount.child_id())
@@ -19,9 +20,13 @@ defmodule Explorer.Chain.Cache.TransactionCountTest do
     insert(:transaction)
     insert(:transaction)
 
-    _result = TransactionCount.get_count()
+    result = TransactionCount.get_count()
+    assert is_nil(result)
 
     Process.sleep(1000)
+
+    counter = Repo.one!(from(c in LastFetchedCounter, where: c.counter_type == "total_transaction_count"))
+    assert 2 == Decimal.to_integer(counter.value)
 
     updated_value = TransactionCount.get_count()
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -6000,7 +6000,7 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "get_last_fetched_counters/1" do
+  describe "get_last_fetched_counter/1" do
     test "it returns zero if doesn't exist in db" do
       value = Chain.get_last_fetched_counter("total_transaction_count")
       assert 0 == Decimal.to_integer(value)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5999,4 +5999,22 @@ defmodule Explorer.ChainTest do
       Chain.list_top_tokens("tsSLAueP<esi:include%20src=\"http://bxss.me/rpb.png\"/>")
     end
   end
+
+  describe "get_last_fetched_counters/1" do
+    test "it returns zero if doesn't exist in db" do
+      value = Chain.get_last_fetched_counter("total_transaction_count")
+      assert 0 == Decimal.to_integer(value)
+    end
+
+    test "it returns previous value" do
+      params = %{
+        counter_type: "total_transaction_count",
+        value: 100
+      }
+
+      Chain.upsert_last_fetched_counter(params)
+
+      assert 100 == Decimal.to_integer(Chain.get_last_fetched_counter("total_transaction_count"))
+    end
+  end
 end


### PR DESCRIPTION
### Description

The total TX count is stored in ETS cache only and the API method that is supposed to return it always falls back to fetching an estimated value based on the number of tuples in the table. This method is fast but, unfortunately, leads to very intermittent results and usually never returns correct values.
There is a job that updates cache value every 2 hours by default with accurate values using the `SELECT *` query.

This PR persists the value of the cache in the counters table so it can be reused by API.
 
 ### Other changes

Fixes the method that returns last fetched counters.

### Tested

Added a test to make sure that there is no regression in `get_last_fetched_counter`.
Added a test to check that the cached value is saved in the counters table.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/164

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
