### PR TITLE
Verify contracts asynchronously from web / api pod on indexer pod

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
@@ -21,8 +21,15 @@ defmodule BlockScoutWeb.AddressContractVerificationViaJsonController do
     else
       case Sourcify.check_by_address(address_hash_string) do
         {:ok, _verified_status} ->
-          get_metadata_and_publish(address_hash_string, conn)
-          redirect(conn, to: address_path)
+          case get_metadata_and_publish(address_hash_string, conn) do
+            :update_submitted ->
+              conn
+              |> put_flash(:info, "Contract submitted for verification")
+              |> redirect(to: address_path)
+
+            _ ->
+              redirect(conn, to: address_path)
+          end
 
         _ ->
           changeset =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
@@ -24,8 +24,7 @@ defmodule BlockScoutWeb.AddressContractVerificationViaJsonController do
           case get_metadata_and_publish(address_hash_string, conn) do
             :update_submitted ->
               conn
-              |> put_flash(:info, "Contract submitted for verification")
-              |> redirect(to: address_path)
+              |> render("submitted.html", address_string: address_hash_string, path: address_path)
 
             _ ->
               redirect(conn, to: address_path)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -331,7 +331,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
         {:error, changeset}
 
       {:update_submitted} ->
-          :update_submitted
+        :update_submitted
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -310,6 +310,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
     result = publish_without_broadcast(input)
 
     EventsPublisher.broadcast([{:contract_verification_result, {address_hash, result, conn}}], :on_demand)
+    result
   end
 
   def proccess_params(input) do
@@ -328,6 +329,9 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
 
       {:error, changeset} ->
         {:error, changeset}
+
+      {:update_submitted} ->
+          :update_submitted
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -67,6 +67,9 @@ defmodule BlockScoutWeb.Notifier do
             )
 
           {:error, result}
+
+          {:submitted}   ->
+            require IEx; IEx.pry
       end
 
     Endpoint.broadcast(

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -68,8 +68,8 @@ defmodule BlockScoutWeb.Notifier do
 
           {:error, result}
 
-          :update_submitted   ->
-            {:ok, :update_submitted}
+        :update_submitted ->
+          {:ok, :update_submitted}
       end
 
     Endpoint.broadcast(

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -68,8 +68,8 @@ defmodule BlockScoutWeb.Notifier do
 
           {:error, result}
 
-          {:submitted}   ->
-            require IEx; IEx.pry
+          :update_submitted   ->
+            {:ok, :update_submitted}
       end
 
     Endpoint.broadcast(

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/submitted.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/submitted.html.eex
@@ -1,0 +1,12 @@
+<section class="container">
+  <div class="block-not-found">
+    <div class="block-not-found-img">
+      <img alt="Contract Submitted" src="/images/errors-img/pic-404.svg">
+    </div>
+    <div class="block-not-found-content">
+      <h1 class="card-title error-title">Contract submitted for verification</h1>
+      <p class="error-descr">The contract at <%= @address_string %> has been submitted for verification and will be available shortly after propagation.</p>
+      <a class="error-btn btn-line" href="<%= @path %>">View Contract</a>
+    </div>
+  </div>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/submitted.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/submitted.html.eex
@@ -4,7 +4,7 @@
       <img alt="Contract Submitted" src="/images/errors-img/pic-404.svg">
     </div>
     <div class="block-not-found-content">
-      <h1 class="card-title error-title">Contract submitted for verification</h1>
+      <h1 class="card-title error-title">Smart Contract submitted for verification</h1>
       <p class="error-descr">The contract at <%= @address_string %> has been submitted for verification and will be available shortly after propagation.</p>
       <a class="error-btn btn-line" href="<%= @path %>">View Contract</a>
     </div>

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -153,6 +153,8 @@ config :explorer, Explorer.Market.History.Cataloger, enabled: System.get_env("DI
 
 config :explorer, Explorer.Chain.Cache.MinMissingBlockNumber, enabled: System.get_env("DISABLE_WRITE_API") != "true"
 
+config :explorer, :write_api_enabled, System.get_env("DISABLE_WRITE_API") != "true"
+
 txs_stats_init_lag =
   System.get_env("TXS_HISTORIAN_INIT_LAG", "0")
   |> Integer.parse()

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -241,7 +241,7 @@ config :explorer,
 config :logger_json, :explorer,
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk import_id transaction_id celo_rid)a,
+       block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :explorer]
 
 config :logger, :explorer, backends: [LoggerJSON]

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -241,7 +241,7 @@ config :explorer,
 config :logger_json, :explorer,
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk import_id transaction_id)a,
+       block_number step count error_count shrunk import_id transaction_id celo_rid)a,
   metadata_filter: [application: :explorer]
 
 config :logger, :explorer, backends: [LoggerJSON]

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -60,8 +60,8 @@ defmodule Explorer.Application do
       Transactions,
       Accounts,
       Uncles,
