### PR TITLE
Handle event properties of type `bytes` with unspecified size the same as with specified size

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For details on acceptable file patterns, please refer to the [Github Documentation](https://help.github.com/articles/about-codeowners/)
 
 # default owners
-* @celo-org/data-services @obasilakis @eruizgar91
+* @celo-org/data-services

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # For details on acceptable file patterns, please refer to the [Github Documentation](https://help.github.com/articles/about-codeowners/)
 
 # default owners
-* @celo-org/core-services @obasilakis @eruizgar91
+* @celo-org/data-services @obasilakis @eruizgar91

--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -30,8 +30,10 @@ defmodule Explorer.Celo.ContractEvents.Common do
     |> Enum.map(fn
       # list of bytes to 2d list of ints
       {d, {:array, {:bytes, _}}} -> d |> Enum.map(&:binary.bin_to_list(&1))
+      {d, {:array, :bytes}} -> d |> Enum.map(&:binary.bin_to_list(&1))
       # bytes to list of ints
       {d, {:bytes, _}} -> :binary.bin_to_list(d)
+      {d, :bytes} -> :binary.bin_to_list(d)
       {d, _} -> d
     end)
   end
@@ -43,9 +45,8 @@ defmodule Explorer.Celo.ContractEvents.Common do
     address
   end
 
-  defp convert_result(result, {:bytes, _size}) do
-    :binary.bin_to_list(result)
-  end
+  defp convert_result(result, {:bytes, _size}), do: :binary.bin_to_list(result)
+  defp convert_result(result, :bytes), do: :binary.bin_to_list(result)
 
   def extract_common_event_params(event) do
     # set full hashes

--- a/apps/explorer/lib/mix/tasks/event_map_template.eex
+++ b/apps/explorer/lib/mix/tasks/event_map_template.eex
@@ -63,7 +63,7 @@ defmodule Explorer.Celo.ContractEvents.EventMap do
     |> celo_contract_event_to_concrete_event()
   end
 
-  @doc "Convert concrete event to CeloContractEvent insertion parameters"
+  @doc "Convert concrete event to CeloContractEvent changeset parameters"
   def event_to_contract_event_params(events) when is_list(events) do
     events |> Enum.map(&event_to_contract_event_params/1)
   end

--- a/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
@@ -9,33 +9,45 @@ defmodule Explorer.Celo.Events.ValidatorEcdsaPublicKeyUpdatedEvent do
 
   describe "encoding / decoding" do
     test "should handle encoding of bytes data that includes invalid utf8 codepoints" do
-
-      %Explorer.Chain.Block{number: block_number} = insert(:block)
+      %Explorer.Chain.Block{number: block_number, hash: hash} = insert(:block)
       %Explorer.Chain.CeloCoreContract{address_hash: address_hash} = insert(:core_contract)
 
       # values taken from production environment and causing an error due to "invalid byte 0x95" in ecdsa_public_key
-      contract_event = %CeloContractEvent{
-        block_number: block_number,
-        contract_address_hash:  address_hash,
-        inserted_at: ~U[2022-05-16 13:11:06.729479Z],
-        log_index: 12,
-        name: "ValidatorEcdsaPublicKeyUpdated",
-        params: %{
-          ecdsa_public_key:
-            <<27, 149, 173, 3, 199, 243, 248, 121, 204, 177, 130, 75, 29, 132, 235, 113, 78, 246, 213, 171, 152, 216,
-            246, 254, 154, 199, 124, 145, 7, 153, 92, 105, 76, 239, 244, 76, 75, 6, 166, 156, 19, 179, 255, 236, 186,
-            85, 16, 198, 10, 147, 57, 94, 183, 88, 171, 28, 12, 210, 179, 85, 248, 221, 82, 36>>,
-          validator: "\\x2bdc5ccda08a7f821ae0df72b5fda60cd58d6353"
-        },
-        topic: "0x213377eec2c15b21fa7abcbb0cb87a67e893cdb94a2564aa4bb4d380869473c8",
-        transaction_hash: nil,
-        updated_at: ~U[2022-05-16 13:11:06.729479Z]
+      # https://github.com/celo-org/data-services/issues/231
+
+      #below log_data includes an event parameter that should decode to the following binary term
+      expected_public_key = <<27, 149, 173, 3, 199, 243, 248, 121, 204, 177, 130, 75, 29, 132, 235, 113, 78, 246, 213, 171, 152, 216, 246, 254, 154, 199, 124, 145, 7, 153, 92, 105, 76, 239, 244, 76, 75, 6, 166, 156, 19, 179, 255, 236, 186, 85, 16, 198, 10, 147, 57, 94, 183, 88, 171, 28, 12, 210, 179, 85, 248, 221, 82, 36>>
+
+      log_data = %{
+        "address" => address_hash |> to_string(),
+        "topics" => [
+          "0x213377eec2c15b21fa7abcbb0cb87a67e893cdb94a2564aa4bb4d380869473c8",
+          "0x0000000000000000000000002bdc5ccda08a7f821ae0df72b5fda60cd58d6353"
+        ],
+        "data" =>
+          "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000401b95ad03c7f3f879ccb1824b1d84eb714ef6d5ab98d8f6fe9ac77c9107995c694ceff44c4b06a69c13b3ffecba5510c60a93395eb758ab1c0cd2b355f8dd5224",
+        "blockNumber" => block_number,
+        "transactionHash" => nil,
+        "transactionIndex" => nil,
+        "blockHash" => hash |> to_string(),
+        "logIndex" => "0xc",
+        "removed" => false
       }
+      |> EthereumJSONRPC.Log.to_elixir()
+      |> EthereumJSONRPC.Log.elixir_to_params()
 
-      changeset_params = EventMap.celo_contract_event_to_concrete_event(contract_event)
-      |> EventMap.event_to_contract_event_params()
+      changeset_params = EventMap.rpc_to_event_params([log_data])
+      |> List.first()
+      |> Map.put(:updated_at, Timex.now())
+      |> Map.put(:inserted_at, Timex.now())
 
+      #insert into db and assert that public key is inserted as valid json
       {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [changeset_params])
+
+      #retrieve from db
+      [event] = ValidatorEcdsaPublicKeyUpdatedEvent.query |> EventMap.query_all()
+
+      assert(event.ecdsa_public_key |> :erlang.list_to_binary() == expected_public_key)
     end
   end
 end

--- a/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
@@ -13,7 +13,8 @@ defmodule Explorer.Celo.Events.ValidatorEcdsaPublicKeyUpdatedEvent do
       %Explorer.Chain.Block{number: block_number} = insert(:block)
       %Explorer.Chain.CeloCoreContract{address_hash: address_hash} = insert(:core_contract)
 
-      contract_event = %{
+      # values taken from production environment and causing an error due to "invalid byte 0x95" in ecdsa_public_key
+      contract_event = %CeloContractEvent{
         block_number: block_number,
         contract_address_hash:  address_hash,
         inserted_at: ~U[2022-05-16 13:11:06.729479Z],
@@ -31,7 +32,10 @@ defmodule Explorer.Celo.Events.ValidatorEcdsaPublicKeyUpdatedEvent do
         updated_at: ~U[2022-05-16 13:11:06.729479Z]
       }
 
-      {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [contract_event])
+      changeset_params = EventMap.celo_contract_event_to_concrete_event(contract_event)
+      |> EventMap.event_to_contract_event_params()
+
+      {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [changeset_params])
     end
   end
 end

--- a/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
@@ -15,37 +15,42 @@ defmodule Explorer.Celo.Events.ValidatorEcdsaPublicKeyUpdatedEvent do
       # values taken from production environment and causing an error due to "invalid byte 0x95" in ecdsa_public_key
       # https://github.com/celo-org/data-services/issues/231
 
-      #below log_data includes an event parameter that should decode to the following binary term
-      expected_public_key = <<27, 149, 173, 3, 199, 243, 248, 121, 204, 177, 130, 75, 29, 132, 235, 113, 78, 246, 213, 171, 152, 216, 246, 254, 154, 199, 124, 145, 7, 153, 92, 105, 76, 239, 244, 76, 75, 6, 166, 156, 19, 179, 255, 236, 186, 85, 16, 198, 10, 147, 57, 94, 183, 88, 171, 28, 12, 210, 179, 85, 248, 221, 82, 36>>
+      # below log_data includes an event parameter that should decode to the following binary term
+      expected_public_key =
+        <<27, 149, 173, 3, 199, 243, 248, 121, 204, 177, 130, 75, 29, 132, 235, 113, 78, 246, 213, 171, 152, 216, 246,
+          254, 154, 199, 124, 145, 7, 153, 92, 105, 76, 239, 244, 76, 75, 6, 166, 156, 19, 179, 255, 236, 186, 85, 16,
+          198, 10, 147, 57, 94, 183, 88, 171, 28, 12, 210, 179, 85, 248, 221, 82, 36>>
 
-      log_data = %{
-        "address" => address_hash |> to_string(),
-        "topics" => [
-          "0x213377eec2c15b21fa7abcbb0cb87a67e893cdb94a2564aa4bb4d380869473c8",
-          "0x0000000000000000000000002bdc5ccda08a7f821ae0df72b5fda60cd58d6353"
-        ],
-        "data" =>
-          "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000401b95ad03c7f3f879ccb1824b1d84eb714ef6d5ab98d8f6fe9ac77c9107995c694ceff44c4b06a69c13b3ffecba5510c60a93395eb758ab1c0cd2b355f8dd5224",
-        "blockNumber" => block_number,
-        "transactionHash" => nil,
-        "transactionIndex" => nil,
-        "blockHash" => hash |> to_string(),
-        "logIndex" => "0xc",
-        "removed" => false
-      }
-      |> EthereumJSONRPC.Log.to_elixir()
-      |> EthereumJSONRPC.Log.elixir_to_params()
+      log_data =
+        %{
+          "address" => address_hash |> to_string(),
+          "topics" => [
+            "0x213377eec2c15b21fa7abcbb0cb87a67e893cdb94a2564aa4bb4d380869473c8",
+            "0x0000000000000000000000002bdc5ccda08a7f821ae0df72b5fda60cd58d6353"
+          ],
+          "data" =>
+            "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000401b95ad03c7f3f879ccb1824b1d84eb714ef6d5ab98d8f6fe9ac77c9107995c694ceff44c4b06a69c13b3ffecba5510c60a93395eb758ab1c0cd2b355f8dd5224",
+          "blockNumber" => block_number,
+          "transactionHash" => nil,
+          "transactionIndex" => nil,
+          "blockHash" => hash |> to_string(),
+          "logIndex" => "0xc",
+          "removed" => false
+        }
+        |> EthereumJSONRPC.Log.to_elixir()
+        |> EthereumJSONRPC.Log.elixir_to_params()
 
-      changeset_params = EventMap.rpc_to_event_params([log_data])
-      |> List.first()
-      |> Map.put(:updated_at, Timex.now())
-      |> Map.put(:inserted_at, Timex.now())
+      changeset_params =
+        EventMap.rpc_to_event_params([log_data])
+        |> List.first()
+        |> Map.put(:updated_at, Timex.now())
+        |> Map.put(:inserted_at, Timex.now())
 
-      #insert into db and assert that public key is inserted as valid json
+      # insert into db and assert that public key is inserted as valid json
       {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [changeset_params])
 
-      #retrieve from db
-      [event] = ValidatorEcdsaPublicKeyUpdatedEvent.query |> EventMap.query_all()
+      # retrieve from db
+      [event] = ValidatorEcdsaPublicKeyUpdatedEvent.query() |> EventMap.query_all()
 
       assert(event.ecdsa_public_key |> :erlang.list_to_binary() == expected_public_key)
     end

--- a/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_ecdsa_public_key_updated_event_test.exs
@@ -1,0 +1,37 @@
+defmodule Explorer.Celo.Events.ValidatorEcdsaPublicKeyUpdatedEvent do
+  use Explorer.DataCase, async: true
+
+  alias Explorer.Chain.CeloContractEvent
+  alias Explorer.Chain.{Address, Block, Log}
+  alias Explorer.Celo.ContractEvents.EventTransformer
+  alias Explorer.Celo.ContractEvents.EventMap
+  alias Explorer.Celo.ContractEvents.Validators.ValidatorEcdsaPublicKeyUpdatedEvent
+
+  describe "encoding / decoding" do
+    test "should handle encoding of bytes data that includes invalid utf8 codepoints" do
+
+      %Explorer.Chain.Block{number: block_number} = insert(:block)
+      %Explorer.Chain.CeloCoreContract{address_hash: address_hash} = insert(:core_contract)
+
+      contract_event = %{
+        block_number: block_number,
+        contract_address_hash:  address_hash,
+        inserted_at: ~U[2022-05-16 13:11:06.729479Z],
+        log_index: 12,
+        name: "ValidatorEcdsaPublicKeyUpdated",
+        params: %{
+          ecdsa_public_key:
+            <<27, 149, 173, 3, 199, 243, 248, 121, 204, 177, 130, 75, 29, 132, 235, 113, 78, 246, 213, 171, 152, 216,
+            246, 254, 154, 199, 124, 145, 7, 153, 92, 105, 76, 239, 244, 76, 75, 6, 166, 156, 19, 179, 255, 236, 186,
+            85, 16, 198, 10, 147, 57, 94, 183, 88, 171, 28, 12, 210, 179, 85, 248, 221, 82, 36>>,
+          validator: "\\x2bdc5ccda08a7f821ae0df72b5fda60cd58d6353"
+        },
+        topic: "0x213377eec2c15b21fa7abcbb0cb87a67e893cdb94a2564aa4bb4d380869473c8",
+        transaction_hash: nil,
+        updated_at: ~U[2022-05-16 13:11:06.729479Z]
+      }
+
+      {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [contract_event])
+    end
+  end
+end


### PR DESCRIPTION
closes celo-org/data-services#231

## Explanation

Changesets with an event containing a parameter of type `bytes` were being cast to utf8 strings, this doesn't work in the general case as a binary object can contain byte sequences that represent invalid utf8 codepoints. 

Instead this PR changes the behavior to treat these parameters the same as sized binary parameters (e.g. `{:bytes, 32}` as opposed to just `:bytes`). This stores them in the db as arrays of int values.

## Additional changes

* modifies the CODEOWNERS file so that the repo is now owned by data-services instead of `core-services`


