### PR TITLE
Define prometheus metrics in config + collect ingestion metrics

### DIFF
--- a/apps/explorer/lib/explorer/celo/pubsub.ex
+++ b/apps/explorer/lib/explorer/celo/pubsub.ex
@@ -17,8 +17,8 @@ defmodule Explorer.Celo.PubSub do
 
     Logger.info("Sending smart contract publish request #{msg_id}")
     message = {:smart_contract_publish, address_hash, attrs, msg_id}
+    Telemetry.event(:smart_contract_publish_send, %{address: address_hash})
     PubSub.broadcast(@pubsub_name, "smart_contract_publish", message)
-    Telemetry.event(:smart_contract_publish_send, %{size: byte_size(message)})
   end
 
   @doc "Subscribe to smart contract messages, messages are in the format {:smart_contract_publish, address_hash, attributes, msg_id}"

--- a/apps/explorer/lib/explorer/celo/pubsub.ex
+++ b/apps/explorer/lib/explorer/celo/pubsub.ex
@@ -16,8 +16,9 @@ defmodule Explorer.Celo.PubSub do
     msg_id = UUID.generate()
 
     Logger.info("Sending smart contract publish request #{msg_id}")
-    PubSub.broadcast(@pubsub_name, "smart_contract_publish", {:smart_contract_publish, address_hash, attrs, msg_id})
-    Telemetry.event(:smart_contract_publish_send, %{})
+    message = {:smart_contract_publish, address_hash, attrs, msg_id}
+    PubSub.broadcast(@pubsub_name, "smart_contract_publish", message)
+    Telemetry.event(:smart_contract_publish_send, %{size: byte_size(message)})
   end
 
   @doc "Subscribe to smart contract messages, messages are in the format {:smart_contract_publish, address_hash, attributes, msg_id}"

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -136,6 +136,10 @@ defmodule Explorer.Chain.Import do
 
   defp emit_ingestion_metrics(data) do
     data
+    |> Enum.filter(fn
+      {_, n} when is_list(n) -> true
+      _ -> false
+    end)
     |> Enum.into(%{}, fn {type, imported_data} -> {type, length(imported_data)} end)
     |> then(&( Telemetry.event(:ingested, &1) ))
   end

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -127,21 +127,24 @@ defmodule Explorer.Chain.Import do
          {:ok, valid_runner_option_pairs} <- validate_runner_options_pairs(runner_options_pairs),
          {:ok, runner_to_changes_list} <- runner_to_changes_list(valid_runner_option_pairs),
          {:ok, data} <- insert_runner_to_changes_list(runner_to_changes_list, options) do
-
       emit_ingestion_metrics(data)
       Publisher.broadcast(data, Map.get(options, :broadcast, false))
       {:ok, data}
     end
   end
 
+  # for all inserted changes that are a valid list + non zero length
+  # collect a mapping
   defp emit_ingestion_metrics(data) do
     data
