### PR TITLE
Speed up the tokentx query

### DIFF
--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -236,11 +236,6 @@ defmodule Explorer.GraphQL do
     query =
       token_txtransfers_query()
       |> where([t], t.to_address_hash == ^address_hash or t.from_address_hash == ^address_hash)
-
-    from(
-      t in subquery(query),
-      order_by: [desc: t.block_number, asc: t.nonce]
-    )
   end
 
   def celo_tx_transfers_query_by_txhash(tx_hash) do
@@ -338,7 +333,7 @@ defmodule Explorer.GraphQL do
       },
       distinct: [desc: tt.block_number, desc: tt.transaction_hash],
       # to get the ordering from distinct clause, something is needed here too
-      order_by: [desc: tt.from_address_hash, desc: tt.to_address_hash]
+      order_by: [asc: tx.nonce, desc: tt.from_address_hash, desc: tt.to_address_hash]
     )
   end
 


### PR DESCRIPTION
### Description

Removes a nested subquery that kills performance.

<img width="345" alt="image" src="https://user-images.githubusercontent.com/20768968/187913889-78392d69-64b1-4d27-97f5-b9df394e367a.png">

<img width="458" alt="image" src="https://user-images.githubusercontent.com/20768968/187914103-85b235f3-f371-4262-be3a-712d1d30d10f.png">

<img width="982" alt="image" src="https://user-images.githubusercontent.com/20768968/187914255-47724297-0a6f-42b1-8b05-c6c2e1238f28.png">

