### PR TITLE
Renamed Celo Reserve to Mento Reserve

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/stats/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stats/index.html.eex
@@ -25,7 +25,7 @@
       </li>  
       <li class="stats-link" data-tab-id="4">
         <a href="<%= reserve_url %>" target="myiframe">
-          <%=  gettext("Celo Reserve") %>
+          <%=  gettext("Mento Reserve") %>
         </a>
       </li> 
       <li class="stats-link" data-tab-id="5">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -543,11 +543,6 @@ msgid "Candidate’s Staked Amount"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stats/index.html.eex:28
-msgid "Celo Reserve"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/layout/_network_selector.html.eex:11
 msgid "Change Network"
 msgstr ""
@@ -3406,4 +3401,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
 msgid "Source code matches deployed contracts except the metadata hash"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/stats/index.html.eex:28
+msgid "Mento Reserve"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -544,11 +544,6 @@ msgid "Candidate’s Staked Amount"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/stats/index.html.eex:28
-msgid "Celo Reserve"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/layout/_network_selector.html.eex:11
 msgid "Change Network"
 msgstr ""
@@ -3407,4 +3402,9 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:43
 msgid "Source code matches deployed contracts except the metadata hash"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/stats/index.html.eex:28
+msgid "Mento Reserve"
 msgstr ""


### PR DESCRIPTION
### Description

Renames the name of the dashboard tab to `Mento Reserve`.

 ### Other changes

No.

### Tested

Locally.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
