### PR TITLE
Bugfix/tokens

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1260,7 +1260,8 @@ defmodule Explorer.Chain do
     end
   end
 
-  defp prepare_search_term(string) do
+  #def prepare_search_term(nil), do: ""
+  def prepare_search_term(string) do
     case Regex.scan(~r/[a-zA-Z0-9]+/, string) do
       [_ | _] = words ->
         term_final =

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1261,6 +1261,7 @@ defmodule Explorer.Chain do
   end
 
   def prepare_search_term(nil), do: ""
+
   def prepare_search_term(string) do
     case Regex.scan(~r/[a-zA-Z0-9]+/, string) do
       [_ | _] = words ->

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1260,7 +1260,7 @@ defmodule Explorer.Chain do
     end
   end
 
-  #def prepare_search_term(nil), do: ""
+  def prepare_search_term(nil), do: ""
   def prepare_search_term(string) do
     case Regex.scan(~r/[a-zA-Z0-9]+/, string) do
       [_ | _] = words ->

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -6011,4 +6011,11 @@ defmodule Explorer.ChainTest do
       assert 100 == Decimal.to_integer(Chain.get_last_fetched_counter("total_transaction_count"))
     end
   end
+
+  describe "prepare_search_term/1" do
+    test "doesn't crash when given nil search term" do
+      term = Chain.prepare_search_term(nil)
+      assert true, "Didn't crash"
+    end
+  end
 end


### PR DESCRIPTION
closes celo-org/data-services#176

### Description

Token page is throwing a 500 error due to being provided with a nil search term and trying to run a regex on it. This pr explicitly returns an empty string as a search term when no filter is provided.
 

### Tested

* added and ran unit test for bug

