### PR TITLE
Event backfill process

### DIFF
--- a/apps/explorer/lib/explorer/celo/telemetry.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry.ex
@@ -57,8 +57,9 @@ defmodule Explorer.Celo.Telemetry do
 
       start = Telemetry.start(:event_name)
       try do
-        call_function()
+        result = call_function()
         Telemetry.stop(:event_name, start)
+        result
       rescue
         e ->
           Telemetry.exception(:event_name, start, :exception, e, __STACKTRACE__)
@@ -70,8 +71,9 @@ defmodule Explorer.Celo.Telemetry do
       start_time = Telemetry.start(unquote(event_name))
 
       try do
-        unquote(call)
+        result = unquote(call)
         Telemetry.stop(unquote(event_name), start_time)
+        result
       rescue
         e ->
           Telemetry.exception(unquote(event_name), start_time, :exception, e, __STACKTRACE__)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2857,7 +2857,7 @@ defmodule Explorer.Chain do
         on: sc.id == cet.smart_contract_id,
         where: cet.backfilled == false,
         where: cet.enabled == true,
-        select: {sc.address_hash, cet.topic}
+        select: {sc.address_hash, cet.topic, cet.id}
       )
 
     Repo.stream_reduce(query, initial, reducer)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -86,7 +86,7 @@ defmodule Explorer.Chain do
     Uncles
   }
 
-  alias Explorer.Chain.Celo.{TrackedContractEvent, ContractEventTracking}
+  alias Explorer.Chain.Celo.ContractEventTracking
   alias Explorer.Chain.Celo.TransactionStats, as: CeloTxStats
 
   alias Explorer.Chain.Import.Runner

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -86,6 +86,7 @@ defmodule Explorer.Chain do
     Uncles
   }
 
+  alias Explorer.Chain.Celo.{TrackedContractEvent, ContractEventTracking}
   alias Explorer.Chain.Celo.TransactionStats, as: CeloTxStats
 
   alias Explorer.Chain.Import.Runner
@@ -2843,6 +2844,20 @@ defmodule Explorer.Chain do
         where: celo_pending_ops.fetch_epoch_data,
         select: %{block_hash: b.hash, block_number: b.number, block_timestamp: b.timestamp},
         order_by: [asc: b.number]
+      )
+
+    Repo.stream_reduce(query, initial, reducer)
+  end
+
+  def stream_events_to_backfill(initial, reducer) do
+    query =
+      from(
+        cet in ContractEventTracking,
+        join: sc in SmartContract,
+        on: sc.id == cet.smart_contract_id,
+        where: cet.backfilled == false,
+        where: cet.enabled == true,
+        select: {sc.address_hash, cet.topic}
       )
 
     Repo.stream_reduce(query, initial, reducer)

--- a/apps/explorer/lib/explorer/chain/celo/contract_event_tracking.ex
+++ b/apps/explorer/lib/explorer/chain/celo/contract_event_tracking.ex
@@ -23,6 +23,10 @@ defmodule Explorer.Chain.Celo.ContractEventTracking do
         }
 
   @attrs ~w(
+          abi name topic smart_contract_id backfilled enabled
+        )a
+
+  @required ~w(
           abi name topic smart_contract_id
         )a
 
@@ -78,7 +82,7 @@ defmodule Explorer.Chain.Celo.ContractEventTracking do
   def changeset(%__MODULE__{} = event_tracking, %{smart_contract_id: _scid} = attrs) do
     event_tracking
     |> cast(attrs, @attrs)
-    |> validate_required(@attrs)
+    |> validate_required(@required)
     |> unique_constraint(:unique_event_topic_on_smart_contract, name: :smart_contract_id_topic)
   end
 

--- a/apps/explorer/lib/explorer/chain/celo/tracked_contract_event.ex
+++ b/apps/explorer/lib/explorer/chain/celo/tracked_contract_event.ex
@@ -81,7 +81,8 @@ defmodule Explorer.Chain.Celo.TrackedContractEvent do
           topic: fragment("EXCLUDED.topic"),
           params: fragment("EXCLUDED.params"),
           contract_address_hash: fragment("EXCLUDED.contract_address_hash"),
-          transaction_hash: fragment("EXCLUDED.transaction_hash")
+          transaction_hash: fragment("EXCLUDED.transaction_hash"),
+          updated_at: fragment("EXCLUDED.updated_at")
         ]
       ],
       where:

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -394,6 +394,12 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
               or_where(acc, [it], it.transaction_hash == ^transaction_hash and it.index == ^index)
             end)
 
