### PR TITLE
Parallelise metrics cron operations

### DIFF
--- a/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
@@ -29,7 +29,6 @@ defmodule Indexer.Prometheus.MetricsCron do
 
   @impl true
   def handle_info(:import_and_reschedule, state) do
-
     pending_transactions()
 
     block_age_and_gas_metrics()
@@ -43,7 +42,6 @@ defmodule Indexer.Prometheus.MetricsCron do
     number_of_deadlocks()
 
     longest_query_duration()
-
 
     rpc_response_times()
 
@@ -135,9 +133,7 @@ defmodule Indexer.Prometheus.MetricsCron do
     :telemetry.execute([:indexer, :blocks, :last_block_number], %{value: last_block_number})
   end
 
-
-
-    defp calculate_and_add_rpc_response_metrics(id, [start, finish]) do
+  defp calculate_and_add_rpc_response_metrics(id, [start, finish]) do
     RPCInstrumenter.instrument(%{
       time: Map.get(finish, :finish) - Map.get(start, :start),
       method: Map.get(start, :method),

--- a/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
@@ -42,7 +42,7 @@ defmodule Indexer.Prometheus.MetricsCron do
   ]
 
   @impl true
-  def handle_info(:import_and_reschedule, state = %{running_operations: running}) do
+  def handle_info(:import_and_reschedule, %{running_operations: running} = state) do
     unless running == [] do
       Logger.info("MetricsCron scheduled, tasks still running: #{Enum.join(running, ",")}")
     end
@@ -65,7 +65,7 @@ defmodule Indexer.Prometheus.MetricsCron do
   end
 
   @impl true
-  def handle_info({_task_ref, {:completed, operation}}, state = %{running_operations: ops}) do
+  def handle_info({_task_ref, {:completed, operation}}, %{running_operations: ops} = state) do
     {:noreply, %{state | running_operations: List.delete(ops, operation)}}
   end
 

--- a/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
@@ -112,12 +112,8 @@ defmodule Indexer.Prometheus.MetricsCron do
   end
 
   def transaction_count do
-    response_times = RpcResponseEts.get_all()
-
-    response_times
-    |> Enum.filter(&Map.has_key?(elem(&1, 1), :finish))
-    |> Enum.map(&elem(&1, 0))
-    |> Enum.each(&calculate_and_add_rpc_response_metrics(&1, :proplists.get_all_values(&1, response_times)))
+    total_transaction_count = Chain.transaction_estimated_count()
+    :telemetry.execute([:indexer, :transactions, :total], %{value: total_transaction_count})
   end
 
   def address_count do

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -188,7 +188,10 @@ defmodule Indexer.Supervisor do
 
     fetchers_with_metrics =
       if metrics_enabled do
-        [{MetricsCron, [[]]} | fetchers_with_amb_bridge_mediators]
+        [
+          {MetricsCron, [[]]},
+          {Task.Supervisor, name: Indexer.Prometheus.MetricsCron.TaskSupervisor} | fetchers_with_amb_bridge_mediators
+        ]
       else
         fetchers_with_amb_bridge_mediators
       end

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -188,10 +188,12 @@ defmodule Indexer.Supervisor do
 
     fetchers_with_metrics =
       if metrics_enabled do
-        [
+        metrics_processes = [
           {MetricsCron, [[]]},
-          {Task.Supervisor, name: Indexer.Prometheus.MetricsCron.TaskSupervisor} | fetchers_with_amb_bridge_mediators
+          {Task.Supervisor, name: Indexer.Prometheus.MetricsCron.TaskSupervisor}
         ]
+
+        metrics_processes ++ fetchers_with_amb_bridge_mediators
       else
         fetchers_with_amb_bridge_mediators
       end


### PR DESCRIPTION
### Description

Runs `metrics_cron` operatoins in parallel so that slow db queries don't prevent the exposure of all metrics. Refactors the structure of the module to be discrete functions rather than a single large function.

### Tested

* Ran locally against staging and saw metrics displayed on the prometheus endpoint

