### PR TITLE
Prevent name collisions of generated event properties against event "meta" properties

### DIFF
--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -48,18 +48,21 @@ defmodule Explorer.Celo.ContractEvents.Common do
   end
 
   def extract_common_event_params(event) do
-    case Map.get(event, :__transaction_hash) do
-      nil ->
-        %{transaction_hash: nil}
+    # handle optional transaction hash
+    common_properties =
+      case Map.get(event, :__transaction_hash) do
+        nil ->
+          %{transaction_hash: nil}
 
-      v ->
-        {:ok, hsh} = Full.cast(v)
-        %{transaction_hash: hsh}
-    end
-    |> then(fn map ->
-      {:ok, hsh} = Address.cast(event.__contract_address_hash)
-      Map.put(map, :contract_address_hash, hsh)
-    end)
+        v ->
+          {:ok, hsh} = Full.cast(v)
+          %{transaction_hash: hsh}
+      end
+
+    {:ok, hsh} = Address.cast(event.__contract_address_hash)
+
+    common_properties
+    |> Map.put(:contract_address_hash, hsh)
     |> Map.put(:name, event.__name)
     |> Map.put(:topic, event.__topic)
     |> Map.put(:block_number, event.__block_number)

--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -48,27 +48,22 @@ defmodule Explorer.Celo.ContractEvents.Common do
   end
 
   def extract_common_event_params(event) do
-    # set full hashes
-    [:transaction_hash]
-    |> Enum.into(%{}, fn key ->
-      case Map.get(event, key) do
-        nil ->
-          {key, nil}
+    case Map.get(event, :__transaction_hash) do
+      nil ->
+        %{transaction_hash: nil}
 
-        v ->
-          {:ok, hsh} = Full.cast(v)
-          {key, hsh}
-      end
-    end)
-    # set contract address hash
+      v ->
+        {:ok, hsh} = Full.cast(v)
+        %{transaction_hash: hsh}
+    end
     |> then(fn map ->
-      {:ok, hsh} = Address.cast(event.contract_address_hash)
+      {:ok, hsh} = Address.cast(event.__contract_address_hash)
       Map.put(map, :contract_address_hash, hsh)
     end)
-    |> Map.put(:name, event.name)
-    |> Map.put(:topic, event.topic)
-    |> Map.put(:block_number, event.block_number)
-    |> Map.put(:log_index, event.log_index)
+    |> Map.put(:name, event.__name)
+    |> Map.put(:topic, event.__topic)
+    |> Map.put(:block_number, event.__block_number)
+    |> Map.put(:log_index, event.__log_index)
   end
 
   @doc "Store address in postgres json format to make joins work with indices"

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -43,7 +43,6 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
         def function_signature, do: "TestName(string,string,address,uint256,uint256)"
       end
 
-
       test_name = "event_parameter_test_name"
       test_topic = "event_parameter_test_topic"
       test_log_index = 555
@@ -59,7 +58,7 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
         address_hash: "0x765de816845861e75a25fca122bb6898b8b1282a",
         block_hash: "0x42b21f09e9956d1a01195b1ca461059b2705fe850fc1977bd7182957e1b390d3",
         block_number: 10_913_664,
-        data: data,
+        data: "0x" <> data,
         first_topic: TestParamCollisionEvent.topic(),
         fourth_topic: nil,
         index: 8,
@@ -68,7 +67,9 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
         transaction_hash: "0xb8960575a898afa8a124cd7414f1261109a119dba3bed4489393952a1556a5f0"
       }
 
-      require IEx; IEx.pry
+      event = TestParamCollisionEvent |> struct!() |> EventTransformer.from_params(test_params)
+
+      assert(event.name == "TestName")
     end
   end
 

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -5,6 +5,7 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
   alias Explorer.Celo.ContractEvents.EventMap
   alias Explorer.Celo.ContractEvents.Reserve.AssetAllocationSetEvent
   alias Explorer.Chain.{Address, CeloContractEvent, Log}
+  alias Explorer.Test.TestParamCollisionEvent
 
   describe "overall generic tests" do
     @tag :skip
@@ -27,22 +28,6 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
     end
 
     test "handling new events with property name collisions" do
