### PR TITLE
204: Internal server error on a token with no symbol

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/overview/_details.html.eex
@@ -101,7 +101,10 @@
                   <%= format_according_to_decimals(@token.total_supply, @token.decimals) %>
                 <% else %>
                   <%= format_integer_to_currency(@token.total_supply) %>
-                <% end %> <%= Gettext.gettext(BlockScoutWeb.Gettext, @token.symbol) %>
+                <% end %>
+                <%= unless is_nil(@token.symbol) do %>
+                <%= Gettext.gettext(BlockScoutWeb.Gettext, @token.symbol) %>
+                <% end %>
               </h3>
               <%= if @token.usd_value do %>
                 <div class="text-uppercase">

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
@@ -69,6 +69,10 @@ defmodule BlockScoutWeb.Tokens.Helpers do
     AddressView.short_hash_left_right(address_hash)
   end
 
+  defp build_token_name(%{name: "", contract_address_hash: address_hash}) do
+    AddressView.short_hash_left_right(address_hash)
+  end
+
   defp build_token_name(%{name: name}) do
     name
   end

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/helpers_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/helpers_test.exs
@@ -68,5 +68,12 @@ defmodule BlockScoutWeb.Tokens.HelpersTest do
 
       assert Helpers.token_name(token) == "0xde3fa0-f2e65f"
     end
+
+    test "returns the token contract address hash when the name is empty" do
+      address = build(:address, hash: "de3fa0f9f8d47790ce88c2b2b82ab81f79f2e65f")
+      token = build(:token, name: "", contract_address_hash: address.hash)
+
+      assert Helpers.token_name(token) == "0xde3fa0-f2e65f"
+    end
   end
 end


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description

Currently, when accessing token page that has empty (`nil`) symbol it fails to load. 
 
 ### Other changes

Apart from fixing bug itself, added a case of empty (`""`) token name while building token name (for displaying in meta tags). Without it, it would be displayed as ` - <network> - BlockScout`.

### Issues

https://app.zenhub.com/workspaces/data-services-sprint-60103a7bf450290020c3800c/issues/celo-org/data-services/204

 ### Backwards compatibility

 _Brief explanation of why these changes are/are not backwards compatible._

### Checklist

  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I added code comments for anything non trivial.
  - [ ] I added documentation for my changes.
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
