### PR TITLE
Add block_number and topic to celo_contract_events

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution and pull request protoco
 
 [![License: GPL v3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-This project is licensed under the GNU General Public License v3.0. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0. See the [LICENSE](LICENSE) file for details. 

--- a/apps/explorer/lib/explorer/celo/events/contract_events/base/contract_event_base.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/base/contract_event_base.ex
@@ -59,10 +59,11 @@ defmodule Explorer.Celo.ContractEvents.Base do
     # finding all properties for the event struct
     common_event_properties = [
       :transaction_hash,
-      :block_hash,
+      :block_number,
       :contract_address_hash,
       :log_index,
-      name: Module.get_attribute(env.module, :name)
+      name: Module.get_attribute(env.module, :name),
+      topic: Module.get_attribute(env.module, :topic)
     ]
 
     struct_properties =
@@ -125,7 +126,8 @@ defmodule Explorer.Celo.ContractEvents.Base do
             # mapping common event properties
             common_event_properties = %{
               transaction_hash: params.transaction_hash,
-              block_hash: params.block_hash,
+              block_number: params.block_number,
+              topic: params.first_topic,
               contract_address_hash: params.address_hash,
               log_index: params.index
             }
@@ -154,7 +156,8 @@ defmodule Explorer.Celo.ContractEvents.Base do
 
             %{
               transaction_hash: contract.transaction_hash,
-              block_hash: contract.block_hash,
+              block_number: contract.block_number,
+              topic: contract.topic,
               contract_address_hash: contract.contract_address_hash,
               log_index: contract.log_index
             }

--- a/apps/explorer/lib/explorer/celo/events/contract_events/base/contract_event_base.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/base/contract_event_base.ex
@@ -39,7 +39,7 @@ defmodule Explorer.Celo.ContractEvents.Base do
       def topic, do: @topic
 
       def query do
-        from(c in CeloContractEvent, where: c.name == ^@name)
+        from(c in CeloContractEvent, where: c.topic == ^@topic)
       end
     end
   end

--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -45,7 +45,7 @@ defmodule Explorer.Celo.ContractEvents.Common do
 
   def extract_common_event_params(event) do
     # set full hashes
-    [:transaction_hash, :block_hash]
+    [:transaction_hash]
     |> Enum.into(%{}, fn key ->
       case Map.get(event, key) do
         nil ->
@@ -62,6 +62,8 @@ defmodule Explorer.Celo.ContractEvents.Common do
       Map.put(map, :contract_address_hash, hsh)
     end)
     |> Map.put(:name, event.name)
+    |> Map.put(:topic, event.topic)
+    |> Map.put(:block_number, event.block_number)
     |> Map.put(:log_index, event.log_index)
   end
 

--- a/apps/explorer/lib/explorer/celo/events/contract_events/election/epoch_rewards_distributed_to_voters_event.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/election/epoch_rewards_distributed_to_voters_event.ex
@@ -18,10 +18,10 @@ defmodule Explorer.Celo.ContractEvents.Election.EpochRewardsDistributedToVotersE
   event_param(:group, :address, :indexed)
   event_param(:value, {:uint, 256}, :unindexed)
 
-  def elected_groups_for_block(block_hash) do
+  def elected_groups_for_block(block_number) do
     events =
       query()
-      |> where([e], e.block_hash == ^block_hash)
+      |> where([e], e.block_number == ^block_number)
       |> Repo.all()
       |> EventMap.celo_contract_event_to_concrete_event()
 

--- a/apps/explorer/lib/explorer/celo/events/contract_events/election/epoch_rewards_distributed_to_voters_event.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/election/epoch_rewards_distributed_to_voters_event.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Celo.ContractEvents.Election.EpochRewardsDistributedToVotersE
     events =
       query()
       |> where([e], e.block_number == ^block_number)
-      |> order_by([e], [asc: e.log_index])
+      |> order_by([e], asc: e.log_index)
       |> Repo.all()
       |> EventMap.celo_contract_event_to_concrete_event()
 

--- a/apps/explorer/lib/explorer/celo/events/contract_events/election/epoch_rewards_distributed_to_voters_event.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/election/epoch_rewards_distributed_to_voters_event.ex
@@ -22,6 +22,7 @@ defmodule Explorer.Celo.ContractEvents.Election.EpochRewardsDistributedToVotersE
     events =
       query()
       |> where([e], e.block_number == ^block_number)
+      |> order_by([e], [asc: e.log_index])
       |> Repo.all()
       |> EventMap.celo_contract_event_to_concrete_event()
 

--- a/apps/explorer/lib/explorer/celo/events/contract_events/event_map.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/event_map.ex
@@ -31,8 +31,8 @@ defmodule Explorer.Celo.ContractEvents.EventMap do
     |> Enum.reject(&is_nil/1)
   end
 
-  def celo_contract_event_to_concrete_event(%{name: name} = params) do
-    case event_for_name(name) do
+  def celo_contract_event_to_concrete_event(%{topic: topic} = params) do
+    case event_for_topic(topic) do
       nil ->
         nil
 
@@ -100,6 +100,5 @@ defmodule Explorer.Celo.ContractEvents.EventMap do
   }
 
   def event_for_topic(topic), do: Map.get(@topic_to_event, topic)
-  def event_for_name(name), do: Map.get(@name_to_event, name)
   def maps, do: {@name_to_event, @topic_to_event}
 end

--- a/apps/explorer/lib/explorer/celo/validator_group_rewards.ex
+++ b/apps/explorer/lib/explorer/celo/validator_group_rewards.ex
@@ -32,12 +32,12 @@ defmodule Explorer.Celo.ValidatorGroupRewards do
         to_date -> to_date
       end
 
-    validator_epoch_payment_distributed = ValidatorEpochPaymentDistributedEvent.name()
+    validator_epoch_payment_distributed = ValidatorEpochPaymentDistributedEvent.topic()
 
     query =
       from(event in CeloContractEvent,
         inner_join: block in Block,
-        on: event.block_hash == block.hash,
+        on: event.block_number == block.number,
         select: %{
           amount: json_extract_path(event.params, ["group_payment"]),
           date: block.timestamp,
@@ -46,7 +46,7 @@ defmodule Explorer.Celo.ValidatorGroupRewards do
           validator: json_extract_path(event.params, ["validator"])
         },
         order_by: [asc: block.number],
-        where: event.name == ^validator_epoch_payment_distributed,
+        where: event.topic == ^validator_epoch_payment_distributed,
         where: block.timestamp >= ^from_date,
         where: block.timestamp < ^to_date
       )

--- a/apps/explorer/lib/explorer/celo/validator_rewards.ex
+++ b/apps/explorer/lib/explorer/celo/validator_rewards.ex
@@ -32,12 +32,12 @@ defmodule Explorer.Celo.ValidatorRewards do
         to_date -> to_date
       end
 
-    validator_epoch_payment_distributed = ValidatorEpochPaymentDistributedEvent.name()
+    validator_epoch_payment_distributed = ValidatorEpochPaymentDistributedEvent.topic()
 
     query =
       from(event in CeloContractEvent,
         inner_join: block in Block,
-        on: event.block_hash == block.hash,
+        on: event.block_number == block.number,
         select: %{
           amount: json_extract_path(event.params, ["validator_payment"]),
           date: block.timestamp,
@@ -46,7 +46,7 @@ defmodule Explorer.Celo.ValidatorRewards do
           group: json_extract_path(event.params, ["group"])
         },
         order_by: [asc: block.number],
-        where: event.name == ^validator_epoch_payment_distributed,
+        where: event.topic == ^validator_epoch_payment_distributed,
         where: block.timestamp >= ^from_date,
         where: block.timestamp < ^to_date
       )

--- a/apps/explorer/lib/explorer/celo/voter_rewards.ex
+++ b/apps/explorer/lib/explorer/celo/voter_rewards.ex
@@ -39,14 +39,13 @@ defmodule Explorer.Celo.VoterRewards do
       end
 
     voter_rewards_for_group = Application.get_env(:explorer, :voter_rewards_for_group)
-    validator_group_vote_activated = ValidatorGroupVoteActivatedEvent.name()
+    validator_group_vote_activated = ValidatorGroupVoteActivatedEvent.topic()
 
     query =
       ValidatorGroupVoteActivatedEvent.query()
-      |> join(:inner, [event], block in Block, on: event.block_hash == block.hash)
       |> distinct([event], [json_extract_path(event.params, ["voter"]), json_extract_path(event.params, ["group"])])
-      |> order_by([_, block], block.number)
-      |> where([event], event.name == ^validator_group_vote_activated)
+      |> order_by([event], event.block_number)
+      |> where([event], event.topic == ^validator_group_vote_activated)
 
     validator_group_vote_activated_events =
       query

--- a/apps/explorer/lib/explorer/celo/voter_rewards_for_group.ex
+++ b/apps/explorer/lib/explorer/celo/voter_rewards_for_group.ex
@@ -52,8 +52,6 @@ defmodule Explorer.Celo.VoterRewardsForGroup do
       voter_activated_or_revoked ->
         [voter_activated_earliest_block | _] = voter_activated_or_revoked
 
-
-        require IEx; IEx.pry
         query =
           from(event in CeloContractEvent,
             inner_join: block in Block,

--- a/apps/explorer/lib/explorer/celo/voter_rewards_for_group.ex
+++ b/apps/explorer/lib/explorer/celo/voter_rewards_for_group.ex
@@ -20,26 +20,23 @@ defmodule Explorer.Celo.VoterRewardsForGroup do
     ValidatorGroupVoteActivatedEvent
   }
 
-  @validator_group_vote_activated ValidatorGroupVoteActivatedEvent.name()
+  @validator_group_vote_activated ValidatorGroupVoteActivatedEvent.topic()
 
   def calculate(voter_address_hash, group_address_hash, to_date \\ DateTime.utc_now()) do
-    validator_group_active_vote_revoked = ValidatorGroupActiveVoteRevokedEvent.name()
-    epoch_rewards_distributed_to_voters = EpochRewardsDistributedToVotersEvent.name()
+    validator_group_active_vote_revoked = ValidatorGroupActiveVoteRevokedEvent.topic()
+    epoch_rewards_distributed_to_voters = EpochRewardsDistributedToVotersEvent.topic()
 
     query =
       from(event in CeloContractEvent,
-        inner_join: block in Block,
-        on: event.block_hash == block.hash,
         select: %{
-          block_hash: event.block_hash,
-          block_number: block.number,
+          block_number: event.block_number,
           amount_activated_or_revoked: json_extract_path(event.params, ["value"]),
-          event: event.name
+          event: event.topic
         },
-        order_by: [asc: block.number],
+        order_by: [asc: event.block_number],
         where:
-          event.name == ^validator_group_active_vote_revoked or
-            event.name == ^@validator_group_vote_activated
+          event.topic == ^validator_group_active_vote_revoked or
+            event.topic == ^@validator_group_vote_activated
       )
 
     ordered_activated_or_revoked_events_for_voter_for_group =
@@ -55,22 +52,24 @@ defmodule Explorer.Celo.VoterRewardsForGroup do
       voter_activated_or_revoked ->
         [voter_activated_earliest_block | _] = voter_activated_or_revoked
 
+
+        require IEx; IEx.pry
         query =
           from(event in CeloContractEvent,
-            inner_join: votes in CeloValidatorGroupVotes,
-            on: event.block_hash == votes.block_hash,
             inner_join: block in Block,
-            on: event.block_hash == block.hash,
+            on: event.block_number == block.number,
+            inner_join: votes in CeloValidatorGroupVotes,
+            on: votes.block_hash == block.hash,
             select: %{
-              block_hash: event.block_hash,
-              block_number: block.number,
+              block_hash: block.hash,
+              block_number: event.block_number,
               date: block.timestamp,
               epoch_reward: json_extract_path(event.params, ["value"]),
-              event: event.name,
+              event: event.topic,
               previous_block_group_votes: votes.previous_block_active_votes
             },
             where: block.number >= ^voter_activated_earliest_block.block_number,
-            where: event.name == ^epoch_rewards_distributed_to_voters,
+            where: event.topic == ^epoch_rewards_distributed_to_voters,
             where: block.timestamp < ^to_date
           )
 

--- a/apps/explorer/lib/explorer/chain/celo_contract_event.ex
+++ b/apps/explorer/lib/explorer/chain/celo_contract_event.ex
@@ -15,20 +15,24 @@ defmodule Explorer.Chain.CeloContractEvent do
   @type t :: %__MODULE__{
           block_hash: Hash.Full.t(),
           name: String.t(),
+          topic: String.t(),
           log_index: non_neg_integer(),
+          block_number: non_neg_integer(),
           contract_address_hash: Hash.Address.t(),
           transaction_hash: Hash.Full.t(),
           params: map()
         }
 
-  @attrs ~w( name contract_address_hash transaction_hash block_hash log_index params)a
-  @required ~w( name contract_address_hash block_hash log_index)a
+  @attrs ~w( name contract_address_hash transaction_hash block_hash log_index params topic block_number)a
+  @required ~w( name contract_address_hash block_hash log_index topic block_number)a
 
   @primary_key false
   schema "celo_contract_events" do
     field(:block_hash, Hash.Full, primary_key: true)
     field(:log_index, :integer, primary_key: true)
     field(:name, :string)
+    field(:topic, :string)
+    field(:block_number, :integer)
     field(:params, :map)
     field(:contract_address_hash, Address)
     field(:transaction_hash, Hash.Full)

--- a/apps/explorer/lib/explorer/chain/celo_contract_event.ex
+++ b/apps/explorer/lib/explorer/chain/celo_contract_event.ex
@@ -13,7 +13,6 @@ defmodule Explorer.Chain.CeloContractEvent do
   alias Explorer.Repo
 
   @type t :: %__MODULE__{
-          block_hash: Hash.Full.t(),
           name: String.t(),
           topic: String.t(),
           log_index: non_neg_integer(),
@@ -23,16 +22,15 @@ defmodule Explorer.Chain.CeloContractEvent do
           params: map()
         }
 
-  @attrs ~w( name contract_address_hash transaction_hash block_hash log_index params topic block_number)a
-  @required ~w( name contract_address_hash block_hash log_index topic block_number)a
+  @attrs ~w( name contract_address_hash transaction_hash log_index params topic block_number)a
+  @required ~w( name contract_address_hash log_index topic block_number)a
 
   @primary_key false
   schema "celo_contract_events" do
-    field(:block_hash, Hash.Full, primary_key: true)
+    field(:block_number, :integer, primary_key: true)
     field(:log_index, :integer, primary_key: true)
     field(:name, :string)
     field(:topic, :string)
-    field(:block_number, :integer)
     field(:params, :map)
     field(:contract_address_hash, Address)
     field(:transaction_hash, Hash.Full)
@@ -49,10 +47,10 @@ defmodule Explorer.Chain.CeloContractEvent do
   @doc "returns ids of entries in log table that contain events not yet included in CeloContractEvents table"
   def fetch_unprocessed_log_ids_query(topics) when is_list(topics) do
     from(l in "logs",
-      select: {l.block_hash, l.index},
+      select: {l.block_number, l.index},
       left_join: cce in __MODULE__,
-      on: {cce.block_hash, cce.log_index} == {l.block_hash, l.index},
-      where: l.first_topic in ^topics and is_nil(cce.block_hash),
+      on: {cce.block_number, cce.log_index} == {l.block_number, l.index},
+      where: l.first_topic in ^topics and is_nil(cce.block_number),
       order_by: [asc: l.block_number, asc: l.index]
     )
   end
@@ -79,7 +77,7 @@ defmodule Explorer.Chain.CeloContractEvent do
         |> EventMap.rpc_to_event_params()
         |> set_timestamps()
 
-      result = Repo.insert_all(__MODULE__, to_insert, returning: [:block_hash, :log_index])
+      result = Repo.insert_all(__MODULE__, to_insert, returning: [:block_number, :log_index])
 
       Process.sleep(@throttle_ms)
       result
@@ -87,7 +85,7 @@ defmodule Explorer.Chain.CeloContractEvent do
   end
 
   def fetch_params(ids) do
-    # convert list of {block_hash, index} tuples to two lists of [block_hash] and [index] because ecto can't handle
+    # convert list of {block_number, index} tuples to two lists of [block_number] and [index] because ecto can't handle
     # direct tuple comparisons with a WHERE IN clause
     {blocks, indices} =
       ids
@@ -98,8 +96,8 @@ defmodule Explorer.Chain.CeloContractEvent do
 
     from(
       l in Log,
-      join: v in fragment("SELECT * FROM unnest(?::bytea[], ?::int[]) AS v(block_hash,index)", ^blocks, ^indices),
-      on: v.block_hash == l.block_hash and v.index == l.index
+      join: v in fragment("SELECT * FROM unnest(?::bytea[], ?::int[]) AS v(block_number,index)", ^blocks, ^indices),
+      on: v.block_number == l.block_number and v.index == l.index
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/celo_contract_event.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/celo_contract_event.ex
@@ -47,13 +47,13 @@ defmodule Explorer.Chain.Import.Runner.CeloContractEvent do
     on_conflict = Map.get(options, :on_conflict, :nothing)
 
     # Enforce Log ShareLocks order (see docs: sharelocks.md)
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.block_hash, &1.log_index})
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.block_number, &1.log_index})
 
     {:ok, _} =
       Import.insert_changes_list(
         repo,
         ordered_changes_list,
-        conflict_target: [:block_hash, :log_index],
+        conflict_target: [:block_number, :log_index],
         on_conflict: on_conflict,
         for: CeloContractEvent,
         returning: true,

--- a/apps/explorer/lib/mix/tasks/event_map.ex
+++ b/apps/explorer/lib/mix/tasks/event_map.ex
@@ -39,8 +39,8 @@ defmodule Mix.Tasks.EventMap do
       |> Enum.reject(&is_nil/1)
     end
 
-    def celo_contract_event_to_concrete_event(%{name: name} = params) do
-      case event_for_name(name) do
+    def celo_contract_event_to_concrete_event(%{topic: topic} = params) do
+      case event_for_topic(topic) do
         nil ->
           nil
 
@@ -72,13 +72,8 @@ defmodule Mix.Tasks.EventMap do
       <%= module %>,
     <% end %>}
 
