### PR TITLE
Added DB locks monitor view

### DIFF
--- a/apps/explorer/priv/repo/migrations/20220530155133_add_locks_monitoring.exs
+++ b/apps/explorer/priv/repo/migrations/20220530155133_add_locks_monitoring.exs
@@ -1,0 +1,48 @@
+defmodule Explorer.Repo.Migrations.AddLocksMonitoring do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE VIEW dbg_lock_monitor AS (
+      SELECT
+        COALESCE (
+          blocking.relation :: regclass :: text,
+          blocking.locktype
+        ) as locked_item,
+        NOW() - blocked_activity.query_start AS waiting_duration,
+        blocked_activity.pid AS blocked_pid,
+        blocked_activity.query as blocked_query,
+        blocked.mode as blocked_mode,
+        blocking_activity.pid AS blocking_pid,
+        blocking_activity.query as blocking_query,
+        blocking.mode as blocking_mode
+      FROM pg_catalog.pg_locks AS blocked
+      JOIN pg_stat_activity AS blocked_activity
+        ON blocked.pid = blocked_activity.pid
+      JOIN pg_catalog.pg_locks AS blocking
+        ON ((
+          (
+            blocking.transactionid = blocked.transactionid
+          )
+          OR (
+            blocking.relation = blocked.relation
+            AND blocking.locktype = blocked.locktype
+          )
+        )
+        AND blocked.pid != blocking.pid
+      )
+      JOIN pg_stat_activity AS blocking_activity
+        ON blocking.pid = blocking_activity.pid AND blocking_activity.datid = blocked_activity.datid
+      WHERE
+        NOT blocked.granted
+        AND blocking_activity.datname = current_database()
+    )
+    """)
+  end
+
+  def down do
+    execute("""
+    DROP VIEW IF EXISTS dbg_lock_monitor
+    """)
+  end
+end


### PR DESCRIPTION
### Description

Adds a debugging view that would help with analysing database locks.
Usage:
```
SELECT * FROM dbg_lock_monitor;
```

 ### Other changes

No.

### Tested

Tested on staging.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/242.

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
