### PR TITLE
Added block number to the tokenlist response

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -1344,7 +1344,8 @@ defmodule BlockScoutWeb.Etherscan do
       name: @token_name_type,
       symbol: @token_symbol_type,
       decimals: @token_decimal_type,
-      contractAddress: @address_hash_type
+      contractAddress: @address_hash_type,
+      blockNumber: @block_number_type
     }
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -226,6 +226,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "contractAddress" => to_string(token.contract_address_hash),
       "name" => token.name,
       "decimals" => to_string(token.decimals),
+      "blockNumber" => token.block_number,
       "symbol" => token.symbol,
       "type" => token.type
     }

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2604,7 +2604,9 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "with address with existing balance in token_balances table", %{conn: conn} do
-      token_balance = :address_current_token_balance |> insert() |> Repo.preload(:token)
+      block = insert(:block)
+
+      token_balance = :address_current_token_balance |> insert(block_number: block.number) |> Repo.preload(:token)
 
       params = %{
         "module" => "account",
@@ -2618,6 +2620,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
           "contractAddress" => to_string(token_balance.token_contract_address_hash),
           "name" => token_balance.token.name,
           "decimals" => to_string(token_balance.token.decimals),
+          "blockNumber" => block.number,
           "symbol" => token_balance.token.symbol,
           "type" => token_balance.token.type
         }

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -386,6 +386,7 @@ defmodule Explorer.Etherscan do
         where: ctb.value > 0,
         select: %{
           balance: ctb.value,
+          block_number: ctb.block_number,
           contract_address_hash: ctb.token_contract_address_hash,
           name: t.name,
           decimals: t.decimals,

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1598,11 +1598,12 @@ defmodule Explorer.EtherscanTest do
 
   describe "list_tokens/1" do
     test "returns the tokens owned by an address hash" do
+      block = insert(:block)
       address = insert(:address)
 
       token_balance =
         :address_current_token_balance
-        |> insert(address: address)
+        |> insert(address: address, block_number: block.number)
         |> Repo.preload(:token)
 
       insert(:address_current_token_balance, address: build(:address))
@@ -1615,6 +1616,7 @@ defmodule Explorer.EtherscanTest do
           contract_address_hash: token_balance.token_contract_address_hash,
           name: token_balance.token.name,
           decimals: token_balance.token.decimals,
+          block_number: block.number,
           symbol: token_balance.token.symbol,
           type: token_balance.token.type,
           id: token_balance.token_id


### PR DESCRIPTION
### Description

Adds `blockNumber` field to the response of the `module=account&action=tokenlist` API method.

### Tested

Tests updated.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/510
