### PR TITLE
Change log level for failed token instance fetching

### DIFF
--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -229,7 +229,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     end
   rescue
     e ->
-      Logger.debug(["Could not send request to token uri #{inspect(uri)}. error #{inspect(e)}"],
+      Logger.info(["Could not send request to token uri #{inspect(uri)}. error #{inspect(e)}"],
         fetcher: :token_instances
       )
 


### PR DESCRIPTION
This PR change log level for failed token instance fetching to give us more visibility over what's happening.