Before:
```
explain analyze SELECT s0."transaction_hash", s0."to_address_hash", s0."from_address_hash", s0."gas_used", s0."gas_price", s0."fee_currency", s0."fee_token", s0."gateway_fee", s0."gateway_fee_recipient", s0."timestamp", s0."input", s0."nonce", s0."block_number" FROM (SELECT DISTINCT ON (st0."block_number", st0."transaction_hash") st0."transaction_hash" AS "transaction_hash", st0."to_address_hash" AS "to_address_hash", st0."from_address_hash" AS "from_address_hash", st1."gas_used" AS "gas_used", st1."gas_price" AS "gas_price", st1."gas_currency_hash" AS "fee_currency", coalesce(st3."symbol", 'CELO') AS "fee_token", st1."gateway_fee" AS "gateway_fee", st1."gas_fee_recipient_hash" AS "gateway_fee_recipient", sb2."timestamp" AS "timestamp", st1."input" AS "input", st1."nonce" AS "nonce", st0."block_number" AS "block_number" FROM "token_transfers" AS st0 INNER JOIN "transactions" AS st1 ON st1."hash" = st0."transaction_hash" INNER JOIN "blocks" AS sb2 ON st1."block_hash" = sb2."hash" LEFT OUTER JOIN "tokens" AS st3 ON st1."gas_currency_hash" = st3."contract_address_hash" WHERE (NOT (st0."transaction_hash" IS NULL)) AND ((st0."to_address_hash" = '\x6131a6d616a4be3737b38988847270a64bc10caa') OR (st0."from_address_hash" = '\x6131a6d616a4be3737b38988847270a64bc10caa')) ORDER BY st0."block_number" DESC, st0."transaction_hash" DESC, st0."from_address_hash" DESC, st0."to_address_hash" DESC) AS s0 ORDER BY s0."block_number" DESC, s0."nonce" LIMIT 26 OFFSET 0;

 Limit  (cost=698976.82..698982.74 rows=26 width=357) (actual time=6934.523..6945.670 rows=26 loops=1)
   ->  Incremental Sort  (cost=698976.82..760591.03 rows=270276 width=357) (actual time=6934.522..6945.665 rows=26 loops=1)
         Sort Key: st0.block_number DESC, st1.nonce
         Presorted Key: st0.block_number
         Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 36kB  Peak Memory: 36kB
         ->  Unique  (cost=698685.89..742612.79 rows=270276 width=357) (actual time=6934.444..6945.622 rows=27 loops=1)
               ->  Gather Merge  (cost=698685.89..740804.60 rows=361638 width=357) (actual time=6934.404..6945.565 rows=48 loops=1)
                     Workers Planned: 2
                     Workers Launched: 2
                     ->  Sort  (cost=697685.87..698062.57 rows=150682 width=357) (actual time=6922.689..6922.717 rows=156 loops=3)
                           Sort Key: st0.block_number DESC, st0.transaction_hash DESC, st0.from_address_hash DESC, st0.to_address_hash DESC
                           Sort Method: quicksort  Memory: 64386kB
                           Worker 0:  Sort Method: quicksort  Memory: 63351kB
                           Worker 1:  Sort Method: quicksort  Memory: 61784kB
                           ->  Hash Left Join  (cost=9494.11..684726.35 rows=150682 width=357) (actual time=2729.920..6545.944 rows=122390 loops=3)
                                 Hash Cond: (st1.gas_currency_hash = st3.contract_address_hash)
                                 ->  Nested Loop  (cost=8911.11..683747.81 rows=150682 width=325) (actual time=2717.474..6440.568 rows=122390 loops=3)
                                       ->  Nested Loop  (cost=8910.55..418600.69 rows=150682 width=350) (actual time=2717.440..5201.262 rows=122390 loops=3)
                                             ->  Parallel Bitmap Heap Scan on token_transfers st0  (cost=8909.99..107128.96 rows=150682 width=79) (actual time=2717.366..3630.455 rows=122390 loops=3)
                                                   Recheck Cond: (((to_address_hash = '\x6131a6d616a4be3737b38988847270a64bc10caa'::bytea) AND (transaction_hash IS NOT NULL)) OR ((from_address_hash = '\x6
131a6d616a4be3737b38988847270a64bc10caa'::bytea) AND (transaction_hash IS NOT NULL)))
                                                   Heap Blocks: exact=14392
                                                   ->  BitmapOr  (cost=8909.99..8909.99 rows=365595 width=0) (actual time=2711.735..2711.737 rows=0 loops=1)
                                                         ->  Bitmap Index Scan on token_transfers_to_address_hash_transaction_hash_index  (cost=0.00..1069.01 rows=44915 width=0) (actual time=323.227..323.
227 rows=43569 loops=1)
                                                               Index Cond: ((to_address_hash = '\x6131a6d616a4be3737b38988847270a64bc10caa'::bytea) AND (transaction_hash IS NOT NULL))
                                                         ->  Bitmap Index Scan on token_transfers_from_address_hash_transaction_hash_index  (cost=0.00..7660.17 rows=320681 width=0) (actual time=2388.505..
2388.506 rows=323922 loops=1)
                                                               Index Cond: ((from_address_hash = '\x6131a6d616a4be3737b38988847270a64bc10caa'::bytea) AND (transaction_hash IS NOT NULL))
                                             ->  Index Scan using transactions_pkey on transactions st1  (cost=0.56..2.07 rows=1 width=304) (actual time=0.012..0.012 rows=1 loops=367170)
                                                   Index Cond: (hash = st0.transaction_hash)
                                       ->  Index Scan using blocks_pkey on blocks sb2  (cost=0.56..1.76 rows=1 width=41) (actual time=0.009..0.009 rows=1 loops=367170)
                                             Index Cond: (hash = st1.block_hash)
                                 ->  Hash  (cost=398.00..398.00 rows=14800 width=27) (actual time=12.009..12.010 rows=14814 loops=3)
                                       Buckets: 16384  Batches: 1  Memory Usage: 971kB
                                       ->  Seq Scan on tokens st3  (cost=0.00..398.00 rows=14800 width=27) (actual time=0.030..5.310 rows=14814 loops=3)
 Planning Time: 1.465 ms
 Execution Time: 6950.101 ms
(35 rows)
```