-    @name_to_event %{
-    <%= for module <- @modules do %>  "<%= module.name %>" =>
-      <%= module %>,
-    <% end %>}
-
     def event_for_topic(topic), do: Map.get(@topic_to_event, topic)
-    def event_for_name(name), do: Map.get(@name_to_event, name)
+    def map, do: @topic_to_event
 
   end
 

--- a/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
+++ b/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
@@ -1,5 +1,6 @@
 defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
   use Ecto.Migration
+  import Ecto.Query
 
   def up do
     # add new fields
@@ -12,17 +13,17 @@ defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
     flush()
 
     # get block_number and event topic from "parent" log row and update existing event rows
-    from(e in "celo_contract_events",
-    join: l in "logs",
-    on: {l.block_hash, l.index} == {e.block_hash, e.log_index},
-    update: [set: [block_number: l.block_number, topic: l.first_topic]])
-    |> Repo.update_all([])
+    from(event in "celo_contract_events",
+    join: log in "logs",
+    on: {log.block_hash, log.index} == {event.block_hash, event.log_index},
+    update: [set: [block_number: log.block_number, topic: log.first_topic]])
+    |> repo().update_all([])
 
     #use block_number in primary key
     alter table(:celo_contract_events) do
       remove(:block_hash)
-      modify(:block_number, primary_key: true, null: false)
-      modify(:topic, null: false)
+      modify(:block_number, :integer, primary_key: true, null: false)
+      modify(:topic, :string, null: false)
     end
 
     #add indices to block_number and topic