-      {Phoenix.PubSub, name: :chain_pubsub, id: :chain_pubsub},
-      {Phoenix.PubSub, name: :operations, id: :operations}
+      Supervisor.child_spec({Phoenix.PubSub, name: :chain_pubsub}, id: :chain_pubsub),
+      Supervisor.child_spec({Phoenix.PubSub, name: :operations}, id: :operations)
     ]
 
     children = base_children ++ configurable_children()

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -60,8 +60,8 @@ defmodule Explorer.Application do
       Transactions,
       Accounts,
       Uncles,
-      {Phoenix.PubSub, name: :chain_pubsub},
-      {Phoenix.PubSub, name: :operations}
+      {Phoenix.PubSub, name: :chain_pubsub, id: :chain_pubsub},
+      {Phoenix.PubSub, name: :operations, id: :operations}
     ]
 
     children = base_children ++ configurable_children()

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -60,7 +60,8 @@ defmodule Explorer.Application do
       Transactions,
       Accounts,
       Uncles,
-      {Phoenix.PubSub, name: :chain_pubsub}
+      {Phoenix.PubSub, name: :chain_pubsub},
+      {Phoenix.PubSub, name: :operations}
     ]
 
     children = base_children ++ configurable_children()

--- a/apps/explorer/lib/explorer/celo/pubsub.ex
+++ b/apps/explorer/lib/explorer/celo/pubsub.ex
@@ -1,0 +1,22 @@
+defmodule Explorer.Celo.PubSub do
+  @moduledoc """
+      Messages for cross cluster operations
+  """
+
+  alias Ecto.UUID
+  alias Explorer.Celo.Telemetry
+  alias Phoenix.PubSub
+
+  @pubsub_name :operations
+
+  @doc "Broadcast a message to publish a smart contract"
+  def publish_smart_contract(address_hash, attrs) do
+    PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, UUID.generate() } )
+    Telemetry.event(:smart_contract_publish_send, %{})
+  end
+
+  @doc "Subscribe to smart contract messages, messages are in the format {:smart_contract_publish, address_hash, attributes, msg_id}"
+  def subscribe_to_smart_contract_publishing() do
+    PubSub.subscribe(@pubsub_name, "smart_contract_publish")
+  end
+end

--- a/apps/explorer/lib/explorer/celo/pubsub.ex
+++ b/apps/explorer/lib/explorer/celo/pubsub.ex
@@ -7,11 +7,16 @@ defmodule Explorer.Celo.PubSub do
   alias Explorer.Celo.Telemetry
   alias Phoenix.PubSub
 
+  require Logger
+
   @pubsub_name :operations
 
   @doc "Broadcast a message to publish a smart contract"
   def publish_smart_contract(address_hash, attrs) do
-    PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, UUID.generate() } )
+    msg_id = UUID.generate()
+
+    Logger.info("Sending smart contract publish request", celo_rid: msg_id)
+    PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, msg_id} )
     Telemetry.event(:smart_contract_publish_send, %{})
   end
 

