### PR TITLE
Explicitly add `api` to allowed request paths for valora compatiblity.

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
@@ -126,6 +126,6 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
       {:error, Exception.format(:error, e, __STACKTRACE__)}
   end
 
-  defp valid_api_request_path(%{request_path: rp}) when rp in ["/api", "/api/v1"], do: :valid
+  defp valid_api_request_path(%{request_path: rp}) when rp in ["/api", "/api/", "/api/v1"], do: :valid
   defp valid_api_request_path(_), do: :invalid
 end


### PR DESCRIPTION
### Description

Valora require `/api/` request path to get token balances correctly, this hasn't been supported since the last deploy. This PR just adds it to the list of valid paths.