### PR TITLE
Fix block gap detection query

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3167,7 +3167,7 @@ defmodule Explorer.Chain do
 
   defp block_status(nil), do: {:error, :no_blocks}
 
-  def fetch_min_missing_block_cache do
+  def fetch_min_missing_block_cache(last_fetched_counter) do
     max_block_number = BlockNumber.get_max()
 
     if max_block_number > 0 do
@@ -3177,10 +3177,11 @@ defmodule Explorer.Chain do
             missing_range in fragment(
               """
                 (SELECT b1.number
-                FROM generate_series(0, (?)::integer) AS b1(number)
+                FROM generate_series((?)::integer, (?)::integer) AS b1(number)
                 WHERE NOT EXISTS
                   (SELECT 1 FROM blocks b2 WHERE b2.number=b1.number AND b2.consensus))
               """,
+              ^last_fetched_counter,
               ^max_block_number
             ),
           on: b.number == missing_range.number,

--- a/apps/explorer/lib/explorer/chain/cache/min_missing_block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/min_missing_block.ex
@@ -7,6 +7,8 @@ defmodule Explorer.Chain.Cache.MinMissingBlockNumber do
 
   alias Explorer.Chain
 
+  @counter_type "min_missing_block_number"
+
   @doc """
   Starts a process to periodically update the % of blocks indexed.
   """
@@ -25,11 +27,12 @@ defmodule Explorer.Chain.Cache.MinMissingBlockNumber do
   end
 
   def fetch_min_missing_block do
-    result = Chain.fetch_min_missing_block_cache()
+    last_fetched_counter = Chain.get_last_fetched_counter(@counter_type)
+    result = Chain.fetch_min_missing_block_cache(Decimal.to_integer(last_fetched_counter))
 
     if result > 0 do
       params = %{
-        counter_type: "min_missing_block_number",
+        counter_type: @counter_type,
         value: result
       }
 

--- a/apps/explorer/lib/explorer/chain/cache/min_missing_block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/min_missing_block.ex
@@ -28,7 +28,8 @@ defmodule Explorer.Chain.Cache.MinMissingBlockNumber do
 
   def fetch_min_missing_block do
     result =
-      Chain.get_last_fetched_counter(@counter_type)
+      @counter_type
+      |> Chain.get_last_fetched_counter()
       |> Decimal.to_integer()
       |> Chain.fetch_min_missing_block_cache()
 

--- a/apps/explorer/lib/explorer/chain/cache/min_missing_block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/min_missing_block.ex
@@ -27,8 +27,10 @@ defmodule Explorer.Chain.Cache.MinMissingBlockNumber do
   end
 
   def fetch_min_missing_block do
-    last_fetched_counter = Chain.get_last_fetched_counter(@counter_type)
-    result = Chain.fetch_min_missing_block_cache(Decimal.to_integer(last_fetched_counter))
+    result =
+      Chain.get_last_fetched_counter(@counter_type)
+      |> Decimal.to_integer()
+      |> Chain.fetch_min_missing_block_cache()
 
     if result > 0 do
       params = %{


### PR DESCRIPTION
### Description

This PR fixes block gap detection query which used to be super heavy. By injecting last correct value as a start of range to generate series the query becomes much faster.
 
### Issues

 - Fixes https://github.com/celo-org/data-services/issues/314