### PR TITLE
Reenable empty blocks sanitizer (with optimized query)

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -1,7 +1,7 @@
 defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   @moduledoc """
   Periodically checks empty blocks starting from the head of the chain, detects for which blocks transactions should be refetched
-  and loose consensus for block in order to refetch transactions.
+  and lose consensus for block in order to refetch transactions.
   """
 
   use GenServer
@@ -135,9 +135,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
     from(block in Block,
       where: is_nil(block.is_empty),
       where: block.consensus == true,
-      order_by: [asc: block.hash],
       limit: ^limit,
-      offset: 1000,
       lock: "FOR UPDATE"
     )
   end
@@ -150,8 +148,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
         inner_join: transaction in Transaction,
         on: q.number == transaction.block_number,
         select: q.hash,
-        distinct: q.hash,
-        order_by: [asc: q.hash]
+        distinct: q.hash
       )
 
     query
@@ -166,8 +163,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
         left_join: transaction in Transaction,
         on: q.number == transaction.block_number,
         where: is_nil(transaction.block_number),
-        select: {q.number, q.hash},
-        order_by: [asc: q.hash]
+        select: {q.number, q.hash}
       )
 
     query


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)_

### Description

As we need to reenable empty blocks sanitizer the query needs to be optimised. This PR is an attempt to achieve better performance.

Fixes https://github.com/celo-org/data-services/issues/408