### PR TITLE
Use gas used from TX receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#581](https://github.com/celo-org/blockscout/pull/581) - Save voter active votes to db
 
 ### Fixes
+- [#5212](https://github.com/blockscout/blockscout/pull/5212) - Fix `gas_used` value bug
 - [#5066](https://github.com/blockscout/blockscout/pull/5066) - Fix read contract page bug
 - [#5071](https://github.com/blockscout/blockscout/pull/5071) - Fix write page contract tuple input
 - [#5034](https://github.com/blockscout/blockscout/pull/5034) - Fix broken functions input at transation page

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -584,14 +584,10 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
       )
 
     set_with_gas_used =
-      if first_trace.gas_used do
-        Keyword.put_new(set, :gas_used, first_trace.gas_used)
+      if transaction_receipt_from_node && transaction_receipt_from_node.gas_used do
+        Keyword.put_new(set, :gas_used, transaction_receipt_from_node.gas_used)
       else
-        if transaction_receipt_from_node && transaction_receipt_from_node.gas_used do
-          Keyword.put_new(set, :gas_used, transaction_receipt_from_node.gas_used)
-        else
-          set
-        end
+        set
       end
 
     filtered_set = Enum.reject(set_with_gas_used, fn {_key, value} -> is_nil(value) end)

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -291,7 +291,15 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "does not overwrite gas_used from transaction" do
       block = insert(:block)
-      transaction = insert(:transaction, gas_used: 30_000, cumulative_gas_used: 30_000, index: 0, block_hash: block.hash, block_number: block.number)
+
+      transaction =
+        insert(:transaction,
+          gas_used: 30_000,
+          cumulative_gas_used: 30_000,
+          index: 0,
+          block_hash: block.hash,
+          block_number: block.number
+        )
 
       insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
 

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -288,6 +288,21 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       assert %{consensus: true} = Repo.get(Block, full_block.hash)
       assert PendingBlockOperation |> Repo.get(full_block.hash) |> is_nil()
     end
+
+    test "does not overwrite gas_used from transaction" do
+      block = insert(:block)
+      transaction = insert(:transaction, gas_used: 30_000, cumulative_gas_used: 30_000, index: 0, block_hash: block.hash, block_number: block.number)
+
+      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+
+      transaction_changes = make_internal_transaction_changes(transaction, 0, nil)
+
+      assert {:ok, _} = run_internal_transactions([transaction_changes])
+
+      assert Repo.get(Transaction, transaction.hash).gas_used == Decimal.new(30_000)
+      assert %{consensus: true} = Repo.get(Block, block.hash)
+      assert is_nil(Repo.get(PendingBlockOperation, block.hash))
+    end
   end
 
   defp run_internal_transactions(changes_list, multi \\ Multi.new()) when is_list(changes_list) do


### PR DESCRIPTION
### Description

For [some transactions](https://explorer.celo.org/tx/0x27e51374271f99dc6a871e6b38f97f584aa04b598a5ad246cb24c12867eba4d0/token-transfers) the `gasUsed` value is `0`, although if you fetch the transaction receipt, it's obviously non-zero:

```
curl -s -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x27e51374271f99dc6a871e6b38f97f584aa04b598a5ad246cb24c12867eba4d0"],"id":1}' https://forno.celo.org  -H 'Content-type: application/json' | jq '.'
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0x49ee01a5c86a21af2d6f9b73b9905e31c0f61663077a3450269e7c0cd1a96902",
    "blockNumber": "0x95b708",
    "contractAddress": null,
    "cumulativeGasUsed": "0x230d2b",
    "from": "0x6ec033738b388d0605b287bc3e375063a4039942",
    "gasUsed": "0x520c",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "status": "0x1",
    "to": "0xf6436829cf96ea0f8bc49d300c536fcc4f84c4ed",
    "transactionHash": "0x27e51374271f99dc6a871e6b38f97f584aa04b598a5ad246cb24c12867eba4d0",
    "transactionIndex": "0x7"
  }
} 
```

As was discovered upstream [here](https://github.com/blockscout/blockscout/issues/5210), see details [here](https://github.com/NethermindEth/nethermind/issues/3831),`gasUsed` value returned by the tracer sometimes can be different from real gas used by the transaction (returned by eth_getTransactionReceipt), so the value from the receipt should be used.

The fix prevents blockscout from overwriting `gas_used` field in the `transactions` table from internal transactions.

 ### Other changes

No.

### Tested
Added a test that makes sure that the value stored in the `transactions` table doesn't get overwritten.

Tested locally for the example TX above:
Before:
![image](https://user-images.githubusercontent.com/20768968/164236573-9d4c68c6-c88c-4615-a5e5-f9ed85353563.png)

After:
![image](https://user-images.githubusercontent.com/20768968/164236657-bafd68eb-f904-4f61-b8c1-af2e7a877db2.png)
that matches the value from the receipt `0x520c`.

### Issues

 - Fixes https://github.com/celo-org/blockscout/issues/485

 ### Backwards compatibility

Yes, but most likely re-indexing will be needed.

### Checklist

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
