### PR TITLE
Add indices to `updated_at` timestamp on various tables

### DIFF
--- a/apps/explorer/priv/repo/migrations/20220712081709_updated_at_indices.exs
+++ b/apps/explorer/priv/repo/migrations/20220712081709_updated_at_indices.exs
@@ -5,14 +5,15 @@ defmodule Explorer.Repo.Migrations.UpdatedAtIndices do
   @disable_ddl_transaction true
 
   @tables ~w(
-    token_transfers
     blocks
     celo_wallets
     address_current_token_balances
     address_token_balances
+    addresses
+    token_transfers
   )a
 
   def change do
-    for table <- @tables, do: create(index(table, [:updated_at], concurrently: true))
+    for table <- @tables, do: create_if_not_exists(index(table, [:updated_at], concurrently: true))
   end
 end

--- a/apps/explorer/priv/repo/migrations/20220712081709_updated_at_indices.exs
+++ b/apps/explorer/priv/repo/migrations/20220712081709_updated_at_indices.exs
@@ -1,0 +1,18 @@
+defmodule Explorer.Repo.Migrations.UpdatedAtIndices do
+  use Ecto.Migration
+
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
+  @tables ~w(
+    token_transfers
+    blocks
+    celo_wallets
+    address_current_token_balances
+    address_token_balances
+  )a
+
+  def change do
+    for table <- @tables, do: create(index(table, [:updated_at], concurrently: true))
+  end
+end


### PR DESCRIPTION
## Description

Adds indices to various tables in order to aid replication to bigquery.

## Testing

* Migrated and rolled back local db without issue

## Notes

* This migration will likely take a long time due to the size of the `token_transfers` table. It should be possible to run concurrently without impacting the indexing process, but issues have been seen before due to autovacuum processes causing locking problems (in this instance the indexer + web pods will have to be scaled down during the migration)
* Implements https://github.com/celo-org/data-services/issues/357