--- a/apps/explorer/lib/explorer/celo/pubsub.ex
+++ b/apps/explorer/lib/explorer/celo/pubsub.ex
@@ -15,7 +15,7 @@ defmodule Explorer.Celo.PubSub do
   def publish_smart_contract(address_hash, attrs) do
     msg_id = UUID.generate()
 
-    Logger.info("Sending smart contract publish request", celo_rid: msg_id)
+    Logger.info("Sending smart contract publish request")
     PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, msg_id} )
     Telemetry.event(:smart_contract_publish_send, %{})
   end

--- a/apps/explorer/lib/explorer/celo/pubsub.ex
+++ b/apps/explorer/lib/explorer/celo/pubsub.ex
@@ -16,12 +16,12 @@ defmodule Explorer.Celo.PubSub do
     msg_id = UUID.generate()
 
     Logger.info("Sending smart contract publish request")
-    PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, msg_id} )
+    PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, msg_id})
     Telemetry.event(:smart_contract_publish_send, %{})
   end
 
   @doc "Subscribe to smart contract messages, messages are in the format {:smart_contract_publish, address_hash, attributes, msg_id}"
-  def subscribe_to_smart_contract_publishing() do
+  def subscribe_to_smart_contract_publishing do
     PubSub.subscribe(@pubsub_name, "smart_contract_publish")
   end
 end

--- a/apps/explorer/lib/explorer/celo/pubsub.ex
+++ b/apps/explorer/lib/explorer/celo/pubsub.ex
@@ -15,7 +15,7 @@ defmodule Explorer.Celo.PubSub do
   def publish_smart_contract(address_hash, attrs) do
     msg_id = UUID.generate()
 
-    Logger.info("Sending smart contract publish request")
+    Logger.info("Sending smart contract publish request #{msg_id}")
     PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, msg_id})
     Telemetry.event(:smart_contract_publish_send, %{})
   end

--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -153,5 +153,16 @@ defmodule Explorer.Repo do
       otp_app: :explorer,
       adapter: Ecto.Adapters.Postgres,
       read_only: true
+
+    def init(_, opts) do
+      extra_postgres_parameters = [application_name: get_application_name() <> "-replica1"]
+
+      opts =
+        Keyword.update(opts, :parameters, extra_postgres_parameters, fn params ->
+          Keyword.merge(params, extra_postgres_parameters)
+        end)
+
+      {:ok, opts}
+    end
   end
 end

--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -154,8 +154,10 @@ defmodule Explorer.Repo do
       adapter: Ecto.Adapters.Postgres,
       read_only: true
 
+    alias Explorer.Repo, as: ExplorerRepo
+
     def init(_, opts) do