After:
```
explain analyze SELECT DISTINCT ON (st0."block_number", st0."transaction_hash") st0."transaction_hash" AS "transaction_hash", st0."to_address_hash" AS "to_address_hash", st0."from_address_hash" AS "from_address_hash", st1."gas_used" AS "gas_used", st1."gas_price" AS "gas_price", st1."gas_currency_hash" AS "fee_currency", coalesce(st3."symbol", 'CELO') AS "fee_token", st1."gateway_fee" AS "gateway_fee", st1."gas_fee_recipient_hash" AS "gateway_fee_recipient", sb2."timestamp" AS "timestamp", st1."input" AS "input", st1."nonce" AS "nonce", st0."block_number" AS "block_number" FROM "token_transfers" AS st0 INNER JOIN "transactions" AS st1 ON st1."hash" = st0."transaction_hash" INNER JOIN "blocks" AS sb2 ON st1."block_hash" = sb2."hash" LEFT OUTER JOIN "tokens" AS st3 ON st1."gas_currency_hash" = st3."contract_address_hash" WHERE (NOT (st0."transaction_hash" IS NULL)) AND ((st0."to_address_hash" = '\x6131a6d616a4be3737b38988847270a64bc10caa') OR (st0."from_address_hash" = '\x6131a6d616a4be3737b38988847270a64bc10caa')) ORDER BY st0."block_number" DESC, st0."transaction_hash" DESC, st1.nonce ASC, st0."from_address_hash" DESC, st0."to_address_hash" DESC LIMIT 26 OFFSET 0;

 Limit  (cost=1007.04..1087.64 rows=26 width=357) (actual time=14.727..21.679 rows=26 loops=1)
   ->  Unique  (cost=1007.04..838787.90 rows=270276 width=357) (actual time=14.726..21.673 rows=26 loops=1)
         ->  Nested Loop Left Join  (cost=1007.04..836979.71 rows=361638 width=357) (actual time=14.713..21.629 rows=46 loops=1)
               ->  Gather Merge  (cost=1006.75..827933.18 rows=361638 width=325) (actual time=14.697..21.530 rows=46 loops=1)
                     Workers Planned: 2
                     Workers Launched: 2
                     ->  Incremental Sort  (cost=6.73..785191.16 rows=150682 width=325) (actual time=1.733..5.532 rows=71 loops=3)
                           Sort Key: st0.block_number DESC, st0.transaction_hash DESC, st1.nonce, st0.from_address_hash DESC, st0.to_address_hash DESC
                           Presorted Key: st0.block_number
                           Full-sort Groups: 2  Sort Method: quicksort  Average Memory: 38kB  Peak Memory: 38kB
                           Worker 0:  Full-sort Groups: 2  Sort Method: quicksort  Average Memory: 39kB  Peak Memory: 39kB
                           Worker 1:  Full-sort Groups: 5  Sort Method: quicksort  Average Memory: 41kB  Peak Memory: 41kB
                           ->  Nested Loop  (cost=1.55..778410.47 rows=150682 width=325) (actual time=0.547..5.050 rows=99 loops=3)
                                 ->  Nested Loop  (cost=0.99..513263.16 rows=150682 width=350) (actual time=0.514..4.032 rows=99 loops=3)
                                       ->  Parallel Index Scan Backward using token_transfers_block_number_index on token_transfers st0  (cost=0.43..201790.96 rows=150682 width=79) (actual time=0.488..2.8
86 rows=99 loops=3)
                                             Filter: ((transaction_hash IS NOT NULL) AND ((to_address_hash = '\x6131a6d616a4be3737b38988847270a64bc10caa'::bytea) OR (from_address_hash = '\x6131a6d616a4be3
737b38988847270a64bc10caa'::bytea)))
                                             Rows Removed by Filter: 863
                                       ->  Index Scan using transactions_pkey on transactions st1  (cost=0.56..2.07 rows=1 width=304) (actual time=0.010..0.010 rows=1 loops=297)
                                             Index Cond: (hash = st0.transaction_hash)
                                 ->  Index Scan using blocks_pkey on blocks sb2  (cost=0.56..1.76 rows=1 width=41) (actual time=0.009..0.009 rows=1 loops=297)
                                       Index Cond: (hash = st1.block_hash)
               ->  Memoize  (cost=0.30..1.40 rows=1 width=27) (actual time=0.001..0.001 rows=0 loops=46)
                     Cache Key: st1.gas_currency_hash
                     Cache Mode: logical
                     Hits: 44  Misses: 2  Evictions: 0  Overflows: 0  Memory Usage: 1kB
                     ->  Index Scan using tokens_pkey on tokens st3  (cost=0.29..1.39 rows=1 width=27) (actual time=0.008..0.008 rows=0 loops=2)
                           Index Cond: (contract_address_hash = st1.gas_currency_hash)
 Planning Time: 2.650 ms
 Execution Time: 21.853 ms
(29 rows)
```

 ### Other changes

No.

### Tested

Yes, on Alfajores.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/433
 - Fixes https://github.com/celo-org/data-services/issues/434

 ### Backwards compatibility

Yes.

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I added code comments for anything non trivial.
  - [x] I added documentation for my changes.
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