+          unless File.exists?("/tmp/internal_tx_query") do
+            sql = Ecto.Adapters.SQL.to_sql(:all, Explorer.Repo, delete_query)
+            r = File.write("/tmp/internal_tx_query", sql)
+            Logger.info("!!!!!!  wrote itx #{inspect(r)}")
+          end
+
           # ShareLocks order already enforced by `acquire_pending_internal_txs` (see docs: sharelocks.md)
           {count, result} = repo.delete_all(delete_query, [])
 

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -394,12 +394,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
               or_where(acc, [it], it.transaction_hash == ^transaction_hash and it.index == ^index)
             end)
 
-          unless File.exists?("/tmp/internal_tx_query") do
-            sql = Ecto.Adapters.SQL.to_sql(:all, Explorer.Repo, delete_query)
-            r = File.write("/tmp/internal_tx_query", sql)
-            Logger.info("!!!!!!  wrote itx #{inspect(r)}")
-          end
-
           # ShareLocks order already enforced by `acquire_pending_internal_txs` (see docs: sharelocks.md)
           {count, result} = repo.delete_all(delete_query, [])
 

--- a/apps/explorer/priv/repo/migrations/20220829132237_logs_contract_topic_index.exs
+++ b/apps/explorer/priv/repo/migrations/20220829132237_logs_contract_topic_index.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.LogsContractTopicIndex do
+  use Ecto.Migration
+
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
+  def change do
+    create_if_not_exists(index(:logs, [:address_hash, :first_topic, :block_number], concurrently: true))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20220829132237_logs_contract_topic_index.exs
+++ b/apps/explorer/priv/repo/migrations/20220829132237_logs_contract_topic_index.exs
@@ -7,7 +7,7 @@ defmodule Explorer.Repo.Migrations.LogsContractTopicLogIndexIndex do
   def change do
     create_if_not_exists(index(:logs, [:address_hash, :first_topic, :block_number], concurrently: true))
 
-    #above index obsoletes existing address_hash index
-    drop_if_exists(index(:logs,[:address_hash], concurrently: true))
+    # above index obsoletes existing address_hash index
+    drop_if_exists(index(:logs, [:address_hash], concurrently: true))
   end
 end

--- a/apps/explorer/priv/repo/migrations/20220829132237_logs_contract_topic_index.exs
+++ b/apps/explorer/priv/repo/migrations/20220829132237_logs_contract_topic_index.exs
@@ -1,4 +1,4 @@
-defmodule Explorer.Repo.Migrations.LogsContractTopicIndex do
+defmodule Explorer.Repo.Migrations.LogsContractTopicLogIndexIndex do
   use Ecto.Migration
 
   @disable_migration_lock true
@@ -6,5 +6,8 @@ defmodule Explorer.Repo.Migrations.LogsContractTopicIndex do
 
   def change do
     create_if_not_exists(index(:logs, [:address_hash, :first_topic, :block_number], concurrently: true))
+
+    #above index obsoletes existing address_hash index
+    drop_if_exists(index(:logs,[:address_hash], concurrently: true))
   end
 end

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -79,6 +79,7 @@ config :logger_json, :indexer,
        block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :indexer]
 
+config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]
 
 config :logger, :logger_backend, level: :error
 # config :logger, :indexer,

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -79,7 +79,6 @@ config :logger_json, :indexer,
        block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :indexer]
 
-config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]
 
 config :logger, :logger_backend, level: :error
 # config :logger, :indexer,

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -2,6 +2,8 @@ import Config
 
 config :indexer, Indexer.Tracer, env: "production", disabled?: true
 
+config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]
+
 config :logger, :indexer,
   level: :info,
   path: Path.absname("logs/prod/indexer.log"),

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -2,8 +2,6 @@ import Config
 
 config :indexer, Indexer.Tracer, env: "production", disabled?: true
 
-config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]
-
 config :logger, :indexer,
   level: :info,
   path: Path.absname("logs/prod/indexer.log"),

--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -409,13 +409,17 @@ defmodule Indexer.BufferedTask do
     GenServer.call(pid, {:push_back, entries})
   end
 
-  defp push_back(%BufferedTask{bound_queue: bound_queue, callback_module: callback_module, dedup_entries: dedup} = state, entries) when is_list(entries) do
+  defp push_back(
+         %BufferedTask{bound_queue: bound_queue, callback_module: callback_module, dedup_entries: dedup} = state,
+         entries
+       )
+       when is_list(entries) do
     entries_to_push =
-    if dedup do
-      callback_module.dedup_entries(state, entries)
-    else
-      entries
-    end
+      if dedup do
+        callback_module.dedup_entries(state, entries)
+      else
+        entries
+      end
 
     new_bound_queue =
       case BoundQueue.push_back_until_maximum_size(bound_queue, entries_to_push) do