-      defmodule TestParamCollisionEvent do
-        @moduledoc "An event with properties the same names as event struct properties "
-
-        use Explorer.Celo.ContractEvents.Base,
-          name: "TestName",
-          topic: "0x08812eccd29961180ca7d99a726f3ec3d86acc2c0b7ad920180ca9d31f31c250"
-
-        event_param(:name, :string, :unindexed)
-        event_param(:topic, :string, :unindexed)
-        event_param(:transaction_hash, :address, :indexed)
-        event_param(:log_index, {:uint, 256}, :unindexed)
-        event_param(:block_number, {:uint, 256}, :unindexed)
-
-        def function_signature, do: "TestName(string,string,address,uint256,uint256)"
-      end
-
       test_name = "event_parameter_test_name"
       test_topic = "event_parameter_test_topic"
       test_log_index = 555

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -17,8 +17,9 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
         |> MapSet.new()
 
       blockscout_events =
-        EventTransformer.__protocol__(:impls)
-        |> then(fn {:consolidated, modules} -> Enum.map(modules, & &1.name()) end)
+        EventMap.map()
+        |> Map.values()
+        |> Enum.map(fn module -> module |> Atom.to_string() |> String.split(".") |> List.last() end)
         |> MapSet.new()
 
       missing_events = MapSet.difference(exportisto_events, blockscout_events)

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -6,8 +6,6 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
   alias Explorer.Celo.ContractEvents.Reserve.AssetAllocationSetEvent
   alias Explorer.Chain.{Address, CeloContractEvent, Log}
 
-
-
   describe "overall generic tests" do
     @tag :skip
     test "exportisto event type parity" do
@@ -28,12 +26,13 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
              "Blockscout events should be a superset of exsportisto events, found #{Enum.count(missing_events)} missing events: #{Enum.join(missing_events, ", ")}"
     end
 
-
     test "handling new events with property name collisions" do
       defmodule TestParamCollisionEvent do
         @moduledoc "An event with properties the same names as event struct properties "
 
-        use Explorer.Celo.ContractEvents.Base, name: "TestName", topic: "0x08812eccd29961180ca7d99a726f3ec3d86acc2c0b7ad920180ca9d31f31c250"
+        use Explorer.Celo.ContractEvents.Base,
+          name: "TestName",
+          topic: "0x08812eccd29961180ca7d99a726f3ec3d86acc2c0b7ad920180ca9d31f31c250"
 
         event_param(:name, :string, :unindexed)
         event_param(:topic, :string, :unindexed)
@@ -50,10 +49,13 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
       test_block_number = 444
       test_transaction_hash = "0x00000000000000000000000088c1c759600ec3110af043c183a2472ab32d099c"
 
-      data = ABI.TypeEncoder.encode(
-               [test_name, test_topic, test_log_index,test_block_number],
-               [:string,:string,{:uint, 256}, {:uint, 256}], :output)
-             |> Base.encode16(case: :lower)
+      data =
+        ABI.TypeEncoder.encode(
+          [test_name, test_topic, test_log_index, test_block_number],
+          [:string, :string, {:uint, 256}, {:uint, 256}],
+          :output
+        )
+        |> Base.encode16(case: :lower)
 
       test_params = %{
         address_hash: "0x765de816845861e75a25fca122bb6898b8b1282a",
@@ -70,7 +72,11 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
 
       event = TestParamCollisionEvent |> struct!() |> EventTransformer.from_params(test_params)
 
-      assert(event.__name == TestParamCollisionEvent.name(), "Event name should be available with underscored property name")
+      assert(
+        event.__name == TestParamCollisionEvent.name(),
+        "Event name should be available with underscored property name"
+      )
+
       assert(event.name == test_name, "Generated property value should be available under the name")
 
       celo_event = event |> EventTransformer.to_celo_contract_event_params()

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -69,7 +69,13 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
 
       event = TestParamCollisionEvent |> struct!() |> EventTransformer.from_params(test_params)
 
-      assert(event.name == "TestName")
+      assert(event.__name == TestParamCollisionEvent.name(), "Event name should be available with underscored property name")
+      assert(event.name == test_name, "Generated property value should be available under the name")
+
+      celo_event = event |> EventTransformer.to_celo_contract_event_params()
+
+      assert(celo_event.name == TestParamCollisionEvent.name(), "CeloContractEvent name should be name of the event")
+      assert(celo_event.params.name == test_name, "CeloContractEvent params should contain event property")
     end
   end
 

--- a/apps/explorer/test/explorer/celo/events/epoch_rewards_distributed_to_voters_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/epoch_rewards_distributed_to_voters_event_test.exs
@@ -39,7 +39,7 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       assert result.value == 411_618_438_366_361_072_744
       assert to_string(result.group) == "0xb33e9e01e561a1da60f7cb42508500e571afb6eb"
-      assert result.log_index == 573
+      assert result.__log_index == 573
     end
   end
 
@@ -57,9 +57,9 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_number: 172_800,
-          log_index: log_1_1.index,
-          contract_address_hash: contract_address_hash,
+          __block_number: 172_800,
+          __log_index: log_1_1.index,
+          __contract_address_hash: contract_address_hash,
           group: group_address_1_hash,
           value: 650
         }