-    |> Enum.filter(fn
-      {_, n} when is_list(n) -> true
-      _ -> false
+    |> Enum.reduce(%{}, fn
+      {change_key, change_list}, acc when is_list(change_list) and change_list != [] ->
+        {change_key, length(change_list)}
+
+      _, acc ->
+        acc
     end)
-    |> Enum.into(%{}, fn {type, imported_data} -> {type, length(imported_data)} end)
-    |> then(&( Telemetry.event(:ingested, &1) ))
+    |> then(&Telemetry.event(:ingested, &1))
   end
 
   defp runner_to_changes_list(runner_options_pairs) when is_list(runner_options_pairs) do

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -139,7 +139,7 @@ defmodule Explorer.Chain.Import do
     data
     |> Enum.reduce(%{}, fn
       {change_key, change_list}, acc when is_list(change_list) and change_list != [] ->
-        {change_key, length(change_list)}
+        acc |> Map.put(change_key, length(change_list))
 
       _, acc ->
         acc

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -100,6 +100,15 @@ config :indexer, Indexer.Block.Fetcher, enable_gold_token: true
 config :indexer, Indexer.Prometheus.MetricsCron, metrics_fetcher_blocks_count: 1000
 config :indexer, Indexer.Prometheus.MetricsCron, metrics_cron_interval: System.get_env("METRICS_CRON_INTERVAL") || "2"
 
+
+config :indexer, :telemetry_config, [
+  [name: [:blockscout, :ingested], type: :histogram, label: "indexer_ingested", meta: %{
+    buckets: :exponential,
+    help: "Blockchain primitives ingested by type",
+    metric_labels: [:type]
+  }]
+]
+
 config :prometheus, Indexer.Prometheus.Exporter,
   path: "/metrics/indexer",
   format: :text,

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -37,19 +37,19 @@ block_transformer =
   end
 
 config :indexer,
-       block_transformer: block_transformer,
-       ecto_repos: [Explorer.Repo],
-       metadata_updater_seconds_interval:
-         String.to_integer(System.get_env("TOKEN_METADATA_UPDATE_INTERVAL") || "#{10 * 60 * 60}"),
-       health_check_port: port || 4001,
-       first_block: System.get_env("FIRST_BLOCK") || "",
-       last_block: System.get_env("LAST_BLOCK") || "",
-       metrics_enabled: System.get_env("METRICS_ENABLED") || false,
-       trace_first_block: System.get_env("TRACE_FIRST_BLOCK") || "",
-       trace_last_block: System.get_env("TRACE_LAST_BLOCK") || ""
+  block_transformer: block_transformer,
+  ecto_repos: [Explorer.Repo],
+  metadata_updater_seconds_interval:
+    String.to_integer(System.get_env("TOKEN_METADATA_UPDATE_INTERVAL") || "#{10 * 60 * 60}"),
+  health_check_port: port || 4001,
+  first_block: System.get_env("FIRST_BLOCK") || "",
+  last_block: System.get_env("LAST_BLOCK") || "",
+  metrics_enabled: System.get_env("METRICS_ENABLED") || false,
+  trace_first_block: System.get_env("TRACE_FIRST_BLOCK") || "",
+  trace_last_block: System.get_env("TRACE_LAST_BLOCK") || ""
 
 config :indexer, Indexer.Fetcher.PendingTransaction.Supervisor,
-       disabled?: System.get_env("ETHEREUM_JSONRPC_VARIANT") == "besu"
+  disabled?: System.get_env("ETHEREUM_JSONRPC_VARIANT") == "besu"
 
 token_balance_on_demand_fetcher_threshold =
   if System.get_env("TOKEN_BALANCE_ON_DEMAND_FETCHER_THRESHOLD_MINUTES") do
@@ -75,15 +75,15 @@ config :indexer, Indexer.Fetcher.InternalTransaction.Supervisor, disabled?: fals
 config :indexer, Indexer.Supervisor, enabled: System.get_env("DISABLE_INDEXER") != "true"
 
 config :indexer, Indexer.Tracer,
-       service: :indexer,
-       adapter: SpandexDatadog.Adapter,
-       trace_key: :blockscout
+  service: :indexer,
+  adapter: SpandexDatadog.Adapter,
+  trace_key: :blockscout
 
 config :logger_json, :indexer,
-       metadata:
-         ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
        block_number step count error_count shrunk import_id transaction_id)a,
-       metadata_filter: [application: :indexer]
+  metadata_filter: [application: :indexer]
 
 config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]
 
@@ -121,9 +121,9 @@ config :indexer, :telemetry_config, [
 ]
 
 config :prometheus, Indexer.Prometheus.Exporter,
-       path: "/metrics/indexer",
-       format: :text,
-       registry: :default
+  path: "/metrics/indexer",
+  format: :text,
+  registry: :default
 
 indexer_empty_blocks_sanitizer_batch_size =
   if System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE") do
@@ -136,7 +136,7 @@ indexer_empty_blocks_sanitizer_batch_size =
   end
 
 config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer.Supervisor,
-       disabled?: System.get_env("INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER", "false") == "true"
+  disabled?: System.get_env("INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER", "false") == "true"
 
 config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer, batch_size: indexer_empty_blocks_sanitizer_batch_size
 

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -37,19 +37,19 @@ block_transformer =
   end
 
 config :indexer,
-  block_transformer: block_transformer,
-  ecto_repos: [Explorer.Repo],
-  metadata_updater_seconds_interval:
-    String.to_integer(System.get_env("TOKEN_METADATA_UPDATE_INTERVAL") || "#{10 * 60 * 60}"),
-  health_check_port: port || 4001,
-  first_block: System.get_env("FIRST_BLOCK") || "",
-  last_block: System.get_env("LAST_BLOCK") || "",
-  metrics_enabled: System.get_env("METRICS_ENABLED") || false,
-  trace_first_block: System.get_env("TRACE_FIRST_BLOCK") || "",
-  trace_last_block: System.get_env("TRACE_LAST_BLOCK") || ""
+       block_transformer: block_transformer,
+       ecto_repos: [Explorer.Repo],
+       metadata_updater_seconds_interval:
+         String.to_integer(System.get_env("TOKEN_METADATA_UPDATE_INTERVAL") || "#{10 * 60 * 60}"),
+       health_check_port: port || 4001,
+       first_block: System.get_env("FIRST_BLOCK") || "",
+       last_block: System.get_env("LAST_BLOCK") || "",
+       metrics_enabled: System.get_env("METRICS_ENABLED") || false,
+       trace_first_block: System.get_env("TRACE_FIRST_BLOCK") || "",
+       trace_last_block: System.get_env("TRACE_LAST_BLOCK") || ""
 
 config :indexer, Indexer.Fetcher.PendingTransaction.Supervisor,
