### PR TITLE
Expose Token ID in graphQL query

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -329,6 +329,7 @@ defmodule BlockScoutWeb.Schema.Types do
     field(:token, :string)
     field(:token_address, :string)
     field(:token_type, :string)
+    field(:token_id, :decimal)
     field(:block_number, :integer)
     field(:from_address_hash, :address_hash)
     field(:to_address_hash, :address_hash)

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -373,7 +373,8 @@ defmodule Explorer.GraphQL do
         token_address: token.contract_address_hash,
         nonce: tx.nonce,
         block_number: tt.block_number,
-        token_type: token.type
+        token_type: token.type,
+        token_id: tt.token_id
       },
       order_by: [desc: tt.block_number, desc: tt.amount, desc: tt.log_index]
     )
@@ -429,7 +430,8 @@ defmodule Explorer.GraphQL do
         token_address: tt.token_contract_address_hash,
         nonce: tx.nonce,
         block_number: tt.block_number,
-        token_type: token.type
+        token_type: token.type,
+        token_id: tt.token_id
       },
       order_by: [desc: tt.block_number, desc: tt.amount, desc: tt.log_index]
     )

--- a/load-testing/schema.gql
+++ b/load-testing/schema.gql
@@ -149,6 +149,7 @@ type CeloTransfer implements Node {
   toAddressHash: AddressHash
   token: String
   tokenType: String
+  tokenId: Decimal
   transactionHash: FullHash
   value: Decimal
 }


### PR DESCRIPTION
This PR exposes `token_id` field to graphQL transfer queries.

Fixes https://github.com/celo-org/data-services/issues/353