### PR TITLE
Move Runner.CeloContractEvent into BlockReferencing import stage.

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/stage/address_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/address_referencing.ex
@@ -15,7 +15,6 @@ defmodule Explorer.Chain.Import.Stage.AddressReferencing do
       Runner.Address.Names,
       Runner.Blocks,
       Runner.CeloAccounts,
-      Runner.CeloContractEvent,
       Runner.CeloParams,
       Runner.CeloSigners,
       Runner.CeloValidators,

--- a/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
@@ -15,6 +15,7 @@ defmodule Explorer.Chain.Import.Stage.BlockReferencing do
       Runner.Transactions,
       Runner.Transaction.Forks,
       Runner.Logs,
+      Runner.CeloContractEvent,
       Runner.Tokens,
       Runner.TokenTransfers,
       Runner.Address.TokenBalances


### PR DESCRIPTION
### Description

Errors due to importing contract events are preventing two blocks from being imported on the RC1-3 environment. This issue hasn't yet been seen on the live explorer. Ultimately events are in certain circumstances being imported before transactions which causes a foreign key constraint to fail. 

This PR moves the import stage to have the same priority as the log import, just after transactions. 
 
### Tested

* Passed unit tests
    * To test on staging before live deploy

### Issues

 - relates to #564 

