### PR TITLE
Verified contracts: tooltips

### DIFF
--- a/apps/block_scout_web/assets/js/pages/verified_contracts.js
+++ b/apps/block_scout_web/assets/js/pages/verified_contracts.js
@@ -1,0 +1,20 @@
+import 'bootstrap'
+import $ from 'jquery'
+
+$(function () {
+  $('[data-page="verified_contracts"]').tooltip({
+    selector: '[data-toggle="tooltip-with-link"]',
+    html: true,
+    delay: {
+      show: 0,
+      hide: 3000 // to allow user to be able to click the link before tooltip disappears
+    }
+  })
+
+  $('[data-toggle="tooltip-with-link"]').on('show.bs.tooltip', () => {
+    $('[data-toggle="tooltip-with-link"]').each((_, element) => {
+      // becauase of the options.delay.hide we don't want to keep previous tooltips shown
+      $(element).tooltip('hide')
+    })
+  })
+})

--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -102,6 +102,7 @@ const appJs =
       'export-csv': './css/export-csv.scss',
       'datepicker': './js/lib/datepicker.js',
       'stats': './js/pages/stats.js',
+      'verified-contracts': './js/pages/verified_contracts.js',
     },
     output: {
       filename: '[name].js',

--- a/apps/block_scout_web/lib/block_scout_web/templates/verified_contracts/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/verified_contracts/_tile.html.eex
@@ -38,9 +38,15 @@
     <td class="stakes-td">
         <span class="verification-label <%= if contract.partially_verified do %>partial<% else %>full<% end %>">
         <%= if contract.partially_verified do %>
-        <%= gettext "Partially Verified" %>
+        <span data-toggle="tooltip-with-link"
+            data-placement="top"
+            data-title="<%= gettext "Source code matches deployed contracts except the metadata hash" %>. <a target='_blank' href='https://docs.sourcify.dev/docs/full-vs-partial-match/'><%= gettext "Learn more" %></a>."
+        ><%= gettext "Partially Verified" %></span>
         <% else %>
-        <%= gettext "Verified" %>
+        <span data-toggle="tooltip-with-link"
+            data-placement="top"
+            data-title="<%= gettext "Source code matches deployed contract 100%" %>. <a target='_blank' href='https://docs.sourcify.dev/docs/full-vs-partial-match/'><%= gettext "Learn more" %></a>."
+        ><%= gettext "Verified" %></span>
         <% end %>
     </td>
     <td class="stakes-td">

--- a/apps/block_scout_web/lib/block_scout_web/templates/verified_contracts/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/verified_contracts/index.html.eex
@@ -115,3 +115,4 @@
 		</div>
 	</div>
 </section>
+<script defer data-cfasync="false" src="<%= static_path(@conn, "/js/verified-contracts.js") %>"></script>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -3377,7 +3377,7 @@ msgid "Date Verified"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:41
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:44
 msgid "Partially Verified"
 msgstr ""
 
@@ -3387,7 +3387,23 @@ msgid "Txns (past 90 days)"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:49
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:74
 msgid "Verified"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:48
+msgid "Learn more"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:48
+msgid "Source code matches deployed contract 100%"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
+msgid "Source code matches deployed contracts except the metadata hash"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -3378,7 +3378,7 @@ msgid "Date Verified"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:41
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:44
 msgid "Partially Verified"
 msgstr ""
 
@@ -3387,8 +3387,24 @@ msgstr ""
 msgid "Txns (past 90 days)"
 msgstr ""
 
-#, elixir-format, fuzzy
-#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
+#, elixir-format
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:49
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:74
 msgid "Verified"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:48
+msgid "Learn more"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:48
+msgid "Source code matches deployed contract 100%"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
+msgid "Source code matches deployed contracts except the metadata hash"
 msgstr ""


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description

Adding a tooltip on verified contracts page for "Verified" and "Partially verified labels" with links to sourcify. That way it will be clear for our users what those statuses mean.
 
### Issues

 - Fixes #647 
