### PR TITLE
Bugfix/itx transfer index

### DIFF
--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -80,8 +80,9 @@ defmodule Indexer.Transform.TokenTransfers do
     %{token_transfers: [token_transfer | token_transfers], gold_token: gold_token}
   end
 
+  @doc "Discerns CELO token transfers from internal transactions"
   def parse_itx(txs, gold_token) do
-    initial_acc = %{token_transfers: [], gold_token: gold_token}
+    initial_acc = %{token_transfers: [], gold_token: gold_token, transfer_count: 0}
 
     txs
     |> Enum.filter(fn a -> a.value > 0 end)
@@ -91,24 +92,24 @@ defmodule Indexer.Transform.TokenTransfers do
     |> Enum.reduce(initial_acc, &do_parse_itx/2)
   end
 
-  defp do_parse_itx(tx, %{token_transfers: token_transfers, gold_token: gold_token}) do
-    to_hash = Map.get(tx, :to_address_hash, nil) || Map.get(tx, :created_contract_address_hash, nil)
+  defp do_parse_itx(itx, %{token_transfers: token_transfers, gold_token: gold_token, transfer_count: transfer_count}) do
+    to_hash = Map.get(itx, :to_address_hash, nil) || Map.get(itx, :created_contract_address_hash, nil)
 
     token_transfer = %{
-      amount: Decimal.new(tx.value),
-      block_number: tx.block_number,
-      block_hash: tx.block_hash,
+      amount: Decimal.new(itx.value),
+      block_number: itx.block_number,
+      block_hash: itx.block_hash,
       # Celo token transfers discerned from itx do not have a valid log index, so an id is calculated here to
       # satisfy schema constraints
-      log_index: -(tx.index + tx.transaction_index * 100_000_000),
-      from_address_hash: tx.from_address_hash,
+      log_index: -(transfer_count),
+      from_address_hash: itx.from_address_hash,
       to_address_hash: to_hash,
       token_contract_address_hash: gold_token,
-      transaction_hash: tx.transaction_hash,
+      transaction_hash: itx.transaction_hash,
       token_type: "ERC-20"
     }
 
-    %{token_transfers: [token_transfer | token_transfers], gold_token: gold_token}
+    %{token_transfers: [token_transfer | token_transfers], gold_token: gold_token, transfer_count: transfer_count + 1}
   end
 
   defp combine_comments([a | [b | tl]]) do

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -101,7 +101,7 @@ defmodule Indexer.Transform.TokenTransfers do
       block_hash: itx.block_hash,
       # Celo token transfers discerned from itx do not have a valid log index, so an id is calculated here to
       # satisfy schema constraints
-      log_index: -(transfer_count),
+      log_index: -transfer_count,
       from_address_hash: itx.from_address_hash,
       to_address_hash: to_hash,
       token_contract_address_hash: gold_token,

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -199,7 +199,7 @@ defmodule Indexer.Transform.TokenTransfersTest do
     log_indexes
     |> Enum.each(fn {index, count} ->
       assert count == 1, "Index #{index} should be unique but was found #{count} times"
-      assert index in -2147483648..2147483647
+      assert index in -2_147_483_648..2_147_483_647
     end)
   end
 
@@ -207,9 +207,12 @@ defmodule Indexer.Transform.TokenTransfersTest do
     itxi_txi_pairs = [
       {407, 26},
       {39, 34},
-      {39, 199}, # max tx_i found from sampling 10000000 values in live data
-      {39, 1000}, # 1000 transactions in block
-      {39, 9000} # 9000 transactions in block
+      # max tx_i found from sampling 10000000 values in live data
+      {39, 199},
+      # 1000 transactions in block
+      {39, 1000},
+      # 9000 transactions in block
+      {39, 9000}
     ]
 
     test_itx_maps =
@@ -229,8 +232,8 @@ defmodule Indexer.Transform.TokenTransfersTest do
 
     %{token_transfers: result} = TokenTransfers.parse_itx(test_itx_maps, "0xgoldtokenaddresshash")
 
-    #require IEx; IEx.pry
-    for transfer <- result, do: assert transfer.log_index in -2147483648..2147483647
+    # require IEx; IEx.pry
+    for transfer <- result, do: assert(transfer.log_index in -2_147_483_648..2_147_483_647)
   end
 
   defp truncated_hash("0x000000000000000000000000" <> rest) do

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -208,6 +208,8 @@ defmodule Indexer.Transform.TokenTransfersTest do
       {407, 26},
       {39, 34},
       {39, 199}, # max tx_i found from sampling 10000000 values in live data
+      {39, 1000}, # 1000 transactions in block
+      {39, 9000} # 9000 transactions in block
     ]
 
     test_itx_maps =

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -199,7 +199,36 @@ defmodule Indexer.Transform.TokenTransfersTest do
     log_indexes
     |> Enum.each(fn {index, count} ->
       assert count == 1, "Index #{index} should be unique but was found #{count} times"
+      assert index in -2147483648..2147483647
     end)
+  end
+
+  test "creates log indices within the valid range for postgres integer field" do
+    itxi_txi_pairs = [
+      {407, 26},
+      {39, 34},
+      {39, 199}, # max tx_i found from sampling 10000000 values in live data
+    ]
+
+    test_itx_maps =
+      itxi_txi_pairs
+      |> Enum.map(fn {itx_i, tx_i} ->
+        %{
+          value: 1,
+          block_number: 13_606_235,
+          block_hash: "0xtestdata",
+          from_address_hash: "0xfrom",
+          to_address_hash: "0xto",
+          index: itx_i,
+          transaction_index: tx_i,
+          transaction_hash: "0xtransaction hash"
+        }
+      end)
+
+    %{token_transfers: result} = TokenTransfers.parse_itx(test_itx_maps, "0xgoldtokenaddresshash")
+
+    #require IEx; IEx.pry
+    for transfer <- result, do: assert transfer.log_index in -2147483648..2147483647
   end
 
   defp truncated_hash("0x000000000000000000000000" <> rest) do


### PR DESCRIPTION
### Description

Fixes https://github.com/celo-org/data-services/issues/366 by setting the index to be the negative index of this token transfer within the block. This works on the assumption that 

* All internal transactions for a given block are processed in the same batch
* Only CELO transfers have a negative log index for token transfers
 
 ### Other changes

* Changed some variable names to reflect usage

### Tested

* Developed test and ran suite

