### PR TITLE
Fix to update reserve bolster value on runner conflict

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/celo_epoch_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/celo_epoch_rewards.ex
@@ -97,6 +97,7 @@ defmodule Explorer.Chain.Import.Runner.CeloEpochRewards do
           reserve_gold_balance: fragment("EXCLUDED.reserve_gold_balance"),
           gold_total_supply: fragment("EXCLUDED.gold_total_supply"),
           stable_usd_total_supply: fragment("EXCLUDED.stable_usd_total_supply"),
+          reserve_bolster: fragment("EXCLUDED.reserve_bolster"),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", account.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", account.updated_at)
         ]

--- a/apps/indexer/test/indexer/fetcher/celo/celo_epoch_data_test.exs
+++ b/apps/indexer/test/indexer/fetcher/celo/celo_epoch_data_test.exs
@@ -465,6 +465,9 @@ defmodule Indexer.Fetcher.CeloEpochDataTest do
       }
 
       assert CeloEpochDataFetcher.import_items(input) == :ok
+
+      # Test on_conflict cause
+      assert CeloEpochDataFetcher.import_items(input) == :ok
     end
 
     test "with missing data removes rewards type" do


### PR DESCRIPTION
### Description

After merging [a fix for how we fetch reserve bolster value](https://github.com/celo-org/blockscout/pull/762) all values were reset to 0. But after deploying the fix those values were not successfully saved. This PR fixes it.
 
### Tested

Unit tests passed.

### Issues

Fixes https://github.com/celo-org/data-services/issues/509