@@ -67,10 +67,10 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %ValidatorGroupVoteActivatedEvent{
-          block_number: 172_800,
-          log_index: log_1_2.index,
+          __block_number: 172_800,
+          __log_index: log_1_2.index,
           account: group_address_1_hash,
-          contract_address_hash: contract_address_hash,
+          __contract_address_hash: contract_address_hash,
           group: group_address_1_hash,
           units: 10000,
           value: 650
@@ -79,9 +79,9 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_number: 172_800,
-          log_index: log_1_3.index,
-          contract_address_hash: contract_address_hash,
+          __block_number: 172_800,
+          __log_index: log_1_3.index,
+          __contract_address_hash: contract_address_hash,
           group: group_address_2_hash,
           value: 650
         }
@@ -89,9 +89,9 @@ defmodule Explorer.Celo.Events.EpochRewardsDistributedToVotersEventTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_number: 190_080,
-          log_index: log_2.index,
-          contract_address_hash: contract_address_hash,
+          __block_number: 190_080,
+          __log_index: log_2.index,
+          __contract_address_hash: contract_address_hash,
           group: group_address_2_hash,
           value: 650
         }

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -109,17 +109,4 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
       assert result.value == 420_420_420
     end
   end
-
-  describe "General functionality" do
-    test "event map should have definitions for all events" do
-      event_map_topic_set = EventMap.map() |> Map.keys() |> MapSet.new()
-
-      contract_events_topic_set =
-        EventTransformer.__protocol__(:impls)
-        |> then(fn {:consolidated, modules} -> Enum.map(modules, & &1.topic()) end)
-        |> MapSet.new()
-
-      assert MapSet.subset?(contract_events_topic_set, event_map_topic_set)
-    end
-  end
 end

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -118,7 +118,8 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
         EventTransformer.__protocol__(:impls)
         |> then(fn {:consolidated, modules} -> Enum.map(modules, & &1.topic()) end)
         |> MapSet.new()
-        |> MapSet.delete(Explorer.Test.TestParamCollisionEvent.topic()) #only for test suite - not a real event
+        # only for test suite - not a real event
+        |> MapSet.delete(Explorer.Test.TestParamCollisionEvent.topic())
 
       assert MapSet.subset?(contract_events_topic_set, event_map_topic_set)
     end

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -109,4 +109,17 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
       assert result.value == 420_420_420
     end
   end
+
+  describe "General functionality" do
+    test "event map should have definitions for all events" do
+      event_map_topic_set = EventMap.map() |> Map.keys() |> MapSet.new()
+
+      contract_events_topic_set =
+        EventTransformer.__protocol__(:impls)
+        |> then(fn {:consolidated, modules} -> Enum.map(modules, & &1.topic()) end)
+        |> MapSet.new()
+
+      assert MapSet.subset?(contract_events_topic_set, event_map_topic_set)
+    end
+  end
 end

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -118,6 +118,7 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
         EventTransformer.__protocol__(:impls)
         |> then(fn {:consolidated, modules} -> Enum.map(modules, & &1.topic()) end)
         |> MapSet.new()
+        |> MapSet.delete(Explorer.Test.TestParamCollisionEvent.topic()) #only for test suite - not a real event
 
       assert MapSet.subset?(contract_events_topic_set, event_map_topic_set)
     end

