### PR TITLE
Updated internal TXs fetcher concurrency settings

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -21,8 +21,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   @behaviour BufferedTask
 
-  @max_batch_size 1
-  @max_concurrency 20
+  @max_batch_size 3
+  @max_concurrency 55
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),


### PR DESCRIPTION
### Description

Increases concurrency and batch size settings of the internal TXs fetcher. Higher values work better with the larger pool of archive nodes.
 
 ### Other changes

No.

### Tested

Tested in production.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/435

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
