### PR TITLE
Add updated at index to epoch tables

### DIFF
--- a/apps/explorer/priv/repo/migrations/20221010152811_add_updated_at_indices.exs
+++ b/apps/explorer/priv/repo/migrations/20221010152811_add_updated_at_indices.exs
@@ -1,0 +1,19 @@
+defmodule Explorer.Repo.Migrations.AddUpdatedAtIndices do
+  use Ecto.Migration
+
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
+  @tables ~w(
+    celo_account
+    celo_accounts_epochs
+    celo_election_rewards
+    celo_voter_rewards
+    celo_voter_votes
+    token_instances
+  )a
+
+  def change do
+    for table <- @tables, do: create_if_not_exists(index(table, [:updated_at], concurrently: true))
+  end
+end


### PR DESCRIPTION
This PR adds `updated_at` indices to tables that need to be replicated.

Fixes https://github.com/celo-org/data-services/issues/525