### PR TITLE
Fix updated transactions issue

### DIFF
--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -82,7 +82,7 @@ defmodule Indexer.Transform.TokenTransfers do
 
   @doc "Discerns CELO token transfers from internal transactions"
   def parse_itx(txs, gold_token) do
-    initial_acc = %{token_transfers: [], gold_token: gold_token, transfer_count: 1}
+    initial_acc = %{token_transfers: [], gold_token: gold_token, transfer_count: 0}
 
     txs
     |> Enum.filter(fn a -> a.value > 0 end)
@@ -101,7 +101,9 @@ defmodule Indexer.Transform.TokenTransfers do
       block_hash: itx.block_hash,
       # Celo token transfers discerned from itx do not have a valid log index, so an id is calculated here to
       # satisfy schema constraints
-      log_index: -transfer_count,
+      # and it needs to be negative (starting with -1) not to generate conflicts with
+      # log_index for token transfers from block transactions as they start from 0
+      log_index: -1 * (transfer_count + 1),
       from_address_hash: itx.from_address_hash,
       to_address_hash: to_hash,
       token_contract_address_hash: gold_token,

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -82,7 +82,7 @@ defmodule Indexer.Transform.TokenTransfers do
 
   @doc "Discerns CELO token transfers from internal transactions"
   def parse_itx(txs, gold_token) do
-    initial_acc = %{token_transfers: [], gold_token: gold_token, transfer_count: 0}
+    initial_acc = %{token_transfers: [], gold_token: gold_token, transfer_count: 1}
 
     txs
     |> Enum.filter(fn a -> a.value > 0 end)

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -20,7 +20,6 @@ defmodule Indexer.Transform.TokenTransfersTest do
             second_topic: "0x000000000000000000000000556813d9cc20acfe8388af029a679d34a63388db",
             third_topic: "0x00000000000000000000000092148dd870fa1b7c4700f2bd7f44238821c26f73",
             transaction_hash: "0x43dfd761974e8c3351d285ab65bee311454eb45b149a015fe7804a33252f19e5",
-            # block_hash: "0x43dfd761974e8c3351d285ab65bee311454eb45b149a015fe7804a33252f19e5",
             type: "mined"
           },
           %{
@@ -191,10 +190,59 @@ defmodule Indexer.Transform.TokenTransfersTest do
         }
       end)
 
-    %{token_transfers: result} = TokenTransfers.parse_itx(test_itx_maps, "0xgoldtokenaddresshash")
+    %{token_transfers: result_itx} = TokenTransfers.parse_itx(test_itx_maps, "0xgoldtokenaddresshash")
+
+    %{token_transfers: result_tx} =
+      TokenTransfers.parse([
+        %{
+          address_hash: "0xf2eec76e45b328df99a34fa696320a262cb92154",
+          block_number: 3_530_917,
+          block_hash: "0x79594150677f083756a37eee7b97ed99ab071f502104332cb3835bac345711ca",
+          data: "0x000000000000000000000000000000000000000000000000ebec21ee1da40000",
+          first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          fourth_topic: nil,
+          index: 0,
+          second_topic: "0x000000000000000000000000556813d9cc20acfe8388af029a679d34a63388db",
+          third_topic: "0x00000000000000000000000092148dd870fa1b7c4700f2bd7f44238821c26f73",
+          transaction_hash: "0x43dfd761974e8c3351d285ab65bee311454eb45b149a015fe7804a33252f19e5",
+          type: "mined"
+        },
+        %{
+          address_hash: "0xf2eec76e45b328df99a34fa696320a262cb92154",
+          block_number: 3_530_917,
+          block_hash: "0x79594150677f083756a37eee7b97ed99ab071f502104332cb3835bac345711ca",
+          data: "0x000000000000000000000000000000000000000000000000ebec21ee1da40000",
+          first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          fourth_topic: nil,
+          index: 1,
+          second_topic: "0x000000000000000000000000556813d9cc20acfe8388af029a679d34a63388db",
+          third_topic: "0x00000000000000000000000092148dd870fa1b7c4700f2bd7f44238821c26f73",
+          transaction_hash: "0x43dfd761974e8c3351d285ab65bee311454eb45b149a015fe7804a33252f19e5",
+          type: "mined"
+        },
+        %{
+          address_hash: "0xf2eec76e45b328df99a34fa696320a262cb92154",
+          block_number: 3_530_917,
+          block_hash: "0x79594150677f083756a37eee7b97ed99ab071f502104332cb3835bac345711ca",
+          data: "0x000000000000000000000000000000000000000000000000ebec21ee1da40000",
+          first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          fourth_topic: nil,
+          index: 2,
+          second_topic: "0x000000000000000000000000556813d9cc20acfe8388af029a679d34a63388db",
+          third_topic: "0x00000000000000000000000092148dd870fa1b7c4700f2bd7f44238821c26f73",
+          transaction_hash: "0x43dfd761974e8c3351d285ab65bee311454eb45b149a015fe7804a33252f19e5",
+          type: "mined"
+        }
+      ])
+
+    # asset MapSet.new(Enum.map(result_itx, fn itx -> itx.log_index end)));
+    # IO.inspect(MapSet.new(Enum.map(result_tx, fn tx -> tx.log_index end)));
 
     # create a map of log_index -> count of log_index in result
-    log_indexes = result |> Enum.map(& &1.log_index) |> Enum.reduce(%{}, &Map.put(&2, &1, Map.get(&2, &1, 0) + 1))
+    log_indexes =
+      Enum.concat(result_itx, result_tx)
+      |> Enum.map(& &1.log_index)
+      |> Enum.reduce(%{}, &Map.put(&2, &1, Map.get(&2, &1, 0) + 1))
 
     log_indexes
     |> Enum.each(fn {index, count} ->

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -235,9 +235,6 @@ defmodule Indexer.Transform.TokenTransfersTest do
         }
       ])
 
-    # asset MapSet.new(Enum.map(result_itx, fn itx -> itx.log_index end)));
-    # IO.inspect(MapSet.new(Enum.map(result_tx, fn tx -> tx.log_index end)));
-
     # create a map of log_index -> count of log_index in result
     log_indexes =
       Enum.concat(result_itx, result_tx)


### PR DESCRIPTION
### Description

Currently every every first token transfer derived from internal transactions would overwrite data from first transaction in the block (when `log_index` equals to 0). Consequent numbers for internal transactions would be then -1, -2 and not generating conflict on `block_hash, log_index`, so the fix is to start from -1 instead of 0.

### Issues

Fixes https://github.com/celo-org/data-services/issues/390
