### PR TITLE
Fix aggregated group and validator counts

### DIFF
--- a/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
@@ -74,14 +74,11 @@ defmodule Explorer.Chain.CeloElectionRewards do
   end
 
   def base_aggregated_block_query(block_number, reward_types) do
-    query =
-      from(rewards in __MODULE__,
-        group_by: rewards.reward_type,
-        where: rewards.block_number == ^block_number,
-        where: rewards.reward_type in ^reward_types
-      )
-
-    query |> where_non_zero_reward()
+    from(rewards in __MODULE__,
+      group_by: rewards.reward_type,
+      where: rewards.block_number == ^block_number,
+      where: rewards.reward_type in ^reward_types
+    )
   end
 
   def aggregated_voter_and_validator_query(block_number) do


### PR DESCRIPTION
### Description

Previously for aggregated epoch data we were not including rewards with amount = 0. Because it is actually a valid scenario (for example where group commission = 0) we will start including those.
 
### Tested

Tested locally to verify the query works fine.

### Issues

 - Relates to https://github.com/celo-org/data-services/issues/499
 - Fixes https://github.com/celo-org/data-services/issues/511
