### PR TITLE
Handle situation where no code is fetched from blockchain.

### DIFF
--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -145,7 +145,7 @@ defmodule BlockScoutWeb.Mixfile do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      compile: "compile",
+      compile: "compile --warnings-as-errors",
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: [

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -145,7 +145,7 @@ defmodule BlockScoutWeb.Mixfile do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      compile: "compile --warnings-as-errors",
+      compile: "compile",
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: [

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1866,6 +1866,8 @@ defmodule Explorer.Chain do
              [%{block_quantity: "latest", address: address.smart_contract.address_hash}],
              json_rpc_named_arguments
            ) do
+        {:ok, %EthereumJSONRPC.FetchedCodes{params_list: []}} ->
+          address
         {:ok, %EthereumJSONRPC.FetchedCodes{params_list: fetched_codes}} ->
           bytecode_from_node = fetched_codes |> List.first() |> Map.get(:code)
           bytecode_from_db = "0x" <> (address.contract_code.bytes |> Base.encode16(case: :lower))

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1868,6 +1868,7 @@ defmodule Explorer.Chain do
            ) do
         {:ok, %EthereumJSONRPC.FetchedCodes{params_list: []}} ->
           address
+
         {:ok, %EthereumJSONRPC.FetchedCodes{params_list: fetched_codes}} ->
           bytecode_from_node = fetched_codes |> List.first() |> Map.get(:code)
           bytecode_from_db = "0x" <> (address.contract_code.bytes |> Base.encode16(case: :lower))


### PR DESCRIPTION
### Description

Upstream code doesn't handle the situation where the archive node returns no data for a given address. This PR changes the default implementation to fail safe and treat the contract address as not mutated instead of throwing a 500 error
 

### Tested

* Ran locally and was able to access the write contract page
* Passed test suite

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/468
