### PR TITLE
Changed pending txs query

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3542,6 +3542,16 @@ defmodule Explorer.Chain do
     |> Repo.all(timeout: :infinity)
   end
 
+  def pending_transactions_count do
+    query =
+      from(transaction in Transaction,
+        where: is_nil(transaction.block_hash) and (is_nil(transaction.error) or transaction.error != "dropped/replaced")
+      )
+
+    query
+    |> Repo.aggregate(:count, :hash)
+  end
+
   @doc """
   Returns the list of empty blocks from the DB which have not marked with `t:Explorer.Chain.Block.is_empty/0`.
   This query used for initializtion of Indexer.EmptyBlocksSanitizer

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2150,7 +2150,7 @@ defmodule Explorer.Chain do
           """
           SELECT
           COUNT(*) AS last_n_blocks_count,
-          EXTRACT(EPOCH FROM (DATE_TRUNC('second', NOW()::timestamp) - MAX(timestamp))) AS last_block_age,
+          CAST(EXTRACT(EPOCH FROM (DATE_TRUNC('second', NOW()::timestamp) - MAX(timestamp))) AS INTEGER) AS last_block_age,
           AVG((gas_used/gas_limit)*100) AS average_gas_used
           FROM blocks
           WHERE number BETWEEN $1 AND $2;

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3534,22 +3534,16 @@ defmodule Explorer.Chain do
 
   def pending_transactions_list do
     query =
-      from(transaction in Transaction,
-        where: is_nil(transaction.block_hash) and (is_nil(transaction.error) or transaction.error != "dropped/replaced")
-      )
-
-    query
-    |> Repo.all(timeout: :infinity)
+      Transaction
+      |> pending_transactions_query()
+      |> Repo.all(timeout: :infinity)
   end
 
   def pending_transactions_count do
     query =
-      from(transaction in Transaction,
-        where: is_nil(transaction.block_hash) and (is_nil(transaction.error) or transaction.error != "dropped/replaced")
-      )
-
-    query
-    |> Repo.aggregate(:count, :hash)
+      Transaction
+      |> pending_transactions_query()
+      |> Repo.aggregate(:count, :hash)
   end
 
   @doc """

--- a/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/prometheus/metrics_cron.ex
@@ -73,8 +73,8 @@ defmodule Indexer.Prometheus.MetricsCron do
   def handle_info({:DOWN, _, _, _, :normal}, state), do: {:noreply, state}
 
   def pending_transactions do
-    pending_transactions_list_from_db = Chain.pending_transactions_list()
-    :telemetry.execute([:indexer, :transactions, :pending], %{value: Enum.count(pending_transactions_list_from_db)})
+    pending_transactions_count = Chain.pending_transactions_count()
+    :telemetry.execute([:indexer, :transactions, :pending], %{value: pending_transactions_count})
   end
 
   def average_block_time do


### PR DESCRIPTION
### Description

The pending TXs metric collection is very slow as it fetches all rows from the db instead of just the total number. Since it's a heavy request and it's executed very often it generates a significant load on the database.
This PR changes it.

 ### Other changes

Explicit casting to integer of the age of the latest block (seems to be a change between Postgres versions).

### Tested

Yes.

### Issues

 - Fixes [#[issue number here]](https://github.com/celo-org/data-services/issues/424)

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