--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -556,14 +556,12 @@ defmodule Indexer.BufferedTask do
       def dedup_entries(%BufferedTask{dedup_entries: false}, entries), do: entries
 
       def dedup_entries(
-            %BufferedTask{dedup_entries: true, task_ref_to_batch: task_ref_to_batch, bound_queue: bound_queue},
+            %BufferedTask{dedup_entries: true, task_ref_to_batch: task_ref_to_batch, bound_queue: bound_queue} = task,
             entries
           ) do
         running_entries =
-          task_ref_to_batch
-          |> Map.values()
-          |> List.flatten()
-          |> Enum.uniq()
+          task
+          |> currently_processed_items()
           |> MapSet.new()
 
         queued_entries = MapSet.new(bound_queue)
@@ -573,6 +571,13 @@ defmodule Indexer.BufferedTask do
         |> MapSet.difference(running_entries)
         |> MapSet.difference(queued_entries)
         |> MapSet.to_list()
+      end
+
+      def currently_processed_items(%BufferedTask{task_ref_to_batch: task_ref_to_batch}) do
+        task_ref_to_batch
+        |> Map.values()
+        |> List.flatten()
+        |> Enum.uniq()
       end
 
       defoverridable dedup_entries: 2

--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -155,6 +155,11 @@ defmodule Indexer.BufferedTask do
   @callback run(entries, state) :: :ok | :retry | {:retry, new_entries :: list}
 
   @doc """
+    A function used to remove duplicate entries from the buffer
+  """
+  @callback dedup_entries(%BufferedTask{}, entries) :: entries
+
+  @doc """
   Buffers list of entries for future async execution.
   """
   @spec buffer(GenServer.name(), entries(), timeout()) :: :ok
@@ -404,8 +409,13 @@ defmodule Indexer.BufferedTask do
     GenServer.call(pid, {:push_back, entries})
   end
 
-  defp push_back(%BufferedTask{bound_queue: bound_queue} = state, entries) when is_list(entries) do
-    entries_to_push = dedup_entries(state, entries)
+  defp push_back(%BufferedTask{bound_queue: bound_queue, callback_module: callback_module, dedup_entries: dedup} = state, entries) when is_list(entries) do
+    entries_to_push =
+    if dedup do
+      callback_module.dedup_entries(state, entries)
+    else
+      entries
+    end
 
     new_bound_queue =
       case BoundQueue.push_back_until_maximum_size(bound_queue, entries_to_push) do
@@ -423,28 +433,6 @@ defmodule Indexer.BufferedTask do
       end
 
     %BufferedTask{state | bound_queue: new_bound_queue}
-  end
-
-  defp dedup_entries(%BufferedTask{dedup_entries: false}, entries), do: entries
-
-  defp dedup_entries(
-         %BufferedTask{dedup_entries: true, task_ref_to_batch: task_ref_to_batch, bound_queue: bound_queue},
-         entries
-       ) do
-    running_entries =
-      task_ref_to_batch
-      |> Map.values()
-      |> List.flatten()
-      |> Enum.uniq()
-      |> MapSet.new()
-
-    queued_entries = MapSet.new(bound_queue)
-
-    entries
-    |> MapSet.new()
-    |> MapSet.difference(running_entries)
-    |> MapSet.difference(queued_entries)
-    |> MapSet.to_list()
   end
 
   defp take_batch(%BufferedTask{bound_queue: bound_queue, max_batch_size: max_batch_size} = state) do
@@ -559,5 +547,35 @@ defmodule Indexer.BufferedTask do
     %BufferedTask{state | current_buffer: []}
     |> push_back(entries)
     |> flush()
+  end
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour BufferedTask
+
+      def dedup_entries(%BufferedTask{dedup_entries: false}, entries), do: entries
+
+      def dedup_entries(
+            %BufferedTask{dedup_entries: true, task_ref_to_batch: task_ref_to_batch, bound_queue: bound_queue},
+            entries
+          ) do
+        running_entries =
+          task_ref_to_batch
+          |> Map.values()
+          |> List.flatten()
+          |> Enum.uniq()
+          |> MapSet.new()
+
+        queued_entries = MapSet.new(bound_queue)
+
+        entries
+        |> MapSet.new()
+        |> MapSet.difference(running_entries)
+        |> MapSet.difference(queued_entries)
+        |> MapSet.to_list()
+      end
+
+      defoverridable dedup_entries: 2
+    end
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/block_reward.ex
+++ b/apps/indexer/lib/indexer/fetcher/block_reward.ex
@@ -23,7 +23,7 @@ defmodule Indexer.Fetcher.BlockReward do
   alias Indexer.Fetcher.CoinBalance
   alias Indexer.Transform.{AddressCoinBalances, AddressCoinBalancesDaily, Addresses}
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: :timer.seconds(3),

