### PR TITLE
Add migration to remove duplicate indices.

### DIFF
--- a/apps/explorer/priv/repo/migrations/20220829132236_pg_hero_changes.exs
+++ b/apps/explorer/priv/repo/migrations/20220829132236_pg_hero_changes.exs
@@ -9,9 +9,17 @@ defmodule Explorer.Repo.Migrations.DropDuplicateIndicesPgHero do
     ["blocks", [:miner_hash], [name: "blocks_miner_hash_index", concurrently: true]],
     ["celo_contract_events", [:block_number], [name: "celo_contract_events_block_number_index", concurrently: true]],
     ["celo_signers", [:address], [name: "celo_signers_address_index", concurrently: true]],
-    ["clabs_contract_event_trackings", [:smart_contract_id], [name: "clabs_contract_event_trackings_smart_contract_id_index", concurrently: true]],
-    ["clabs_tracked_contract_events", [:block_number], [name: "clabs_tracked_contract_events_block_number_index", concurrently: true]],
-    ["logs", [:block_hash, :index], [name: "logs_block_hash_index_index", concurrently: true]],
+    [
+      "clabs_contract_event_trackings",
+      [:smart_contract_id],
+      [name: "clabs_contract_event_trackings_smart_contract_id_index", concurrently: true]
+    ],
+    [
+      "clabs_tracked_contract_events",
+      [:block_number],
+      [name: "clabs_tracked_contract_events_block_number_index", concurrently: true]
+    ],
+    ["logs", [:block_hash, :index], [name: "logs_block_hash_index_index", concurrently: true]]
   ]
 
   def change do

--- a/apps/explorer/priv/repo/migrations/20220829132236_pg_hero_changes.exs
+++ b/apps/explorer/priv/repo/migrations/20220829132236_pg_hero_changes.exs
@@ -1,0 +1,23 @@
+defmodule Explorer.Repo.Migrations.DropDuplicateIndicesPgHero do
+  use Ecto.Migration
+
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
+  @index_params [
+    ["address_names", [:address_hash], [name: "address_names_address_hash_index", concurrently: true]],
+    ["blocks", [:miner_hash], [name: "blocks_miner_hash_index", concurrently: true]],
+    ["celo_contract_events", [:block_number], [name: "celo_contract_events_block_number_index", concurrently: true]],
+    ["celo_signers", [:address], [name: "celo_signers_address_index", concurrently: true]],
+    ["clabs_contract_event_trackings", [:smart_contract_id], [name: "clabs_contract_event_trackings_smart_contract_id_index", concurrently: true]],
+    ["clabs_tracked_contract_events", [:block_number], [name: "clabs_tracked_contract_events_block_number_index", concurrently: true]],
+    ["logs", [:block_hash, :index], [name: "logs_block_hash_index_index", concurrently: true]],
+  ]
+
+  def change do
+    for params <- @index_params do
+      index = apply(Ecto.Migration, :index, params)
+      drop_if_exists(index)
+    end
+  end
+end


### PR DESCRIPTION
### Description

PG hero states the following 

```
Duplicate Indexes

These indexes exist, but aren’t needed. Remove them for faster writes.

Details
--
On address_names address_names_address_hash_index (address_hash) is covered by unique_address_names (address_hash, name)
On blocks blocks_miner_hash_index (miner_hash) is covered by blocks_miner_hash_number_index (miner_hash, number)
On celo_contract_events celo_contract_events_block_number_index (block_number) is covered by celo_contract_events_pkey (block_number, log_index)
On celo_signers celo_signers_address_index (address)is covered by celo_signers_address_signer_index (address, signer)
On clabs_contract_event_trackings clabs_contract_event_trackings_smart_contract_id_index (smart_contract_id) is covered by smart_contract_id_topic (smart_contract_id, topic)
On clabs_tracked_contract_events clabs_tracked_contract_events_block_number_index (block_number) is covered by clabs_tracked_contract_events_pkey (block_number, log_index)
On logs logs_block_hash_index_index (block_hash, index) is covered by logs_pkey (block_hash, index)
```

This PR removes all these indices concurrently

### Tested

* Ran against local db
    * Removes everything correctly
    * Rollback also works ok

## Notes

* closes https://github.com/celo-org/data-services/issues/454