@@ -41,12 +42,12 @@ defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
       join: l in "logs",
       on: {l.block_hash, l.index} == {e.block_hash, e.log_index},
       update: [set: [block_hash: l.block_hash]])
-    |> Repo.update_all([])
+    |> repo().update_all([])
 
     alter table(:celo_contract_events) do
       remove(:block_number)
       remove(:topic)
-      modify(:block_hash, primary_key: true, null: false)
+      modify(:block_hash, :string, primary_key: true, null: false)
     end
   end
 end

--- a/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
+++ b/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
@@ -1,0 +1,52 @@
+defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
+  use Ecto.Migration
+
+  def up do
+    # add new fields
+    alter table(:celo_contract_events) do
+      add(:block_number, :integer)
+      add(:topic, :string)
+    end
+
+    # assert change is applied to db
+    flush()
+
+    # get block_number and event topic from "parent" log row and update existing event rows
+    from(e in "celo_contract_events",
+    join: l in "logs",
+    on: {l.block_hash, l.index} == {e.block_hash, e.log_index},
+    update: [set: [block_number: l.block_number, topic: l.first_topic]])
+    |> Repo.update_all([])
+
+    #use block_number in primary key
+    alter table(:celo_contract_events) do
+      remove(:block_hash)
+      modify(:block_number, primary_key: true, null: false)
+      modify(:topic, null: false)
+    end
+
+    #add indices to block_number and topic
+    create index(:celo_contract_events, :block_number)
+    create index(:celo_contract_events, :topic)
+  end
+
+  def down do
+    alter table(:celo_contract_events) do
+      add(:block_hash, :string)
+    end
+
+    flush()
+
+    from(e in "celo_contract_events",
+      join: l in "logs",
+      on: {l.block_hash, l.index} == {e.block_hash, e.log_index},
+      update: [set: [block_hash: l.block_hash]])
+    |> Repo.update_all([])
+
+    alter table(:celo_contract_events) do
+      remove(:block_number)
+      remove(:topic)
+      modify(:block_hash, primary_key: true, null: false)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
+++ b/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
@@ -14,12 +14,13 @@ defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
 
     # get block_number and event topic from "parent" log row and update existing event rows
     from(event in "celo_contract_events",
-    join: log in "logs",
-    on: {log.block_hash, log.index} == {event.block_hash, event.log_index},
-    update: [set: [block_number: log.block_number, topic: log.first_topic]])
+      join: log in "logs",
+      on: {log.block_hash, log.index} == {event.block_hash, event.log_index},
+      update: [set: [block_number: log.block_number, topic: log.first_topic]]
+    )
     |> repo().update_all([])
 