--- a/apps/explorer/test/explorer/celo/events/event_map_test.exs
+++ b/apps/explorer/test/explorer/celo/events/event_map_test.exs
@@ -88,9 +88,9 @@ defmodule Explorer.Celo.ContractEvents.EventMapTest do
       contract = insert(:core_contract)
 
       event = %ValidatorGroupActiveVoteRevokedEvent{
-        block_number: 77,
-        log_index: log.index,
-        contract_address_hash: contract.address_hash,
+        __block_number: 77,
+        __log_index: log.index,
+        __contract_address_hash: contract.address_hash,
         account: address_hash(),
         group: address_hash(),
         units: 6_969_696_969,

--- a/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
@@ -47,7 +47,7 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
       assert result.units == 6_136_281_451_163_456_507_329_304_650_157_103_347_504
       assert to_string(result.account) == "0x88c1c759600ec3110af043c183a2472ab32d099c"
       assert to_string(result.group) == "0x47b2db6af05a55d42ed0f3731735f9479abf0673"
-      assert result.log_index == 8
+      assert result.__log_index == 8
     end
 
     test "converts from ethjsonrpc log to event type and insert into db" do

--- a/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
+++ b/apps/explorer/test/explorer/celo/events/validator_group_vote_activated_event_test.exs
@@ -80,7 +80,7 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
       assert result.units == 6_136_281_451_163_456_507_329_304_650_157_103_347_504
       assert result.account |> to_string() == "0x88c1c759600ec3110af043c183a2472ab32d099c"
       assert result.group |> to_string() == "0x47b2db6af05a55d42ed0f3731735f9479abf0673"
-      assert result.log_index == 8
+      assert result.__log_index == 8
 
       # explictly setting timestamps as insert_all doesn't do this
       r =
@@ -100,7 +100,7 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
       assert result.units == 6_136_281_451_163_456_507_329_304_650_157_103_347_504
       assert result.account |> to_string() == "0x88c1c759600ec3110af043c183a2472ab32d099c"
       assert result.group |> to_string() == "0x47b2db6af05a55d42ed0f3731735f9479abf0673"
-      assert result.log_index == 8
+      assert result.__log_index == 8
 
       {:ok, account} = Explorer.Chain.Hash.Address.cast("0x88c1c759600ec3110af043c183a2472ab32d099c")
 
@@ -127,10 +127,10 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
 
       insert(:contract_event, %{
         event: %ValidatorGroupVoteActivatedEvent{
-          block_number: block_1.number,
-          log_index: log_1.index,
+          __block_number: block_1.number,
+          __log_index: log_1.index,
           account: voter_1_address_hash,
-          contract_address_hash: contract_address_hash,
+          __contract_address_hash: contract_address_hash,
           group: group_1_address_hash,
           units: 1000,
           value: 650
@@ -142,10 +142,10 @@ defmodule Explorer.Celo.Events.ValidatorGroupVoteActivatedEventTest do
 
       insert(:contract_event, %{
         event: %ValidatorGroupVoteActivatedEvent{
-          block_number: block_2.number,
-          log_index: log_2.index,
+          __block_number: block_2.number,
+          __log_index: log_2.index,
           account: voter_2_address_hash,
-          contract_address_hash: contract_address_hash,
+          __contract_address_hash: contract_address_hash,
           group: group_2_address_hash,
           units: 1000,
           value: 650

--- a/apps/explorer/test/support/setup_validator_and_group_rewards_test.ex
+++ b/apps/explorer/test/support/setup_validator_and_group_rewards_test.ex
@@ -17,9 +17,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_696_320,
-        contract_address_hash: contract_address_hash,
-        log_index: log_1.index,
+        __block_number: 10_696_320,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_1.index,
         validator: validator_address_1_hash,
         validator_payment: 100_000,
         group: group_address_1_hash,
@@ -35,9 +35,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_730_880,
-        contract_address_hash: contract_address_hash,
-        log_index: log_2.index,
+        __block_number: 10_730_880,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_2.index,
         validator: validator_address_1_hash,
         validator_payment: 100_000,
         group: group_address_1_hash,
@@ -47,9 +47,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_730_880,
-        contract_address_hash: contract_address_hash,
-        log_index: log_3.index,
+        __block_number: 10_730_880,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_3.index,
         validator: validator_address_2_hash,
         validator_payment: 100_000,
         group: group_address_2_hash,
@@ -65,9 +65,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_748_160,
-        contract_address_hash: contract_address_hash,
-        log_index: log_4.index,
+        __block_number: 10_748_160,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_4.index,
         validator: validator_address_1_hash,
         validator_payment: 200_000,
         group: group_address_1_hash,
@@ -77,9 +77,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_748_160,
-        contract_address_hash: contract_address_hash,
-        log_index: log_5.index,
+        __block_number: 10_748_160,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_5.index,
         validator: validator_address_2_hash,
         validator_payment: 200_000,
         group: group_address_2_hash,
@@ -104,9 +104,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_730_880,
-        contract_address_hash: contract_address_hash,
-        log_index: log_1.index,
+        __block_number: 10_730_880,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_1.index,
         validator: validator_address_1_hash,
         validator_payment: 100_000,
         group: group_address_1_hash,
@@ -122,9 +122,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_748_160,
-        contract_address_hash: contract_address_hash,
-        log_index: log_2.index,
+        __block_number: 10_748_160,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_2.index,
         validator: validator_address_1_hash,
         validator_payment: 200_000,
         group: group_address_1_hash,
@@ -134,9 +134,9 @@ defmodule Explorer.SetupValidatorAndGroupRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorEpochPaymentDistributedEvent{
-        block_number: 10_748_160,
-        contract_address_hash: contract_address_hash,
-        log_index: log_3.index,
+        __block_number: 10_748_160,
+        __contract_address_hash: contract_address_hash,
+        __log_index: log_3.index,
         validator: validator_address_2_hash,
         validator_payment: 150_000,
         group: group_address_2_hash,

--- a/apps/explorer/test/support/setup_voter_rewards_test.ex
+++ b/apps/explorer/test/support/setup_voter_rewards_test.ex
@@ -21,10 +21,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: block_1_number,
-        log_index: log_1.index,
+        __block_number: block_1_number,
+        __log_index: log_1.index,
         account: voter_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_hash,
         units: 1000,
         value: 650
@@ -65,10 +65,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: block_4_number,
-        log_index: log_4.index,
+        __block_number: block_4_number,
+        __log_index: log_4.index,
         account: voter_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_hash,
         units: 1000,
         value: 250
@@ -95,10 +95,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupActiveVoteRevokedEvent{
-        block_number: block_6_number,
-        log_index: log_6.index,
+        __block_number: block_6_number,
+        __log_index: log_6.index,
         account: voter_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_hash,
         units: 1000,
         value: 1075
@@ -169,10 +169,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: 10_692_863,
-        log_index: log_1.index,
+        __block_number: 10_692_863,
+        __log_index: log_1.index,
         account: voter_1_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_1_hash,
         units: 1000,
         value: 650
@@ -184,10 +184,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: 10_744_703,
-        log_index: log_2.index,
+        __block_number: 10_744_703,
+        __log_index: log_2.index,
         account: voter_1_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_2_hash,
         units: 1000,
         value: 250
@@ -199,10 +199,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: 10_779_263,
-        log_index: log_3.index,
+        __block_number: 10_779_263,
+        __log_index: log_3.index,
         account: voter_2_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_1_hash,
         units: 1000,
         value: 650
@@ -252,10 +252,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: 10_692_863,
-        log_index: log_1.index,
+        __block_number: 10_692_863,
+        __log_index: log_1.index,
         account: voter_1_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_1_hash,
         units: 1000,
         value: 650
@@ -267,10 +267,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: 10_744_703,
-        log_index: log_2.index,
+        __block_number: 10_744_703,
+        __log_index: log_2.index,
         account: voter_1_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_2_hash,
         units: 1000,
         value: 250
@@ -282,10 +282,10 @@ defmodule Explorer.SetupVoterRewardsTest do
 
     insert(:contract_event, %{
       event: %ValidatorGroupVoteActivatedEvent{
-        block_number: 10_761_983,
-        log_index: log_3.index,
+        __block_number: 10_761_983,
+        __log_index: log_3.index,
         account: voter_2_hash,
-        contract_address_hash: contract_address_hash,
+        __contract_address_hash: contract_address_hash,
         group: group_1_hash,
         units: 1000,
         value: 650

--- a/apps/explorer/test/support/test_param_collision_event.ex
+++ b/apps/explorer/test/support/test_param_collision_event.ex
@@ -2,8 +2,8 @@ defmodule Explorer.Test.TestParamCollisionEvent do
   @moduledoc "An event with properties the same names as event struct properties "
 
   use Explorer.Celo.ContractEvents.Base,
-      name: "TestName",
-      topic: "0x08812eccd29961180ca7d99a726f3ec3d86acc2c0b7ad920180ca9d31f31c250"
+    name: "TestName",
+    topic: "0x08812eccd29961180ca7d99a726f3ec3d86acc2c0b7ad920180ca9d31f31c250"
 
   event_param(:name, :string, :unindexed)
   event_param(:topic, :string, :unindexed)

--- a/apps/explorer/test/support/test_param_collision_event.ex
+++ b/apps/explorer/test/support/test_param_collision_event.ex
@@ -1,0 +1,15 @@
+defmodule Explorer.Test.TestParamCollisionEvent do
+  @moduledoc "An event with properties the same names as event struct properties "
+
+  use Explorer.Celo.ContractEvents.Base,
+      name: "TestName",
+      topic: "0x08812eccd29961180ca7d99a726f3ec3d86acc2c0b7ad920180ca9d31f31c250"
+
+  event_param(:name, :string, :unindexed)
+  event_param(:topic, :string, :unindexed)
+  event_param(:transaction_hash, :address, :indexed)
+  event_param(:log_index, {:uint, 256}, :unindexed)
+  event_param(:block_number, {:uint, 256}, :unindexed)
+
+  def function_signature, do: "TestName(string,string,address,uint256,uint256)"
+end

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -148,8 +148,8 @@ defmodule Indexer.Block.Fetcher do
       %{
         name: event.identifier,
         address_hash: new_contract_address,
-        block_number: event.block_number,
-        log_index: event.log_index
+        block_number: event.__block_number,
+        log_index: event.__log_index
       }
     end)
     |> tap(fn new_contracts ->

--- a/apps/indexer/test/indexer/fetcher/celo_validator_group_votes_test.exs
+++ b/apps/indexer/test/indexer/fetcher/celo_validator_group_votes_test.exs
@@ -72,9 +72,9 @@ defmodule Indexer.Fetcher.CeloValidatorGroupVotesTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_number: 172_800,
-          contract_address_hash: contract_address_hash,
-          log_index: log_1.index,
+          __block_number: 172_800,
+          __contract_address_hash: contract_address_hash,
+          __log_index: log_1.index,
           group: group_1_hash,
           value: 650
         }
@@ -85,9 +85,9 @@ defmodule Indexer.Fetcher.CeloValidatorGroupVotesTest do
 
       insert(:contract_event, %{
         event: %EpochRewardsDistributedToVotersEvent{
-          block_number: 190_080,
-          contract_address_hash: contract_address_hash,
-          log_index: log_2.index,
+          __block_number: 190_080,
+          __contract_address_hash: contract_address_hash,
+          __log_index: log_2.index,
           group: group_2_hash,
           value: 650
         }


### PR DESCRIPTION
### Description

After generating some more events it turns out that collisions with existing struct properties are more likely than first expected. Structs are created based on event ABIs, and if these events happen to define a property that already exists within the struct the original definition will be overwritten and database constraints can't be satisfied when trying to insert.

e.g. if an event was to define a property `name` or `contract_address_hash`, these would be overwritten in the original event.

This PR modifies the existing "meta" properties (properties about the event - `transaction_hash`, `block_number` etc) upon concrete event instances to include a common prefix in order to reduce name collisions. These properties are now referred to by `__transaction_hash` and `__block_number`

A similar approach is taken by the elixir language itself to attach meta info to a struct - each struct contains a property `__struct__` that references the module the struct is representing, so as janky as this might feel the approach is not without precedent.

Note: This only affects the concrete event implementations, the `CeloContractEvent` object already distinguishes between generated and meta properties by virtue of storing them differently in the db.

### Other changes

* modified some variable names and documentation within the event generation macros to improve understanding

### Tested

* added and ran unit tests

### Issues

 - closes celo-org/data-services#232