-      extra_postgres_parameters = [application_name: get_application_name() <> "-replica1"]
+      extra_postgres_parameters = [application_name: ExplorerRepo.get_application_name() <> "-replica1"]
 
       opts =
         Keyword.update(opts, :parameters, extra_postgres_parameters, fn params ->

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -86,7 +86,8 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
 
   defp create_or_update_smart_contract(address_hash, attrs) do
     if Application.get_env(:explorer, :write_api_enabled) do
-      _do_create_or_update(address_hash, attrs)
+      do_create_or_update(address_hash, attrs)
+      {:error, unverified_smart_contract(address_hash, attrs, "Verification in progress", nil, true)}
     else
       broadcast_smart_contract_upsert(address_hash, attrs)
     end
@@ -96,7 +97,7 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
     PubSub.publish_smart_contract(address_hash, attrs)
   end
 
-  defp _do_create_or_update(address_hash, attrs) do
+  def do_create_or_update(address_hash, attrs) do
     if Chain.smart_contract_verified?(address_hash) do
       Chain.update_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
     else

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -4,6 +4,7 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
   """
   require Logger
 
+  alias Explorer.Celo.PubSub
   alias Explorer.Chain
   alias Explorer.Chain.SmartContract
   alias Explorer.SmartContract.CompilerVersion
@@ -84,6 +85,18 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
   end
 
   defp create_or_update_smart_contract(address_hash, attrs) do
+    if Application.get_env(:explorer, :write_api_enabled) do
+      _do_create_or_update(address_hash, attrs)
+    else
+      broadcast_smart_contract_upsert(address_hash, attrs)
+    end
+  end
+
+  defp broadcast_smart_contract_upsert(address_hash, attrs) do
+    PubSub.publish_smart_contract(address_hash, attrs)
+  end
+
+  defp _do_create_or_update(address_hash, attrs) do
     if Chain.smart_contract_verified?(address_hash) do
       Chain.update_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
     else

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -87,9 +87,9 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
   defp create_or_update_smart_contract(address_hash, attrs) do
     if Application.get_env(:explorer, :write_api_enabled) do
       do_create_or_update(address_hash, attrs)
-      {:error, unverified_smart_contract(address_hash, attrs, "Verification in progress", nil, true)}
     else
       broadcast_smart_contract_upsert(address_hash, attrs)
+      {:update_submitted}
     end
   end
 

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -82,7 +82,7 @@ config :indexer, Indexer.Tracer,
 config :logger_json, :indexer,
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk import_id transaction_id celo_rid)a,
+       block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :indexer]
 
 config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -82,7 +82,7 @@ config :indexer, Indexer.Tracer,
 config :logger_json, :indexer,
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
-       block_number step count error_count shrunk import_id transaction_id)a,
+       block_number step count error_count shrunk import_id transaction_id celo_rid)a,
   metadata_filter: [application: :indexer]
 
 config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]

--- a/apps/indexer/lib/indexer/celo/write_operation_handler.ex
+++ b/apps/indexer/lib/indexer/celo/write_operation_handler.ex
@@ -36,7 +36,7 @@ defmodule Indexer.Celo.WriteOperationHandler do
 
   @impl true
   def handle_info({:smart_contract_publish, address_hash, attributes, msg_id}, state) do
-    Logger.info("Got smart contract publish request", celo_rid: msg_id)
+    Logger.info("Got smart contract publish request #{msg_id}")
     SmartContractPublisher.do_create_or_update(address_hash, attributes)
 
     {:noreply, state}

--- a/apps/indexer/lib/indexer/celo/write_operation_handler.ex
+++ b/apps/indexer/lib/indexer/celo/write_operation_handler.ex
@@ -1,0 +1,49 @@
+defmodule Indexer.Celo.WriteOperationHandler do
+  @moduledoc "A process to perform operations broadcast from nodes without write access"
+
+  use GenServer
+
+  require Explorer.Celo.Telemetry, as: Telemetry
+  alias Explorer.Celo.PubSub
+  alias Explorer.SmartContract.Solidity.Publisher, as: SmartContractPublisher
+
+  @cache_refresh_interval :timer.minutes(5)
+
+  def start_link([init_arg, gen_server_opts]) do
+    start_link(init_arg, gen_server_opts)
+  end
+
+  def start_link(init_arg, gen_server_opts) do
+    gen_server_opts = Keyword.merge(gen_server_opts, name: __MODULE__)
+
+    GenServer.start_link(__MODULE__, init_arg, gen_server_opts)
+  end
+
+  @impl true
+  def init(_) do
+    state = %{ }
+
+    {:ok, state, {:continue, :subscribe_to_operations}}
+  end
+
+  @impl true
+  def handle_continue(:subscribe_to_operations, state) do
+    PubSub.subscribe_to_smart_contract_publishing()
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:smart_contract_publish, address_hash, attributes, msg_id}, state) do
+    Logger.info("Got smart contract publish request", celo_rid: msg_id)
+    SmartContractPublisher.do_create_or_update(address_hash, attributes)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(msg,state) do
+    Logger.info("#{__MODULE__} got unknown message #{msg |> inspect()}")
+    {:noreply, state}
+  end
+end

--- a/apps/indexer/lib/indexer/celo/write_operation_handler.ex
+++ b/apps/indexer/lib/indexer/celo/write_operation_handler.ex
@@ -4,6 +4,7 @@ defmodule Indexer.Celo.WriteOperationHandler do
   use GenServer
 
   require Explorer.Celo.Telemetry, as: Telemetry
+  require Logger
   alias Explorer.Celo.PubSub
   alias Explorer.SmartContract.Solidity.Publisher, as: SmartContractPublisher
 

--- a/apps/indexer/lib/indexer/celo/write_operation_handler.ex
+++ b/apps/indexer/lib/indexer/celo/write_operation_handler.ex
@@ -22,7 +22,7 @@ defmodule Indexer.Celo.WriteOperationHandler do
 
   @impl true
   def init(_) do
-    state = %{ }
+    state = %{}
 
     {:ok, state, {:continue, :subscribe_to_operations}}
   end
@@ -43,7 +43,7 @@ defmodule Indexer.Celo.WriteOperationHandler do
   end
 
   @impl true
-  def handle_info(msg,state) do
+  def handle_info(msg, state) do
     Logger.info("#{__MODULE__} got unknown message #{msg |> inspect()}")
     {:noreply, state}
   end

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -169,7 +169,8 @@ defmodule Indexer.Supervisor do
       {EventBackfill.Supervisor, [[], []]},
       {TrackedEventCache, [[], []]},
       {CeloMaterializedViewRefresh, [[], []]},
-      {InternalTransactionCache, [[], []]}
+      {InternalTransactionCache, [[], []]},
+      {Indexer.Celo.WriteOperationHandler, []}
     ]
 
     fetchers_with_bridged_tokens =

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -170,7 +170,7 @@ defmodule Indexer.Supervisor do
       {TrackedEventCache, [[], []]},
       {CeloMaterializedViewRefresh, [[], []]},
       {InternalTransactionCache, [[], []]},
-      {Indexer.Celo.WriteOperationHandler, []}
+      {Indexer.Celo.WriteOperationHandler, [[],[]]}
     ]
 
     fetchers_with_bridged_tokens =

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -170,7 +170,7 @@ defmodule Indexer.Supervisor do
       {TrackedEventCache, [[], []]},
       {CeloMaterializedViewRefresh, [[], []]},
       {InternalTransactionCache, [[], []]},
-      {Indexer.Celo.WriteOperationHandler, [[],[]]}
+      {Indexer.Celo.WriteOperationHandler, [[], []]}
     ]
 
     fetchers_with_bridged_tokens =


### PR DESCRIPTION
### Description

Uses cluster communication to submit a smart contract for verification from web / api pod against an indexer pod. This requires the indexer to listen for contract submission events and to perform the actual verification. 

Due to this being an async operation a message is now displayed after the submission to inform the user that this is happening. This assumes that replication lag is low enough that the contract will be available in the replica db by the time the "View Contract" button has been clicked - given current stats this seems to be a reasonable assumption, but this approach may have to change in future.
 
 ### Other changes

* Set `application_name` on replica1 repo instance so that it's connections appear in `pg_stat_activity` with the correct name

### Tested

* deployed to rc1staging and saw verified contracts + log messages referencing the insertion

> This is actually pretty difficult to test due to the async + distributed nature and the UI is essentially a fallback for when no api routes exist. Essentially, upon entering a contract address within the text field an ajax call is immediately made to `/api/?module=contract&action=getsourcecode&address=$CONTRACT_ADDRESS`. This results in the system checking sourcify for an existing contract, and if found, directly making the request to publish the contract within blockscout db.

> Because of this, the webpage directly calls a blockscout api pod instance which then uses cluster communication to ask the indexer to insert the contract. This happens outrageously quickly and ends up showing that the contract is already verified via a field verification message. Before this feature was implemented the api pod had no means of writing to the db and the request would fail, in this case the web pod will be the component which sends the the request to the indexer.

> tl;dr - verification but (unexpectedly) faster

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/443