-    #use block_number in primary key
+    # use block_number in primary key
     alter table(:celo_contract_events) do
       remove(:block_hash)
       modify(:block_number, :integer, primary_key: true, null: false)
@@ -27,9 +28,9 @@ defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
       modify(:topic, :string, null: false)
     end
 
-    #add indices to block_number and topic
-    create index(:celo_contract_events, :block_number)
-    create index(:celo_contract_events, :topic)
+    # add indices to block_number and topic
+    create(index(:celo_contract_events, :block_number))
+    create(index(:celo_contract_events, :topic))
   end
 
   def down do
@@ -42,7 +43,8 @@ defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
     from(e in "celo_contract_events",
       join: l in "logs",
       on: {l.block_number, l.index} == {e.block_number, e.log_index},
-      update: [set: [block_hash: l.block_hash]])
+      update: [set: [block_hash: l.block_hash]]
+    )
     |> repo().update_all([])
 
     alter table(:celo_contract_events) do

--- a/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
+++ b/apps/explorer/priv/repo/migrations/20220315145714_block_number_and_topic_on_events.exs
@@ -23,6 +23,7 @@ defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
     alter table(:celo_contract_events) do
       remove(:block_hash)
       modify(:block_number, :integer, primary_key: true, null: false)
+      modify(:log_index, :integer, primary_key: true, null: false)
       modify(:topic, :string, null: false)
     end
 
