### PR TITLE
Changed the indexer parameters

### DIFF
--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -34,7 +34,7 @@ config :logger_json, :ethereum_jsonrpc,
 
 config :logger, :ethereum_jsonrpc, backends: [LoggerJSON]
 
-config :ethereum_jsonrpc, :internal_transaction_timeout, "360s"
+config :ethereum_jsonrpc, :internal_transaction_timeout, "900s"
 
 # config :logger, :ethereum_jsonrpc,
 #  # keep synced with `config/config.exs`

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -23,7 +23,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
   @behaviour BufferedTask
 
   @max_batch_size 1
-  @max_concurrency 45
+  @max_concurrency 20
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),


### PR DESCRIPTION
### Description

Changes parameters of the internal TX fetcher to reduce load on the pool of archive nodes.
 
 ### Other changes

No.

### Tested

Tested on all envs.

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