-  disabled?: System.get_env("ETHEREUM_JSONRPC_VARIANT") == "besu"
+       disabled?: System.get_env("ETHEREUM_JSONRPC_VARIANT") == "besu"
 
 token_balance_on_demand_fetcher_threshold =
   if System.get_env("TOKEN_BALANCE_ON_DEMAND_FETCHER_THRESHOLD_MINUTES") do
@@ -75,15 +75,15 @@ config :indexer, Indexer.Fetcher.InternalTransaction.Supervisor, disabled?: fals
 config :indexer, Indexer.Supervisor, enabled: System.get_env("DISABLE_INDEXER") != "true"
 
 config :indexer, Indexer.Tracer,
-  service: :indexer,
-  adapter: SpandexDatadog.Adapter,
-  trace_key: :blockscout
+       service: :indexer,
+       adapter: SpandexDatadog.Adapter,
+       trace_key: :blockscout
 
 config :logger_json, :indexer,
-  metadata:
-    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       metadata:
+         ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
        block_number step count error_count shrunk import_id transaction_id)a,
-  metadata_filter: [application: :indexer]
+       metadata_filter: [application: :indexer]
 
 config :logger, :indexer, backends: [LoggerJSON, {LoggerBackend, :logger_backend}]
 
@@ -106,17 +106,24 @@ config :indexer, :telemetry_config, [
     type: :summary,
     label: "indexer_import_ingested",
     meta: %{
-      buckets: :default,
       help: "Blockchain primitives ingested via `Import.all` by type",
       metric_labels: [:type]
+    }
+  ],
+  [
+    name: [:blockscout, :chain_event_send],
+    type: :counter,
+    label: "indexer_chain_events_sent",
+    meta: %{
+      help: "Number of chain events sent via pubsub"
     }
   ]
 ]
 
 config :prometheus, Indexer.Prometheus.Exporter,
-  path: "/metrics/indexer",
-  format: :text,
-  registry: :default
+       path: "/metrics/indexer",
+       format: :text,
+       registry: :default
 
 indexer_empty_blocks_sanitizer_batch_size =
   if System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE") do
@@ -129,7 +136,7 @@ indexer_empty_blocks_sanitizer_batch_size =
   end
 
 config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer.Supervisor,