--- a/apps/indexer/lib/indexer/fetcher/celo_account.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_account.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.CeloAccount do
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_retries 3
 

--- a/apps/indexer/lib/indexer/fetcher/celo_epoch_data.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_epoch_data.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Fetcher.CeloEpochData do
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @spec async_fetch([%{block_number: Block.block_number()}]) :: :ok
   def async_fetch(blocks) when is_list(blocks) do

--- a/apps/indexer/lib/indexer/fetcher/celo_unlocked.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_unlocked.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.CeloUnlocked do
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_retries 3
 

--- a/apps/indexer/lib/indexer/fetcher/celo_validator.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_validator.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.CeloValidator do
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_retries 3
 

--- a/apps/indexer/lib/indexer/fetcher/celo_validator_group.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_validator_group.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.CeloValidatorGroup do
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_retries 3
 

--- a/apps/indexer/lib/indexer/fetcher/celo_validator_history.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_validator_history.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.CeloValidatorHistory do
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_retries 3
 

--- a/apps/indexer/lib/indexer/fetcher/celo_voters.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo_voters.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.CeloVoters do
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_retries 3
 

--- a/apps/indexer/lib/indexer/fetcher/coin_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance.ex
@@ -17,7 +17,7 @@ defmodule Indexer.Fetcher.CoinBalance do
   alias Explorer.Chain.Cache.Accounts
   alias Indexer.{BufferedTask, Tracer}
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: :timer.seconds(3),

--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -16,7 +16,7 @@ defmodule Indexer.Fetcher.ContractCode do
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Transform.Addresses
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_batch_size 10
   @max_concurrency 4

--- a/apps/indexer/lib/indexer/fetcher/event_backfill.ex
+++ b/apps/indexer/lib/indexer/fetcher/event_backfill.ex
@@ -58,26 +58,27 @@ defmodule Indexer.Fetcher.EventBackfill do
   end
 
   def missing_events_query({contract_address, topic}, {block_number, log_index} \\ {0,0}) do
-    Log
-    |> from(
-      inner_join: ccc in "celo_core_contracts",
-      on: ccc.address_hash == l.address_hash,
-      select: %{
-        first_topic: l.first_topic,
-        second_topic: l.second_topic,
-        third_topic: l.third_topic,
-        fourth_topic: l.fourth_topic,
-        data: l.data,
-        address_hash: l.address_hash,
-        transaction_hash: l.transaction_hash,
-        block_number: l.block_number,
-        index: l.index
-      },
-      where: l.first_topic == ^topic and {l.block_number, l.index} > {^block_number, ^index},
-      order_by: [asc: l.block_number, asc: l.index],
-      limit: @batch_size
-    )
+#    Log
+#    |> from(
+#      inner_join: ccc in "celo_core_contracts",
+#      on: ccc.address_hash == l.address_hash,
+#      select: %{
+#        first_topic: l.first_topic,
+#        second_topic: l.second_topic,
+#        third_topic: l.third_topic,
+#        fourth_topic: l.fourth_topic,
+#        data: l.data,
+#        address_hash: l.address_hash,
+#        transaction_hash: l.transaction_hash,
+#        block_number: l.block_number,
+#        index: l.index
+#      },
+#      where: l.first_topic == ^topic and {l.block_number, l.index} > {^block_number, ^index},
+#      order_by: [asc: l.block_number, asc: l.index],
+#      limit: @batch_size
+#    )
 
+  nil
   end
 end
 

--- a/apps/indexer/lib/indexer/fetcher/event_backfill.ex
+++ b/apps/indexer/lib/indexer/fetcher/event_backfill.ex
@@ -25,6 +25,8 @@ defmodule Indexer.Fetcher.EventBackfill do
     max_batch_size: 1,
     max_concurrency: 1,
     dedup_entries: true,