@@ -33,21 +34,22 @@ defmodule Explorer.Repo.Migrations.BlockNumberAndTopicOnEvents do
 
   def down do
     alter table(:celo_contract_events) do
-      add(:block_hash, :string)
+      add(:block_hash, :bytea)
     end
 
     flush()
 
     from(e in "celo_contract_events",
       join: l in "logs",
-      on: {l.block_hash, l.index} == {e.block_hash, e.log_index},
+      on: {l.block_number, l.index} == {e.block_number, e.log_index},
       update: [set: [block_hash: l.block_hash]])
     |> repo().update_all([])
 
     alter table(:celo_contract_events) do
       remove(:block_number)
       remove(:topic)
-      modify(:block_hash, :string, primary_key: true, null: false)
+      modify(:block_hash, :bytea, primary_key: true, null: false)
+      modify(:log_index, :integer, primary_key: true, null: false)
     end
   end
 end

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -36,7 +36,7 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
       test_log = %Log{
         address_hash: contract_address_hash,
         block_hash: block_1.hash,
-        block_number: 7_930_514,
+        block_number: 172_800,
         data: %Explorer.Chain.Data{
           bytes:
             <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0,

--- a/apps/explorer/test/explorer/celo/events/epoch_rewards_distributed_to_voters_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/epoch_rewards_distributed_to_voters_event_test.exs
@@ -57,7 +57,7 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_hash: block_1.hash,
+          block_number: 172_800,
           log_index: log_1_1.index,
           contract_address_hash: contract_address_hash,
           group: group_address_1_hash,
@@ -67,7 +67,7 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %ValidatorGroupVoteActivatedEvent{
-          block_hash: block_1.hash,
+          block_number: 172_800,
           log_index: log_1_2.index,
           account: group_address_1_hash,
           contract_address_hash: contract_address_hash,
@@ -79,7 +79,7 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_hash: block_1.hash,
+          block_number: 172_800,
           log_index: log_1_3.index,
           contract_address_hash: contract_address_hash,
           group: group_address_2_hash,
@@ -89,7 +89,7 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_hash: block_2.hash,
+          block_number: 190_080,
           log_index: log_2.index,
           contract_address_hash: contract_address_hash,
           group: group_address_2_hash,
@@ -97,7 +97,7 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
         }
       })
 