-  disabled?: System.get_env("INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER", "false") == "true"
+       disabled?: System.get_env("INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER", "false") == "true"
 
 config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer, batch_size: indexer_empty_blocks_sanitizer_batch_size
 

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -102,9 +102,9 @@ config :indexer, Indexer.Prometheus.MetricsCron, metrics_cron_interval: System.g
 
 
 config :indexer, :telemetry_config, [
-  [name: [:blockscout, :ingested], type: :histogram, label: "indexer_ingested", meta: %{
-    buckets: :exponential,
-    help: "Blockchain primitives ingested by type",
+  [name: [:blockscout, :ingested], type: :summary, label: "indexer_import_ingested", meta: %{
+    buckets: :default,
+    help: "Blockchain primitives ingested via `Import.all` by type",
     metric_labels: [:type]
   }]
 ]

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -100,13 +100,17 @@ config :indexer, Indexer.Block.Fetcher, enable_gold_token: true
 config :indexer, Indexer.Prometheus.MetricsCron, metrics_fetcher_blocks_count: 1000
 config :indexer, Indexer.Prometheus.MetricsCron, metrics_cron_interval: System.get_env("METRICS_CRON_INTERVAL") || "2"
 
-
 config :indexer, :telemetry_config, [
-  [name: [:blockscout, :ingested], type: :summary, label: "indexer_import_ingested", meta: %{
-    buckets: :default,
-    help: "Blockchain primitives ingested via `Import.all` by type",
-    metric_labels: [:type]
-  }]
+  [
+    name: [:blockscout, :ingested],
+    type: :summary,
+    label: "indexer_import_ingested",
+    meta: %{
+      buckets: :default,
+      help: "Blockchain primitives ingested via `Import.all` by type",
+      metric_labels: [:type]
+    }
+  ]
 ]
 
 config :prometheus, Indexer.Prometheus.Exporter,

--- a/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
@@ -1,0 +1,66 @@
+defmodule Indexer.Prometheus.CeloInstrumenter do
+  @moduledoc "Instrumentation for Celo telemetry"
+
+  use Prometheus.Metric
+
+  def setup do
+    event_config = Application.get_env(:indexer, :telemetry_config)
+
+    event_config |> Enum.each(&(configure_event(&1)))
+  end
+
+  def configure_event(event_config) do
+    case process_config(event_config) do
+      [name, type, label, meta] ->
+        attach_event(name, type, label, meta)
+      {:error, msg} -> Logger.error("Error configuring event #{inspect(event_config)}: #{msg}")
+    end
+  end
+
+  def attach_event(name, :histogram, label, %{buckets: buckets, metric_labels: metric_labels, help: help} = meta) do
+    Histogram.new(
+      name: label,
+      buckets: buckets,
+      duration_unit: false,
+      labels: metric_labels,
+      help: help
+    )
+
+    :telemetry.attach(handler_id(name), name, &CeloInstrumenter.handle_event/4, %{type: :histogram, label: label})
+  end
+
+  def attach_event(name, _type, _label, _meta), do: Logger.info("Not adding metric nope #{name |> inspect()}")
+
+  defp handler_id(event_name), do: "event_handler_id_#{event_name |> to_string()}"
+
+  def handle_event(_name, measurements, _metadata, %{type: :histogram, label: label} = config) when is_map(measurements) do
+    measurements
+    |> Enum.each(fn {name, value} ->
+      Histogram.observe(
+        [name: label, labels: [name]],
+        value
+      )
+    end)
+  end
+
+  def handle_event(name, _measurements, _metadata, _config) do
+    Logger.error("unhandled metric #{name |> inspect()}")
+  end
+
+  defp process_config(event) do
+    name = Keyword.get(event, :name, {:error, "no event name"})
+    type = Keyword.get(event, :type, {:error, "no metric type"})
+    label = Keyword.get(event, :label, {:error, "no metric label"})
+    meta = Keyword.get(event, :meta, %{})
+
+    metric_def = [name, type, label, meta]
+
+    # return error tuple if that is found in metric_def, otherwise return metric_def
+    metric_def
+    |> Enum.find(metric_def,
+         fn {:error, _} -> true
+                           fn n -> false end
+         end)
+  end
+
+end

--- a/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
@@ -62,7 +62,7 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
   defp handler_id(event_name), do: "event_handler_id_#{event_name |> Enum.join() |> to_string()}"
 
   def handle_event(_name, _measurements, _metadata, %{type: :counter, label: label}) do
-    Counter.inc([name: label])
+    Counter.inc(name: label)
   end
 
   def handle_event(_name, measurements, _metadata, %{type: :histogram, label: label})

--- a/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
@@ -20,7 +20,7 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
     end
   end
 
-  def attach_event(name, :summary, label, %{metric_labels: metric_labels, help: help} = meta) do
+  def attach_event(name, :summary, label, %{metric_labels: metric_labels, help: help} = _meta) do
     Logger.info("Attach event #{name |> inspect()}")
 
     Summary.declare(
@@ -32,7 +32,7 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
     :telemetry.attach(handler_id(name), name, &__MODULE__.handle_event/4, %{type: :summary, label: label})
   end
 
-  def attach_event(name, :counter, label, %{help: help} = meta) do
+  def attach_event(name, :counter, label, %{help: help} = _meta) do
     Logger.info("Attach event #{name |> inspect()}")
 
     Counter.declare(
@@ -43,7 +43,7 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
     :telemetry.attach(handler_id(name), name, &__MODULE__.handle_event/4, %{type: :counter, label: label})
   end
 
-  def attach_event(name, :histogram, label, %{buckets: buckets, metric_labels: metric_labels, help: help} = meta) do
+  def attach_event(name, :histogram, label, %{buckets: buckets, metric_labels: metric_labels, help: help} = _meta) do
     Logger.info("Attach event #{name |> inspect()}")
 
     Histogram.new(

--- a/apps/indexer/lib/indexer/prometheus/setup.ex
+++ b/apps/indexer/lib/indexer/prometheus/setup.ex
@@ -5,6 +5,7 @@ defmodule Indexer.Prometheus.Setup do
 
   alias Indexer.Prometheus.{
     BlockInstrumenter,
+    CeloInstrumenter,
     DBInstrumenter,
     Exporter,
     GenericInstrumenter,
@@ -20,7 +21,7 @@ defmodule Indexer.Prometheus.Setup do
     RPCInstrumenter.setup()
     TokenInstrumenter.setup()
     TransactionInstrumenter.setup()
-
+    CeloInstrumenter.setup()
     Exporter.setup()
   end
 end


### PR DESCRIPTION
### Description

Collects and exposes prometheus metrics around ingestion of blockchain primitives. 
 
 ### Other changes

* WIP feature to define metrics within a config file
    * This is functional for counter, histogram and summary prometheus metric types
    * Gauge still needs to be added

### Tested

* Ran locally and saw metrics exposed
* Deployed to rc1staging and metrics were exposed
* wip dashboard at https://clabs.grafana.net/d/9ykNWy4Vk/blockscout-editable-copy?orgId=1

### Issues

 - Relates to https://github.com/celo-org/data-services/issues/431=