### PR TITLE
Avoid unnecessary redirects

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_link.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_link.html.eex
@@ -3,7 +3,7 @@
     <%= if name = primary_name(@address) do %>
       <span><%= name %> |
     <% end %>
-    <%= link to: AccessHelpers.get_path(BlockScoutWeb.Endpoint, :address_transaction_path, :index, @address), "data-test": "address_hash_link", class: assigns[:class] do %>
+    <%= link to: address_transaction_path(BlockScoutWeb.Endpoint, :index, to_string(@address)), "data-test": "address_hash_link", class: assigns[:class] do %>
       <%= @address %>
     <% end %>
     </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_link.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_link.html.eex
@@ -1,14 +1,14 @@
 <%= if @address do %>
   <%= if assigns[:show_full_hash] do %>
     <%= if name = primary_name(@address) do %>
-      <span><%= name %> | 
+      <span><%= name %> |
     <% end %>
-    <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @address), "data-test": "address_hash_link", class: assigns[:class] do %>
+    <%= link to: AccessHelpers.get_path(BlockScoutWeb.Endpoint, :address_transaction_path, :index, @address), "data-test": "address_hash_link", class: assigns[:class] do %>
       <%= @address %>
     <% end %>
     </span>
   <% else %>
-    <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @address), "data-test": "address_hash_link", class: assigns[:class] do %>
+    <%= link to: address_transaction_path(BlockScoutWeb.Endpoint, :index, to_string(@address)), "data-test": "address_hash_link", class: assigns[:class] do %>
       <%= render BlockScoutWeb.AddressView, "_responsive_hash.html", address: @address, contract: @contract, truncate: assigns[:truncate], use_custom_tooltip: @use_custom_tooltip, no_tooltip: assigns[:no_tooltip] %>
     <% end %>
   <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/views/access_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/access_helpers.ex
@@ -5,14 +5,19 @@ defmodule BlockScoutWeb.AccessHelpers do
 
   alias BlockScoutWeb.WebRouter.Helpers
   alias Plug.Conn
+  alias Plug.Conn.Unfetched
 
   defp get_restricted_key(%Phoenix.Socket{}) do
     nil
   end
 
-  defp get_restricted_key(conn) do
+  defp get_restricted_key(%Conn{query_params: %Unfetched{}} = conn) do
     conn_with_params = Conn.fetch_query_params(conn)
     conn_with_params.query_params["key"]
+  end
+
+  defp get_restricted_key(conn) do
+    Map.get(conn.query_params, "key")
   end
 
   def restricted_access?(address_hash, params) do

--- a/apps/block_scout_web/lib/block_scout_web/views/access_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/access_helpers.ex
@@ -5,19 +5,14 @@ defmodule BlockScoutWeb.AccessHelpers do
 
   alias BlockScoutWeb.WebRouter.Helpers
   alias Plug.Conn
-  alias Plug.Conn.Unfetched
 
   defp get_restricted_key(%Phoenix.Socket{}) do
     nil
   end
 
-  defp get_restricted_key(%Conn{query_params: %Unfetched{}} = conn) do
+  defp get_restricted_key(conn) do
     conn_with_params = Conn.fetch_query_params(conn)
     conn_with_params.query_params["key"]
-  end
-
-  defp get_restricted_key(conn) do
-    Map.get(conn.query_params, "key")
   end
 
   def restricted_access?(address_hash, params) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
   use BlockScoutWeb.ConnCase, async: true
 
   alias Explorer.Chain.Hash
+  import Address, only: [:checksum]
 
   describe "GET index/3" do
     test "with invalid address hash", %{conn: conn} do
@@ -67,7 +68,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
 
       assert Enum.all?(second_page_token_balances, fn token_balance ->
                Enum.any?(token_balance_tiles, fn tile ->
-                 String.contains?(tile, to_string(token_balance.address_hash))
+                 String.contains?(tile, to_string(Address.checksum(token_balance.address_hash)))
                end)
              end)
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
   use BlockScoutWeb.ConnCase, async: true
 
   alias Explorer.Chain.Hash
-  import Address, only: [:checksum]
+  alias Explorer.Chain.Address
 
   describe "GET index/3" do
     test "with invalid address hash", %{conn: conn} do


### PR DESCRIPTION
### Description

Previously upon accessing links generated by `link` partial 2 redirects where happening (first one because it wasn't proper mixed-case and second one because it was redirecting to `/transactions` page). The fix is to generate the "final" link in the partial, so no redirects happen at all.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/162

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I added code comments for anything non trivial.
  - [ ] I added documentation for my changes.
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