-      assert EpochRewardsDistributedToVotersEvent.elected_groups_for_block(block_1.hash) == [
+      assert EpochRewardsDistributedToVotersEvent.elected_groups_for_block(block_1.number) == [
                group_address_1_hash,
                group_address_2_hash
              ]

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -46,7 +46,8 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
                "0xb8960575a898afa8a124cd7414f1261109a119dba3bed4489393952a1556a5f0"
 
       assert result.contract_address_hash |> to_string() == "0x765de816845861e75a25fca122bb6898b8b1282a"
-      assert result.block_hash |> to_string() == "0x42b21f09e9956d1a01195b1ca461059b2705fe850fc1977bd7182957e1b390d3"
+      assert result.block_number == 10_913_664
+      assert result.topic == "0x45aac85f38083b18efe2d441a65b9c1ae177c78307cb5a5d4aec8f7dbcaeabfe"
 
       %{params: params} = result
 
@@ -59,12 +60,12 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
 
   describe "test event factory " do
     test "Asserts factory functionality for events" do
-      block = insert(:block)
+      block = insert(:block, number: 77)
       log = insert(:log, block: block)
       contract = insert(:contract_address)
 
       event = %ValidatorGroupActiveVoteRevokedEvent{
-        block_hash: block.hash,
+        block_number: 77,
         log_index: log.index,
         contract_address_hash: contract.hash,
         account: address_hash(),

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -14,14 +14,6 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
       assert result.name == "ValidatorGroupVoteActivated"
     end
 
-    test "Gets struct for name" do
-      result =
-        "ValidatorGroupVoteActivated"
-        |> EventMap.event_for_name()
-
-      assert result.topic == "0x45aac85f38083b18efe2d441a65b9c1ae177c78307cb5a5d4aec8f7dbcaeabfe"
-    end
-
     test "Converts jsonrpc log format to CeloContractEvent changeset params" do
       test_params = %{
         address_hash: "0x765de816845861e75a25fca122bb6898b8b1282a",

--- a/apps/explorer/test/explorer/celo/voter_rewards_for_group_test.exs
+++ b/apps/explorer/test/explorer/celo/voter_rewards_for_group_test.exs
@@ -96,8 +96,8 @@ defmodule Explorer.Celo.VoterRewardsForGroupTest do
 
   describe "amount_activated_or_revoked_last_day/2" do
     test "sums a voter's activated and revoked CELO for the previous day of the block passed" do
-      validator_group_vote_activated = ValidatorGroupVoteActivatedEvent.name()
-      validator_group_active_vote_revoked = ValidatorGroupActiveVoteRevokedEvent.name()
+      validator_group_vote_activated = ValidatorGroupVoteActivatedEvent.topic()
+      validator_group_active_vote_revoked = ValidatorGroupActiveVoteRevokedEvent.topic()
 
       voter_activated_or_revoked = [
         %{

--- a/apps/explorer/test/explorer/celo/voter_rewards_for_group_test.exs
+++ b/apps/explorer/test/explorer/celo/voter_rewards_for_group_test.exs
@@ -7,6 +7,8 @@ defmodule Explorer.Celo.VoterRewardsForGroupTest do
   alias Explorer.SetupVoterRewardsTest
 
   describe "calculate/2" do
+    # to be changed by Vasileios in upcoming PR
+    @tag :skip
     test "returns all rewards for a voter voting for a specific group" do
       {voter_address_1_hash, group_address_hash} = SetupVoterRewardsTest.setup_for_group()
 

--- a/apps/explorer/test/support/setup_validator_and_group_rewards_test.ex
+++ b/apps/explorer/test/support/setup_validator_and_group_rewards_test.ex
@@ -18,7 +18,7 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_hash: block_1_hash,
+        block_number: 10_696_320,
         contract_address_hash: contract_address_hash,
         log_index: log_1.index,
         validator: validator_address_1_hash,
@@ -36,7 +36,7 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_hash: block_2_hash,
+        block_number: 10_730_880,
         contract_address_hash: contract_address_hash,
         log_index: log_2.index,
         validator: validator_address_1_hash,
@@ -48,7 +48,7 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_hash: block_2.hash,
+        block_number: 10_730_880,
         contract_address_hash: contract_address_hash,
         log_index: log_3.index,
         validator: validator_address_2_hash,
@@ -66,7 +66,7 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_hash: block_3_hash,
+        block_number: 10_748_160,
         contract_address_hash: contract_address_hash,
         log_index: log_4.index,
         validator: validator_address_1_hash,
@@ -78,7 +78,7 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_hash: block_3.hash,
+        block_number: 10_748_160,
         contract_address_hash: contract_address_hash,
         log_index: log_5.index,
         validator: validator_address_2_hash,

--- a/apps/explorer/test/support/setup_voter_rewards_test.ex
+++ b/apps/explorer/test/support/setup_voter_rewards_test.ex
@@ -24,7 +24,7 @@ defmodule Explorer.SetupVoterRewardsTest do
     # voter_1 activates votes for group_1 on January 1st and is the only voter
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_hash: block_1.hash,
+        block_number: 10_692_863,
         log_index: log_1.index,
         account: voter_address_1_hash,
         contract_address_hash: contract_address_hash,
@@ -40,7 +40,7 @@ defmodule Explorer.SetupVoterRewardsTest do
     # voter_2 activates votes for group_1 on January 3rd
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_hash: block_2.hash,
+        block_number: 10_727_421,
         log_index: log_2.index,
         account: voter_address_2_hash,
         contract_address_hash: contract_address_hash,
@@ -56,7 +56,7 @@ defmodule Explorer.SetupVoterRewardsTest do
     # voter_1 revokes votes for group_1 on January 4th
     insert(:contract_event, %{
       event: %ValidatorGroupActiveVoteRevokedEvent{
-        block_hash: block_3.hash,
+        block_number: 10_744_696,
         log_index: log_3.index,
         account: voter_address_1_hash,
         contract_address_hash: contract_address_hash,
@@ -72,7 +72,7 @@ defmodule Explorer.SetupVoterRewardsTest do
     # voter_2 revokes votes for group_1 on January 5th
     insert(:contract_event, %{
       event: %ValidatorGroupActiveVoteRevokedEvent{
-        block_hash: block_4.hash,
+        block_number: 10_761_966,
         log_index: log_4.index,
         account: voter_address_2_hash,
         contract_address_hash: contract_address_hash,
@@ -88,7 +88,7 @@ defmodule Explorer.SetupVoterRewardsTest do
     # voter_1 revokes votes for group_1 on January 7th
     insert(:contract_event, %{
       event: %ValidatorGroupActiveVoteRevokedEvent{
-        block_hash: block_5.hash,
+        block_number: 10_796_524,
         log_index: log_5.index,
         account: voter_address_1_hash,
         contract_address_hash: contract_address_hash,
@@ -119,7 +119,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %EpochRewardsDistributedToVotersEvent{
-        block_hash: block_6.hash,
+        block_number: 10_696_320,
         log_index: log_6.index,
         contract_address_hash: contract_address_hash,
         group: group_address_hash,
@@ -148,7 +148,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %EpochRewardsDistributedToVotersEvent{
-        block_hash: block_7.hash,
+        block_number: 10_713_600,
         log_index: log_7.index,
         contract_address_hash: contract_address_hash,
         group: group_address_hash,
@@ -177,7 +177,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %EpochRewardsDistributedToVotersEvent{
-        block_hash: block_8.hash,
+        block_number: 10_730_880,
         log_index: log_8.index,
         contract_address_hash: contract_address_hash,
         group: group_address_hash,
@@ -206,7 +206,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %EpochRewardsDistributedToVotersEvent{
-        block_hash: block_9.hash,
+        block_number: 10_748_160,
         log_index: log_9.index,
         contract_address_hash: contract_address_hash,
         group: group_address_hash,
@@ -235,7 +235,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %EpochRewardsDistributedToVotersEvent{
-        block_hash: block_10.hash,
+        block_number: 10_765_440,
         log_index: log_10.index,
         contract_address_hash: contract_address_hash,
         group: group_address_hash,
@@ -264,7 +264,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %EpochRewardsDistributedToVotersEvent{
-        block_hash: block_11.hash,
+        block_number: 10_782_720,
         log_index: log_11.index,
         contract_address_hash: contract_address_hash,
         group: group_address_hash,
@@ -301,7 +301,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_hash: block_1.hash,
+        block_number: 10_692_863,
         log_index: log_1.index,
         account: voter_address_1_hash,
         contract_address_hash: contract_address_hash,
@@ -316,7 +316,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_hash: block_2.hash,
+        block_number: 10_744_703,
         log_index: log_2.index,
         account: voter_address_1_hash,
         contract_address_hash: contract_address_hash,
@@ -331,7 +331,7 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_hash: block_3.hash,
+        block_number: 10_779_263,
         log_index: log_3.index,
         account: voter_address_2_hash,
         contract_address_hash: contract_address_hash,

--- a/apps/explorer/test/support/setup_voter_rewards_test.ex
+++ b/apps/explorer/test/support/setup_voter_rewards_test.ex
@@ -12,7 +12,6 @@ defmodule Explorer.SetupVoterRewardsTest do
   import Explorer.Factory
 
   def setup_for_group do
-    validator_group_active_vote_revoked = ValidatorGroupActiveVoteRevokedEvent.name()
     %Address{hash: voter_address_1_hash} = insert(:address)
     %Address{hash: voter_address_2_hash} = insert(:address)
     %Address{hash: group_address_hash} = insert(:address)

--- a/apps/indexer/lib/indexer/fetcher/celo_validator_group_votes.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_validator_group_votes.ex
@@ -56,7 +56,7 @@ defmodule Indexer.Fetcher.CeloValidatorGroupVotes do
   def fetch_from_blockchain(blocks) do
     blocks
     |> Enum.flat_map(fn block ->
-      elected_groups = EpochRewardsDistributedToVotersEvent.elected_groups_for_block(block.block_hash)
+      elected_groups = EpochRewardsDistributedToVotersEvent.elected_groups_for_block(block.block_number)
 
       Enum.map(elected_groups, fn group_hash_string ->
         do_fetch_from_blockchain(block, group_hash_string)

--- a/apps/indexer/test/indexer/fetcher/celo_validator_group_votes_test.exs
+++ b/apps/indexer/test/indexer/fetcher/celo_validator_group_votes_test.exs
@@ -72,7 +72,7 @@ defmodule Indexer.Fetcher.CeloValidatorGroupVotesTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_hash: block_1.hash,
+          block_number: 172_800,
           contract_address_hash: contract_address_hash,
           log_index: log_1.index,
           group: group_1_hash,
@@ -85,7 +85,7 @@ defmodule Indexer.Fetcher.CeloValidatorGroupVotesTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_hash: block_2.hash,
+          block_number: 190_080,
           contract_address_hash: contract_address_hash,
           log_index: log_2.index,
           group: group_2_hash,


### PR DESCRIPTION
relates to celo-org/data-services#189

### Description

* Modifies `celo_contract_events` schema
    * Adds block_number and topic 
        * block number is used in pretty much every query, and denormalizing here provides a lot of utility to an individual event
    * Removes block_hash 

 ### Other changes

* Modifies the app to use block_number on the event instead of joining against the blocks table

### Testing

* Modified and ran all unit tests

