### PR TITLE
Fixed txlist pagination issue

### DIFF
--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -506,7 +506,7 @@ defmodule Explorer.Etherscan do
       from(
         t in Transaction,
         order_by: [{^options.order_by_direction, t.block_number}],
-        limit: ^options.page_size * 3,
+        limit: ^page_size_max() * 3,
         select: %{
           hash: t.hash
         }


### PR DESCRIPTION
### Description

In https://github.com/celo-org/blockscout/pull/533 the txlist API query was optimized. It works properly when pagination parameters are omitted defaulting to the max of 10_000 items in the result. It fails to get past page 3 when the page size is explicitly set.

 ### Other changes

No.

### Tested

Added a unit test.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/381

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
