### PR TITLE
Return tupled string from prepare_search_term in case of nil value.

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1260,7 +1260,7 @@ defmodule Explorer.Chain do
     end
   end
 
-  def prepare_search_term(nil), do: ""
+  def prepare_search_term(nil), do: {:some, ""}
 
   def prepare_search_term(string) do
     case Regex.scan(~r/[a-zA-Z0-9]+/, string) do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -6013,9 +6013,9 @@ defmodule Explorer.ChainTest do
   end
 
   describe "prepare_search_term/1" do
-    test "doesn't crash when given nil search term" do
+    test "returns empty string in tuple when given nil as search term" do
       term = Chain.prepare_search_term(nil)
-      assert true, "Didn't crash"
+      assert {:some, ""} == term, "nil value should result in empty string search term"
     end
   end
 end


### PR DESCRIPTION
closes celo-org/data-services#176 for real this time

### Description

Last PR fixed the cause of the crash but did not restore functionality to the empty search filter case. Now a tupled string is returned which allow the app to treat the search as if no filter was applied (instead of an invalid filter)
 
### Tested

* Modified and ran unit test
* Actually ran the app against the staging DB this time and saw the token page load correctly
