### PR TITLE
Handle unindexed addresses the same as indexed

### DIFF
--- a/apps/explorer/lib/explorer/celo/events/contract_events/base/contract_event_base.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/base/contract_event_base.ex
@@ -120,7 +120,7 @@ defmodule Explorer.Celo.ContractEvents.Base do
             indexed_event_properties =
               unquote(Macro.escape(indexed_types_with_topics))
               |> Enum.map(fn {%{name: name, type: type}, topic} ->
-                {name, decode_event(params[topic], type)}
+                {name, decode_event_topic(params[topic], type)}
               end)
               |> Enum.into(%{})
 

--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -34,6 +34,7 @@ defmodule Explorer.Celo.ContractEvents.Common do
       # bytes to list of ints
       {d, {:bytes, _}} -> :binary.bin_to_list(d)
       {d, :bytes} -> :binary.bin_to_list(d)
+      {d, :address} -> convert_result(d, :address)
       {d, _} -> d
     end)
   end

--- a/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
+++ b/apps/explorer/lib/explorer/celo/events/contract_events/common.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Celo.ContractEvents.Common do
   alias Explorer.Chain.{Data, Hash, Hash.Full}
 
   @doc "Decode a single point of event data of a given type from a given topic"
-  def decode_event(topic, type) do
+  def decode_event_topic(topic, type) do
     topic
     |> extract_hash()
     |> TypeDecoder.decode_raw([type])

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -1,6 +1,7 @@
 defmodule Explorer.Celo.Events.CeloContractEventsTest do
   use Explorer.DataCase, async: true
 
+  alias Explorer.Celo.ContractEvents.Accounts.AccountWalletAddressSetEvent
   alias Explorer.Celo.ContractEvents.EventTransformer
   alias Explorer.Celo.ContractEvents.EventMap
   alias Explorer.Celo.ContractEvents.Reserve.AssetAllocationSetEvent
@@ -79,6 +80,43 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
   end
 
   describe "event parameter conversion tests" do
+    test "converts events with unindexed address types correctly" do
+      block_1 = insert(:block, number: 172_800)
+      %Explorer.Chain.CeloCoreContract{address_hash: contract_address_hash} = insert(:core_contract)
+
+      # event AccountWalletAddressSet with wallet_address as unindexed event parameter of type address
+      # https://github.com/celo-org/data-services/issues/241
+      log_data =  %{
+        "address"=> contract_address_hash |> to_string(),
+        "topics"=> [
+          "0xf81d74398fd47e35c36b714019df15f200f623dde569b5b531d6a0b4da5c5f26",
+          "0x000000000000000000000000bcf444dc843a398c3436cc37729005378c3aae30"
+        ],
+        "data"=> "0x0000000000000000000000005c3909164426a6bff52907d05c83c509ae427119",
+        "blockNumber"=> 172_800,
+        "transactionHash"=> nil,
+        "transactionIndex"=> nil,
+        "blockHash"=> block_1.hash |> to_string(),
+        "logIndex"=> "0x8",
+        "removed"=> false
+      }
+      |> EthereumJSONRPC.Log.to_elixir()
+      |> EthereumJSONRPC.Log.elixir_to_params()
+
+      changeset_params =
+        EventMap.rpc_to_event_params([log_data])
+        |> List.first()
+        |> Map.put(:updated_at, Timex.now())
+        |> Map.put(:inserted_at, Timex.now())
+
+      # insert into db and assert that public key is inserted as valid json
+      {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [changeset_params])
+
+      # retrieve from db
+      [event] = AccountWalletAddressSetEvent.query() |> EventMap.query_all()
+
+      #assert(event.ecdsa_public_key |> :erlang.list_to_binary() == expected_public_key)
+    end
     test "converts arrays of bytes and ints" do
       block_1 = insert(:block, number: 172_800)
       %Explorer.Chain.CeloCoreContract{address_hash: contract_address_hash} = insert(:core_contract)

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -86,22 +86,23 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
 
       # event AccountWalletAddressSet with wallet_address as unindexed event parameter of type address
       # https://github.com/celo-org/data-services/issues/241
-      log_data =  %{
-        "address"=> contract_address_hash |> to_string(),
-        "topics"=> [
-          "0xf81d74398fd47e35c36b714019df15f200f623dde569b5b531d6a0b4da5c5f26",
-          "0x000000000000000000000000bcf444dc843a398c3436cc37729005378c3aae30"
-        ],
-        "data"=> "0x0000000000000000000000005c3909164426a6bff52907d05c83c509ae427119",
-        "blockNumber"=> 172_800,
-        "transactionHash"=> nil,
-        "transactionIndex"=> nil,
-        "blockHash"=> block_1.hash |> to_string(),
-        "logIndex"=> "0x8",
-        "removed"=> false
-      }
-      |> EthereumJSONRPC.Log.to_elixir()
-      |> EthereumJSONRPC.Log.elixir_to_params()
+      log_data =
+        %{
+          "address" => contract_address_hash |> to_string(),
+          "topics" => [
+            "0xf81d74398fd47e35c36b714019df15f200f623dde569b5b531d6a0b4da5c5f26",
+            "0x000000000000000000000000bcf444dc843a398c3436cc37729005378c3aae30"
+          ],
+          "data" => "0x0000000000000000000000005c3909164426a6bff52907d05c83c509ae427119",
+          "blockNumber" => 172_800,
+          "transactionHash" => nil,
+          "transactionIndex" => nil,
+          "blockHash" => block_1.hash |> to_string(),
+          "logIndex" => "0x8",
+          "removed" => false
+        }
+        |> EthereumJSONRPC.Log.to_elixir()
+        |> EthereumJSONRPC.Log.elixir_to_params()
 
       changeset_params =
         EventMap.rpc_to_event_params([log_data])

--- a/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
+++ b/apps/explorer/test/explorer/celo/events/celo_contract_events_test.exs
@@ -109,14 +109,16 @@ defmodule Explorer.Celo.Events.CeloContractEventsTest do
         |> Map.put(:updated_at, Timex.now())
         |> Map.put(:inserted_at, Timex.now())
 
-      # insert into db and assert that public key is inserted as valid json
+      # insert into db and assert that wallet_address is inserted as valid json
       {1, _} = Explorer.Repo.insert_all(CeloContractEvent, [changeset_params])
 
       # retrieve from db
       [event] = AccountWalletAddressSetEvent.query() |> EventMap.query_all()
 
-      #assert(event.ecdsa_public_key |> :erlang.list_to_binary() == expected_public_key)
+      # wallet_address should decode to following value from "data" in log above
+      assert(event.wallet_address |> to_string() == "0x5c3909164426a6bff52907d05c83c509ae427119")
     end
+
     test "converts arrays of bytes and ints" do
       block_1 = insert(:block, number: 172_800)
       %Explorer.Chain.CeloCoreContract{address_hash: contract_address_hash} = insert(:core_contract)


### PR DESCRIPTION
### Description

Events with unindexed parameters of type `address` were being treated as binary objects and then coerced into invalid UTF8 strings which the database would not accept.

> Note: "unindexed" in this context refers to the fact that the parameter is contained within the `data` field of a log object, and not within it's own topic

This PR changes the behavior to treat all addresses the same, and encode them in the same format as other addresses.
 
 ### Other changes

* Renamed a method in the base event macro to better explain what it does

### Tested

* Added and ran unit test

### Issues

 - closes celo-org/data-services#241
 