### PR TITLE
Pass network path to js code

### DIFF
--- a/apps/block_scout_web/assets/js/lib/analytics.js
+++ b/apps/block_scout_web/assets/js/lib/analytics.js
@@ -56,15 +56,15 @@ function getPageName (path) {
   switch (true) {
     case path.includes('/search'):
       return '404SearchResult'
-    case path === '/':
+    case path === `${process.env.NETWORK_PATH}/`:
       return 'home'
-    case path === '/txs':
+    case path === `${process.env.NETWORK_PATH}/txs`:
       return 'validatedTransactions'
-    case path === '/pending_transactions':
+    case path === `${process.env.NETWORK_PATH}/pending_transactions`:
       return 'pendingTransactions'
-    case path === '/blocks':
+    case path === `${process.env.NETWORK_PATH}/blocks`:
       return 'blockHistory'
-    case path === '/accounts':
+    case path === `${process.env.NETWORK_PATH}/accounts`:
       return 'allAccounts'
     case path.includes('/blocks') && path.includes('/transactions'):
       return 'blockTransactions'
@@ -109,7 +109,7 @@ function getPageName (path) {
 // returns referrer path, strips domain name from referrer
 function getReferrerPath () {
   const referrer = document.referrer
-  return referrer.replace('https://explorer.celo.org', '').replace('http://localhost:4000', '')
+  return referrer.replace(`https://explorer.celo.org/${process.env.NETWORK_PATH}`, '').replace(`http://localhost:4000/${process.env.NETWORK_PATH}`, '')
 }
 
 // returns relevant entity ID: Address, Transaction, Block, or Search Parameter

--- a/apps/block_scout_web/assets/js/lib/autocomplete.js
+++ b/apps/block_scout_web/assets/js/lib/autocomplete.js
@@ -15,7 +15,7 @@ const dataSrc = async (query, id) => {
 
     // Fetch External Data Source
     const source = await fetch(
-      `/token-autocomplete?q=${query}`
+      `${process.env.NETWORK_PATH}/token-autocomplete?q=${query}`
     )
     const data = await source.json()
     // Post Loading placeholder text

--- a/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
@@ -56,7 +56,7 @@ export const callMethod = (isWalletEnabled, $functionInputs, explorerChainId, $f
             methodToCall
               .on('error', function (error) {
                 const titleAndError = formatTitleAndError(error)
-                const message = titleAndError.message + (titleAndError.txHash ? `<br><a href="/tx/${titleAndError.txHash}">More info</a>` : '')
+                const message = titleAndError.message + (titleAndError.txHash ? `<br><a href="${process.env.NETWORK_PATH}/tx/${titleAndError.txHash}">More info</a>` : '')
                 openErrorModal(titleAndError.title.length ? titleAndError.title : `Error in sending transaction for method "${functionName}"`, message, false)
               })
               .on('transactionHash', function (txHash) {

--- a/apps/block_scout_web/assets/js/pages/address/logs.js
+++ b/apps/block_scout_web/assets/js/pages/address/logs.js
@@ -76,7 +76,7 @@ if ($('[data-page="address-logs"]').length) {
     const topic = $('[data-search-field]').val()
     const addressHashPlain = store.getState().addressHash
     const addressHashChecksum = addressHashPlain && utils.toChecksumAddress(addressHashPlain)
-    const path = '/search-logs?topic=' + topic + '&address_id=' + addressHashChecksum
+    const path = '${process.env.NETWORK_PATH}/search-logs?topic=' + topic + '&address_id=' + addressHashChecksum
     store.dispatch({ type: 'START_REQUEST' })
     $.getJSON(path, { type: 'JSON' })
       .done(response => store.dispatch(Object.assign({ type: 'ITEMS_FETCHED' }, humps.camelizeKeys(response))))

--- a/apps/block_scout_web/assets/js/pages/address/logs.js
+++ b/apps/block_scout_web/assets/js/pages/address/logs.js
@@ -76,7 +76,7 @@ if ($('[data-page="address-logs"]').length) {
     const topic = $('[data-search-field]').val()
     const addressHashPlain = store.getState().addressHash
     const addressHashChecksum = addressHashPlain && utils.toChecksumAddress(addressHashPlain)
-    const path = '${process.env.NETWORK_PATH}/search-logs?topic=' + topic + '&address_id=' + addressHashChecksum
+    const path = `${process.env.NETWORK_PATH}/search-logs?topic=${topic}&address_id=${addressHashChecksum}`
     store.dispatch({ type: 'START_REQUEST' })
     $.getJSON(path, { type: 'JSON' })
       .done(response => store.dispatch(Object.assign({ type: 'ITEMS_FETCHED' }, humps.camelizeKeys(response))))

--- a/apps/block_scout_web/assets/js/pages/layout.js
+++ b/apps/block_scout_web/assets/js/pages/layout.js
@@ -10,7 +10,7 @@ $(document).click(function (event) {
 
 const search = (value) => {
   if (value) {
-    window.location.href = `/search?q=${value}`
+    window.location.href = `${process.env.NETWORK_PATH}/search?q=${value}`
   }
 }
 

--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -176,7 +176,8 @@ const appJs =
       new webpack.DefinePlugin({
         'process.env.SOCKET_ROOT': JSON.stringify(process.env.SOCKET_ROOT),
         'process.env.CHAIN_ID': JSON.stringify(process.env.CHAIN_ID),
-        'process.env.JSON_RPC': JSON.stringify(process.env.JSON_RPC)
+        'process.env.JSON_RPC': JSON.stringify(process.env.JSON_RPC),
+        'process.env.NETWORK_PATH': JSON.stringify(process.env.NETWORK_PATH)
       }),
       new webpack.ProvidePlugin({
         process: 'process/browser',


### PR DESCRIPTION
### Description

There is an env variable `NETWORK_PATH` (listed in the [doc](https://docs.blockscout.com/for-developers/information-and-settings/env-variables)) that defines a prefix added to all the URL paths. While it works fine for Elixir code, it fails for redirects handled by the javascript code, for example, for the search page or token autocomplete. This PR addresses this problem.
 
 ### Other changes

No.

### Tested

TBD

### Issues

 - Relates to #[issue number here]
 - Fixes #[issue number here]

 ### Backwards compatibility

 _Brief explanation of why these changes are/are not backwards compatible._

### Checklist

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I added code comments for anything non trivial.
  - [ ] I added documentation for my changes.
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/celo-org/monorepo to update the list and default values of env vars.
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools.