+    poll: true,
+    poll_interval: :timer.minutes(3),
     task_supervisor: Indexer.Fetcher.EventBackfill.TaskSupervisor,
     metadata: [fetcher: :event_backfill],
     state: %{

--- a/apps/indexer/lib/indexer/fetcher/event_backfill.ex
+++ b/apps/indexer/lib/indexer/fetcher/event_backfill.ex
@@ -1,0 +1,83 @@
+defmodule Indexer.Fetcher.EventBackfill do
+  @moduledoc "Fetch historical and missing events for the event processor"
+
+  use Indexer.Fetcher
+  require Logger
+
+  alias Explorer.Celo.Events.Transformer
+  alias Explorer.Celo.Telemetry
+  alias Explorer.Chain
+  alias Explorer.Chain.Log
+  alias Indexer.{BufferedTask, Tracer}
+  alias Indexer.Celo.TrackedEventCache
+  alias Indexer.Fetcher.Util
+
+  use BufferedTask
+  import Ecto.Query
+
+  @defaults [
+    flush_interval: :timer.seconds(3),
+    max_batch_size: 1,
+    max_concurrency: 2,
+    dedup_entries: true,
+    task_supervisor: Indexer.Fetcher.EventBackfill.TaskSupervisor,
+    metadata: [fetcher: :event_backfill]
+  ]
+
+  @import_timeout 60_000
+
+  @impl BufferedTask
+  def init(initial, _reducer, _) do
+    initial
+  end
+
+  @doc false
+  def child_spec([init_options, gen_server_options]) do
+    init_options
+    |> Keyword.merge(@defaults)
+    |> Util.default_child_spec(gen_server_options, __MODULE__)
+  end
+
+  #deduplicates entries based on the contract address and topic
+  @impl BufferedTask
+  def dedup_entries( %BufferedTask{dedup_entries: true, task_ref_to_batch: task_ref_to_batch, bound_queue: bound_queue} = task, entries) do
+    contract_address_and_topic = fn {ct, _progress, _strategy} -> ct end
+
+    running_entries =
+      task
+      |> currently_processed_items()
+      |> then(&(&1 ++ bound_queue))
+      |> Enum.map(contract_address_and_topic)
+      |> MapSet.new()
+
+    entries
+    |> Enum.uniq_by(contract_address_and_topic)
+    |> Enum.filter(fn i ->
+      MapSet.member?(running_entries, contract_address_and_topic.(i)) == false
+    end)
+  end
+
+  def missing_events_query({contract_address, topic}, {block_number, log_index} \\ {0,0}) do
+    Log
+    |> from(
+      inner_join: ccc in "celo_core_contracts",
+      on: ccc.address_hash == l.address_hash,
+      select: %{
+        first_topic: l.first_topic,
+        second_topic: l.second_topic,
+        third_topic: l.third_topic,
+        fourth_topic: l.fourth_topic,
+        data: l.data,
+        address_hash: l.address_hash,
+        transaction_hash: l.transaction_hash,
+        block_number: l.block_number,
+        index: l.index
+      },
+      where: l.first_topic == ^topic and {l.block_number, l.index} > {^block_number, ^index},
+      order_by: [asc: l.block_number, asc: l.index],
+      limit: @batch_size
+    )
+
+  end
+end
+

--- a/apps/indexer/lib/indexer/fetcher/event_processor.ex
+++ b/apps/indexer/lib/indexer/fetcher/event_processor.ex
@@ -13,7 +13,7 @@ defmodule Indexer.Fetcher.EventProcessor do
   alias Indexer.Celo.TrackedEventCache
   alias Indexer.Fetcher.Util
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: :timer.seconds(3),

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
   alias Indexer.Fetcher.TokenBalance
   alias Indexer.Transform.{Addresses, TokenTransfers}
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_batch_size 3
   @max_concurrency 55

--- a/apps/indexer/lib/indexer/fetcher/replaced_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/replaced_transaction.ex
@@ -13,7 +13,7 @@ defmodule Indexer.Fetcher.ReplacedTransaction do
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.ReplacedTransaction.Supervisor, as: ReplacedTransactionSupervisor
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_batch_size 10
   @max_concurrency 4

--- a/apps/indexer/lib/indexer/fetcher/token.ex
+++ b/apps/indexer/lib/indexer/fetcher/token.ex
@@ -12,7 +12,7 @@ defmodule Indexer.Fetcher.Token do
   alias Explorer.Token.MetadataRetriever
   alias Indexer.{BufferedTask, Tracer}
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: 300,

--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -22,7 +22,7 @@ defmodule Indexer.Fetcher.TokenBalance do
   alias Explorer.Chain.Hash
   alias Indexer.{BufferedTask, TokenBalances, Tracer}
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: 300,

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -5,6 +5,7 @@ defmodule Indexer.Fetcher.TokenInstance do
 
   use Indexer.Fetcher
   use Spandex.Decorators
+  use BufferedTask
 
   require Logger
 
@@ -12,7 +13,6 @@ defmodule Indexer.Fetcher.TokenInstance do
   alias Explorer.Token.InstanceMetadataRetriever
   alias Indexer.BufferedTask
 
-  @behaviour BufferedTask
 
   @defaults [
     flush_interval: 300,

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -5,7 +5,6 @@ defmodule Indexer.Fetcher.TokenInstance do
 
   use Indexer.Fetcher
   use Spandex.Decorators
-  use BufferedTask
 
   require Logger
 
@@ -13,6 +12,7 @@ defmodule Indexer.Fetcher.TokenInstance do
   alias Explorer.Token.InstanceMetadataRetriever
   alias Indexer.BufferedTask
 
+  use BufferedTask
 
   @defaults [
     flush_interval: 300,

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -11,7 +11,7 @@ defmodule Indexer.Fetcher.TokenUpdater do
   alias Explorer.Token.MetadataRetriever
   alias Indexer.BufferedTask
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @max_batch_size 10
   @max_concurrency 4

--- a/apps/indexer/lib/indexer/fetcher/uncle_block.ex
+++ b/apps/indexer/lib/indexer/fetcher/uncle_block.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Fetcher.UncleBlock do
   alias Indexer.Transform.Addresses
 
   @behaviour Block.Fetcher
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: :timer.seconds(3),

--- a/apps/indexer/lib/indexer/fetcher/util.ex
+++ b/apps/indexer/lib/indexer/fetcher/util.ex
@@ -6,14 +6,14 @@ defmodule Indexer.Fetcher.Util do
   @defaults [
     flush_interval: 300,
     max_batch_size: 100,
-    max_concurrency: 10
+    max_concurrency: 10,
+    state: {0, []}
   ]
 
   def default_child_spec(init_options, gen_server_options, module) do
     merged_init_opts =
       @defaults
       |> Keyword.merge(init_options)
-      |> Keyword.put(:state, {0, []})
       |> Keyword.put(:task_supervisor, Module.concat(module, "TaskSupervisor"))
 
     Supervisor.child_spec({Indexer.BufferedTask, [{module, merged_init_opts}, gen_server_options]}, id: module)

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -115,45 +115,45 @@ defmodule Indexer.Supervisor do
 
     basic_fetchers = [
       # Root fetchers
-#      {PendingTransaction.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
-#      {Realtime.Supervisor,
-#       [
-#         %{block_fetcher: realtime_block_fetcher, subscribe_named_arguments: realtime_subscribe_named_arguments},
-#         [name: Realtime.Supervisor]
-#       ]},
-#      {Catchup.Supervisor,
-#       [
-#         %{block_fetcher: block_fetcher, block_interval: block_interval, memory_monitor: memory_monitor},
-#         [name: Catchup.Supervisor]
-#       ]},
+      {PendingTransaction.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+      {Realtime.Supervisor,
+       [
+         %{block_fetcher: realtime_block_fetcher, subscribe_named_arguments: realtime_subscribe_named_arguments},
+         [name: Realtime.Supervisor]
+       ]},
+      {Catchup.Supervisor,
+       [
+         %{block_fetcher: block_fetcher, block_interval: block_interval, memory_monitor: memory_monitor},
+         [name: Catchup.Supervisor]
+       ]},
 
       # Async catchup fetchers
-#      {UncleBlock.Supervisor, [[block_fetcher: block_fetcher, memory_monitor: memory_monitor]]},
-#      {BlockReward.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {InternalTransaction.Supervisor,
-#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {CoinBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {Token.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {TokenInstance.Supervisor,
-#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {ContractCode.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {TokenBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {TokenUpdater.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
-#
+      {UncleBlock.Supervisor, [[block_fetcher: block_fetcher, memory_monitor: memory_monitor]]},
+      {BlockReward.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {InternalTransaction.Supervisor,
+       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {CoinBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {Token.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {TokenInstance.Supervisor,
+       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {ContractCode.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {TokenBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {TokenUpdater.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
+
 #      # Out-of-band fetchers
-#      {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
-#      {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
-#      {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
-#      {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+      {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
+      {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+      {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
+      {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
 
       # Temporary workers
-#      {UncatalogedTokenTransfers.Supervisor, [[]]},
-#      {UnclesWithoutIndex.Supervisor,
-#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {BlocksTransactionsMismatch.Supervisor,
-#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-#      {PendingOpsCleaner, [[], []]},
+      {UncatalogedTokenTransfers.Supervisor, [[]]},
+      {UnclesWithoutIndex.Supervisor,
+       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {BlocksTransactionsMismatch.Supervisor,
+       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+      {PendingOpsCleaner, [[], []]},
 
       # Celo
       {CeloAccount.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
@@ -166,7 +166,7 @@ defmodule Indexer.Supervisor do
       {CeloUnlocked.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
       {CeloVoters.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
       {EventProcessor.Supervisor, [[], []]},
-      {EventBackfill.Supervisor, [[], [ throttle_time: :timer.seconds(1), page_size: 1000]]},
+      {EventBackfill.Supervisor, [[], []]},
       {TrackedEventCache, [[], []]},
       {CeloMaterializedViewRefresh, [[], []]},
       {InternalTransactionCache, [[], []]}

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -141,7 +141,7 @@ defmodule Indexer.Supervisor do
       {TokenUpdater.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
       {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
 
-#      # Out-of-band fetchers
+      #      # Out-of-band fetchers
       {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
       {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
       {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -36,6 +36,7 @@ defmodule Indexer.Supervisor do
     CoinBalanceOnDemand,
     ContractCode,
     EmptyBlocksSanitizer,
+    EventBackfill,
     EventProcessor,
     InternalTransaction,
     PendingTransaction,
@@ -114,45 +115,45 @@ defmodule Indexer.Supervisor do
 
     basic_fetchers = [
       # Root fetchers
-      {PendingTransaction.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
-      {Realtime.Supervisor,
-       [
-         %{block_fetcher: realtime_block_fetcher, subscribe_named_arguments: realtime_subscribe_named_arguments},
-         [name: Realtime.Supervisor]
-       ]},
-      {Catchup.Supervisor,
-       [
-         %{block_fetcher: block_fetcher, block_interval: block_interval, memory_monitor: memory_monitor},
-         [name: Catchup.Supervisor]
-       ]},
+#      {PendingTransaction.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+#      {Realtime.Supervisor,
+#       [
+#         %{block_fetcher: realtime_block_fetcher, subscribe_named_arguments: realtime_subscribe_named_arguments},
+#         [name: Realtime.Supervisor]
+#       ]},
+#      {Catchup.Supervisor,
+#       [
+#         %{block_fetcher: block_fetcher, block_interval: block_interval, memory_monitor: memory_monitor},
+#         [name: Catchup.Supervisor]
+#       ]},
 
       # Async catchup fetchers
-      {UncleBlock.Supervisor, [[block_fetcher: block_fetcher, memory_monitor: memory_monitor]]},
-      {BlockReward.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {InternalTransaction.Supervisor,
-       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {CoinBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {Token.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {TokenInstance.Supervisor,
-       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {ContractCode.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {TokenBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {TokenUpdater.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
-
-      # Out-of-band fetchers
-      {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
-      {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
-      {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
-      {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+#      {UncleBlock.Supervisor, [[block_fetcher: block_fetcher, memory_monitor: memory_monitor]]},
+#      {BlockReward.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {InternalTransaction.Supervisor,
+#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {CoinBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {Token.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {TokenInstance.Supervisor,
+#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {ContractCode.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {TokenBalance.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {TokenUpdater.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
+#
+#      # Out-of-band fetchers
+#      {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
+#      {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+#      {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
+#      {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
 
       # Temporary workers
-      {UncatalogedTokenTransfers.Supervisor, [[]]},
-      {UnclesWithoutIndex.Supervisor,
-       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {BlocksTransactionsMismatch.Supervisor,
-       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-      {PendingOpsCleaner, [[], []]},
+#      {UncatalogedTokenTransfers.Supervisor, [[]]},
+#      {UnclesWithoutIndex.Supervisor,
+#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {BlocksTransactionsMismatch.Supervisor,
+#       [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
+#      {PendingOpsCleaner, [[], []]},
 
       # Celo
       {CeloAccount.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
@@ -165,6 +166,7 @@ defmodule Indexer.Supervisor do
       {CeloUnlocked.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
       {CeloVoters.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
       {EventProcessor.Supervisor, [[], []]},
+      {EventBackfill.Supervisor, [[], [ throttle_time: :timer.seconds(1), page_size: 1000]]},
       {TrackedEventCache, [[], []]},
       {CeloMaterializedViewRefresh, [[], []]},
       {InternalTransactionCache, [[], []]}

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -141,7 +141,7 @@ defmodule Indexer.Supervisor do
       {TokenUpdater.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
       {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
 
-      #      # Out-of-band fetchers
+      # Out-of-band fetchers
       {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
       {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
       {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},

--- a/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
+++ b/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
@@ -18,7 +18,7 @@ defmodule Indexer.Temporary.BlocksTransactionsMismatch do
   alias Explorer.Repo
   alias Indexer.BufferedTask
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: :timer.seconds(3),

--- a/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
+++ b/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Temporary.UnclesWithoutIndex do
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.UncleBlock
 
-  @behaviour BufferedTask
+  use BufferedTask
 
   @defaults [
     flush_interval: :timer.seconds(3),

--- a/apps/indexer/test/indexer/buffered_task_test.exs
+++ b/apps/indexer/test/indexer/buffered_task_test.exs
@@ -87,10 +87,9 @@ defmodule Indexer.BufferedTaskTest do
     end
 
     def dedup_entries(
-              %BufferedTask{dedup_entries: true, bound_queue: bound_queue} = task,
-              entries
-            ) do
-
+          %BufferedTask{dedup_entries: true, bound_queue: bound_queue} = task,
+          entries
+        ) do
       get_second_element = fn {_, e, _} -> e end
 
       running_entries =
@@ -299,29 +298,28 @@ defmodule Indexer.BufferedTaskTest do
     {:ok, buffer} =
       start_supervised(
         {BufferedTask,
-          [
-            {DedupCustomImplementation,
-              state: nil,
-              task_supervisor: BufferedTaskSup,
-              flush_interval: @flush_interval,
-              dedup_entries: true,
-              max_batch_size: 1,
-              max_concurrency: 1}
-          ]}
+         [
+           {DedupCustomImplementation,
+            state: nil,
+            task_supervisor: BufferedTaskSup,
+            flush_interval: @flush_interval,
+            dedup_entries: true,
+            max_batch_size: 1,
+            max_concurrency: 1}
+         ]}
       )
 
-    entries = [{1,1,1}, {1,2,1},{77,2,77}, {88,2,88}, {99,1,99}]
+    entries = [{1, 1, 1}, {1, 2, 1}, {77, 2, 77}, {88, 2, 88}, {99, 1, 99}]
 
     BufferedTask.buffer(buffer, entries)
 
-    assert_receive {:run, [{1,1,1}]}, @assert_receive_timeout
-    assert_receive {:run, [{1,2,1}]}, @assert_receive_timeout
+    assert_receive {:run, [{1, 1, 1}]}, @assert_receive_timeout
+    assert_receive {:run, [{1, 2, 1}]}, @assert_receive_timeout
 
-    #it should deduplicate based on the custom implementation and remove duplicate instances of the second element in the tuple
-    refute_receive {:run, [{77,2,77}]}, @assert_receive_timeout
-    refute_receive {:run, [{88,2,88}]}, @assert_receive_timeout
-    refute_receive {:run, [{99,1,99}]}, @assert_receive_timeout
-
+    # it should deduplicate based on the custom implementation and remove duplicate instances of the second element in the tuple
+    refute_receive {:run, [{77, 2, 77}]}, @assert_receive_timeout
+    refute_receive {:run, [{88, 2, 88}]}, @assert_receive_timeout
+    refute_receive {:run, [{99, 1, 99}]}, @assert_receive_timeout
   end
 
   describe "handle_info(:flush, state)" do


### PR DESCRIPTION
### Description

Adds a process to fetch historical entries for a given event and pass them to `EventProcessor` for upserting. Events that require backfill are fetched periodically from the DB, before a task is spawned to fetch logs of a specific page size.

The fetch process uses keyset pagination to get the next `n` logs after a specific record, which unfortunately requires a large composite index to function performantly. The migration creating this index took around 1 hour to complete (concurrently) on blockscoutstagingrc1, so an estimate of ~2 hours for mainnet would be reasonable.
 
Fetches are intentionally throttled with a configurable delay between each page fetch to prevent thrashing of the db.

 ### Other changes

* Adds the ability to deduplicate `BufferedTask` buffer entries based on a custom function
    * This is required to prevent duplicate instances of the same event being backfilled - dedup based on the id of the tracking record in the buffer entry, rather than full equality of the buffer entry
    * The existiung `dedup_entries` function is included as a default implementation for each task
    * This requires `BufferedTask` implementations to call `use BufferedTask` (execute the `__using__` macro on the `BufferedTask` module) rather than `@behaviour BufferedTask` (declare compliance to an interface and raise warnings when deviant)
* Modifies the `Telemetry` `wrap` macro to return the value of the executed function
* Ensure `updated_at` is set on a `TrackedContractEvent` instance when upserted
* Modify `Indexer.Fetcher.Util` to allow custom state to be set for a given `BufferedTask`
    * Custom config values beyond `max_concurrency` etc can now be passed to a task implementation

### Tested

* Added and ran unit tests
* Tested locally with backfill + event processor connected to `blockscoutstagingrc1` db and collected contract event
    * got historical data - 807114 event instances
    * `Swap` event from [SwappaRouterV1](https://explorer.celo.org/address/0xF35ed7156BABF2541E032B3bB8625210316e2832/contracts) contract
    * Backfill ran in batches and the `ContractEventTracking` instance was marked as successfully backfilled after completion

### Issues

 - Closes https://github.com/celo-org/data-services/issues/418
