### PR TITLE
Shazarre/upstream merges for token instance fetching fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 
 ### Fixes
 - [#5045](https://github.com/blockscout/blockscout/pull/5045) - Contracts interaction improvements
-- [#5032](https://github.com/blockscout/blockscout/pull/5032) - Fix token transfer csv export
+- [#5032](https://github.com/blockscout/blockscout/pull/5032) - Fix token transfer csv export 
 - [#5020](https://github.com/blockscout/blockscout/pull/5020) - Token instance image display imrovement
 - [#5019](https://github.com/blockscout/blockscout/pull/5019) - Fix fetch_last_token_balance function termination
 - [#5011](https://github.com/blockscout/blockscout/pull/5011) - Fix `0x0` implementation address
@@ -222,7 +222,7 @@
 - [#4488](https://github.com/blockscout/blockscout/pull/4488) - Tx page: handle empty to_address
 - [#4483](https://github.com/blockscout/blockscout/pull/4483) - Fix copy-paste typo in `token_transfers_counter.ex`
 - [#4473](https://github.com/blockscout/blockscout/pull/4473), [#4481](https://github.com/blockscout/blockscout/pull/4481) - Search autocomplete: fix for address/block/tx hash
-- [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: fix Cannot read property toLowerCase of undefined
+- [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: fix Cannot read property toLowerCase of undefined 
 - [#4456](https://github.com/blockscout/blockscout/pull/4456) - URL encoding for NFT media files URLs
 - [#4453](https://github.com/blockscout/blockscout/pull/4453) - Unescape characters for string output type in the contract response
 - [#4401](https://github.com/blockscout/blockscout/pull/4401) - Fix displaying of token holders with the same amount
@@ -274,7 +274,7 @@
 - [#4299](https://github.com/blockscout/blockscout/pull/4299) - Added [Sourcify](https://sourcify.dev) verification API endpoint
 - [#4267](https://github.com/blockscout/blockscout/pull/4267) - Extend verification through [Sourcify](https://sourcify.dev) smart-contract verification: fetch smart contract metadata from Sourcify repo if it has been already verified there
 - [#4241](https://github.com/blockscout/blockscout/pull/4241) - Reload transactions on the main page without reloading of the whole page
-- [#4218](https://github.com/blockscout/blockscout/pull/4218) - Hide long arrays in smart-contracts
+- [#4218](https://github.com/blockscout/blockscout/pull/4218) - Hide long arrays in smart-contracts 
 - [#4205](https://github.com/blockscout/blockscout/pull/4205) - Total transactions fees per day API endpoint
 - [#4158](https://github.com/blockscout/blockscout/pull/4158) - Calculate total fee per day
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
@@ -284,7 +284,7 @@
 - [#4346](https://github.com/blockscout/blockscout/pull/4346) - Fix internal server error on raw-trace transaction page
 - [#4345](https://github.com/blockscout/blockscout/pull/4345) - Fix bug on validator's address transactions page(Support effectiveGasPrice property in receipt (geth specific))
 - [#4342](https://github.com/blockscout/blockscout/pull/4342) - Remove dropped/replaced txs from address transactions page
-- [#4320](https://github.com/blockscout/blockscout/pull/4320) - Fix absence of imported smart-contracts' source code in `getsourcecode` API method
+- [#4320](https://github.com/blockscout/blockscout/pull/4320) - Fix absence of imported smart-contracts' source code in `getsourcecode` API method 
 - [#4274](https://github.com/blockscout/blockscout/pull/4302) - Fix search token-autocomplete
 - [#4316](https://github.com/blockscout/blockscout/pull/4316) - Fix `/decompiled-contracts` bug
 - [#4310](https://github.com/blockscout/blockscout/pull/4310) - Fix logo URL redirection, set font-family defaults for chart.js
@@ -427,7 +427,7 @@
 
 ### Features
 - [#3558](https://github.com/blockscout/blockscout/pull/3558) - Focus to search field with a forward slash key
-- [#3541](https://github.com/blockscout/blockscout/pull/3541) - Staking dapp stats: total number of delegators, total staked amount
+- [#3541](https://github.com/blockscout/blockscout/pull/3541) - Staking dapp stats: total number of delegators, total staked amount 
 - [#3540](https://github.com/blockscout/blockscout/pull/3540) - Apply DarkForest custom theme to NFT instances
 
 ### Fixes
@@ -930,7 +930,7 @@
 - [#2746](https://github.com/blockscout/blockscout/pull/2746) - fixed wrong alignment in logs decoded view
 - [#2745](https://github.com/blockscout/blockscout/pull/2745) - optimize addresses page
 - [#2742](https://github.com/blockscout/blockscout/pull/2742) -
-  fixed menu hovers in dark mode desktop view
+fixed menu hovers in dark mode desktop view
 - [#2737](https://github.com/blockscout/blockscout/pull/2737) - switched hardcoded subnetwork value to elixir expression for mobile menu
 - [#2736](https://github.com/blockscout/blockscout/pull/2736) - do not update cache if no blocks were inserted
 - [#2731](https://github.com/blockscout/blockscout/pull/2731) - fix library verification
@@ -1387,83 +1387,83 @@ Reverting of synchronous block counter, implemented in #1848
 
 ### Fixes
 
-- [#1724](https://github.com/blockscout/blockscout/pull/1724) - Remove internal tx and token balance fetching from realtime fetcher
-- [#1727](https://github.com/blockscout/blockscout/pull/1727) - add logs pagination in rpc api
-- [#1740](https://github.com/blockscout/blockscout/pull/1740) - fix empty block time
-- [#1743](https://github.com/blockscout/blockscout/pull/1743) - sort decompiled smart contracts in lexicographical order
-- [#1756](https://github.com/blockscout/blockscout/pull/1756) - add today's token balance from the previous value
-- [#1769](https://github.com/blockscout/blockscout/pull/1769) - add timestamp to block overview
-- [#1768](https://github.com/blockscout/blockscout/pull/1768) - fix first block parameter
-- [#1778](https://github.com/blockscout/blockscout/pull/1778) - Make websocket optional for realtime fetcher
-- [#1790](https://github.com/blockscout/blockscout/pull/1790) - fix constructor arguments verification
-- [#1793](https://github.com/blockscout/blockscout/pull/1793) - fix top nav autocomplete
-- [#1795](https://github.com/blockscout/blockscout/pull/1795) - fix line numbers for decompiled contracts
-- [#1803](https://github.com/blockscout/blockscout/pull/1803) - use coinmarketcap for total_supply by default
-- [#1802](https://github.com/blockscout/blockscout/pull/1802) - make coinmarketcap's number of pages configurable
-- [#1799](https://github.com/blockscout/blockscout/pull/1799) - Use eth_getUncleByBlockHashAndIndex for uncle block fetching
-- [#1531](https://github.com/blockscout/blockscout/pull/1531) - docker: fix dockerFile for secp256k1 building
-- [#1835](https://github.com/blockscout/blockscout/pull/1835) - fix: ignore `pong` messages without error
+ - [#1724](https://github.com/blockscout/blockscout/pull/1724) - Remove internal tx and token balance fetching from realtime fetcher
+ - [#1727](https://github.com/blockscout/blockscout/pull/1727) - add logs pagination in rpc api
+ - [#1740](https://github.com/blockscout/blockscout/pull/1740) - fix empty block time
+ - [#1743](https://github.com/blockscout/blockscout/pull/1743) - sort decompiled smart contracts in lexicographical order
+ - [#1756](https://github.com/blockscout/blockscout/pull/1756) - add today's token balance from the previous value
+ - [#1769](https://github.com/blockscout/blockscout/pull/1769) - add timestamp to block overview
+ - [#1768](https://github.com/blockscout/blockscout/pull/1768) - fix first block parameter
+ - [#1778](https://github.com/blockscout/blockscout/pull/1778) - Make websocket optional for realtime fetcher
+ - [#1790](https://github.com/blockscout/blockscout/pull/1790) - fix constructor arguments verification
+ - [#1793](https://github.com/blockscout/blockscout/pull/1793) - fix top nav autocomplete
+ - [#1795](https://github.com/blockscout/blockscout/pull/1795) - fix line numbers for decompiled contracts
+ - [#1803](https://github.com/blockscout/blockscout/pull/1803) - use coinmarketcap for total_supply by default
+ - [#1802](https://github.com/blockscout/blockscout/pull/1802) - make coinmarketcap's number of pages configurable
+ - [#1799](https://github.com/blockscout/blockscout/pull/1799) - Use eth_getUncleByBlockHashAndIndex for uncle block fetching
+ - [#1531](https://github.com/blockscout/blockscout/pull/1531) - docker: fix dockerFile for secp256k1 building
+ - [#1835](https://github.com/blockscout/blockscout/pull/1835) - fix: ignore `pong` messages without error
 
 ### Chore
 
-- [#1804](https://github.com/blockscout/blockscout/pull/1804) - (Chore) Divide chains by Mainnet/Testnet in menu
-- [#1783](https://github.com/blockscout/blockscout/pull/1783) - Update README with the chains that use Blockscout
-- [#1780](https://github.com/blockscout/blockscout/pull/1780) - Update link to the Github repo in the footer
-- [#1757](https://github.com/blockscout/blockscout/pull/1757) - Change twitter acc link to official Blockscout acc twitter
-- [#1749](https://github.com/blockscout/blockscout/pull/1749) - Replace the link in the footer with the official POA announcements tg channel link
-- [#1718](https://github.com/blockscout/blockscout/pull/1718) - Flatten indexer module hierarchy and supervisor tree
-- [#1753](https://github.com/blockscout/blockscout/pull/1753) - Add a check mark to decompiled contract tab
-- [#1744](https://github.com/blockscout/blockscout/pull/1744) - remove `0x0..0` from tests
-- [#1763](https://github.com/blockscout/blockscout/pull/1763) - Describe indexer structure and list existing fetchers
-- [#1800](https://github.com/blockscout/blockscout/pull/1800) - Disable lazy logging check in Credo
+ - [#1804](https://github.com/blockscout/blockscout/pull/1804) - (Chore) Divide chains by Mainnet/Testnet in menu
+ - [#1783](https://github.com/blockscout/blockscout/pull/1783) - Update README with the chains that use Blockscout
+ - [#1780](https://github.com/blockscout/blockscout/pull/1780) - Update link to the Github repo in the footer
+ - [#1757](https://github.com/blockscout/blockscout/pull/1757) - Change twitter acc link to official Blockscout acc twitter
+ - [#1749](https://github.com/blockscout/blockscout/pull/1749) - Replace the link in the footer with the official POA announcements tg channel link
+ - [#1718](https://github.com/blockscout/blockscout/pull/1718) - Flatten indexer module hierarchy and supervisor tree
+ - [#1753](https://github.com/blockscout/blockscout/pull/1753) - Add a check mark to decompiled contract tab
+ - [#1744](https://github.com/blockscout/blockscout/pull/1744) - remove `0x0..0` from tests
+ - [#1763](https://github.com/blockscout/blockscout/pull/1763) - Describe indexer structure and list existing fetchers
+ - [#1800](https://github.com/blockscout/blockscout/pull/1800) - Disable lazy logging check in Credo
 
 
 ## 1.3.9-beta
 
 ### Features
 
-- [#1662](https://github.com/blockscout/blockscout/pull/1662) - allow specifying number of optimization runs
-- [#1654](https://github.com/blockscout/blockscout/pull/1654) - add decompiled code tab
-- [#1661](https://github.com/blockscout/blockscout/pull/1661) - try to compile smart contract with the latest evm version
-- [#1665](https://github.com/blockscout/blockscout/pull/1665) - Add contract verification RPC endpoint.
-- [#1706](https://github.com/blockscout/blockscout/pull/1706) - allow setting update interval for addresses with b
+ - [#1662](https://github.com/blockscout/blockscout/pull/1662) - allow specifying number of optimization runs
+ - [#1654](https://github.com/blockscout/blockscout/pull/1654) - add decompiled code tab
+ - [#1661](https://github.com/blockscout/blockscout/pull/1661) - try to compile smart contract with the latest evm version
+ - [#1665](https://github.com/blockscout/blockscout/pull/1665) - Add contract verification RPC endpoint.
+ - [#1706](https://github.com/blockscout/blockscout/pull/1706) - allow setting update interval for addresses with b
 
 ### Fixes
 
-- [#1669](https://github.com/blockscout/blockscout/pull/1669) - do not fail if multiple matching tokens are found
-- [#1691](https://github.com/blockscout/blockscout/pull/1691) - decrease token metadata update interval
-- [#1688](https://github.com/blockscout/blockscout/pull/1688) - do not fail if failure reason is atom
-- [#1692](https://github.com/blockscout/blockscout/pull/1692) - exclude decompiled smart contract from encoding
-- [#1684](https://github.com/blockscout/blockscout/pull/1684) - Discard child block with parent_hash not matching hash of imported block
-- [#1699](https://github.com/blockscout/blockscout/pull/1699) - use seconds as transaction cache period measure
-- [#1697](https://github.com/blockscout/blockscout/pull/1697) - fix failing in rpc if balance is empty
-- [#1711](https://github.com/blockscout/blockscout/pull/1711) - rescue failing repo in block number cache update
-- [#1712](https://github.com/blockscout/blockscout/pull/1712) - do not set contract code from transaction input
-- [#1714](https://github.com/blockscout/blockscout/pull/1714) - fix average block time calculation
+ - [#1669](https://github.com/blockscout/blockscout/pull/1669) - do not fail if multiple matching tokens are found
+ - [#1691](https://github.com/blockscout/blockscout/pull/1691) - decrease token metadata update interval
+ - [#1688](https://github.com/blockscout/blockscout/pull/1688) - do not fail if failure reason is atom
+ - [#1692](https://github.com/blockscout/blockscout/pull/1692) - exclude decompiled smart contract from encoding
+ - [#1684](https://github.com/blockscout/blockscout/pull/1684) - Discard child block with parent_hash not matching hash of imported block
+ - [#1699](https://github.com/blockscout/blockscout/pull/1699) - use seconds as transaction cache period measure
+ - [#1697](https://github.com/blockscout/blockscout/pull/1697) - fix failing in rpc if balance is empty
+ - [#1711](https://github.com/blockscout/blockscout/pull/1711) - rescue failing repo in block number cache update
+ - [#1712](https://github.com/blockscout/blockscout/pull/1712) - do not set contract code from transaction input
+ - [#1714](https://github.com/blockscout/blockscout/pull/1714) - fix average block time calculation
 
 ### Chore
 
-- [#1693](https://github.com/blockscout/blockscout/pull/1693) - Add a checklist to the PR template
+ - [#1693](https://github.com/blockscout/blockscout/pull/1693) - Add a checklist to the PR template
 
 
 ## 1.3.8-beta
 
 ### Features
 
-- [#1611](https://github.com/blockscout/blockscout/pull/1611) - allow setting the first indexing block
-- [#1596](https://github.com/blockscout/blockscout/pull/1596) - add endpoint to create decompiled contracts
-- [#1634](https://github.com/blockscout/blockscout/pull/1634) - add transaction count cache
+ - [#1611](https://github.com/blockscout/blockscout/pull/1611) - allow setting the first indexing block
+ - [#1596](https://github.com/blockscout/blockscout/pull/1596) - add endpoint to create decompiled contracts
+ - [#1634](https://github.com/blockscout/blockscout/pull/1634) - add transaction count cache
 
 ### Fixes
 
-- [#1630](https://github.com/blockscout/blockscout/pull/1630) - (Fix) colour for release link in the footer
-- [#1621](https://github.com/blockscout/blockscout/pull/1621) - Modify query to fetch failed contract creations
-- [#1614](https://github.com/blockscout/blockscout/pull/1614) - Do not fetch burn address token balance
-- [#1639](https://github.com/blockscout/blockscout/pull/1614) - Optimize token holder count updates when importing address current balances
-- [#1643](https://github.com/blockscout/blockscout/pull/1643) - Set internal_transactions_indexed_at for empty blocks
-- [#1647](https://github.com/blockscout/blockscout/pull/1647) - Fix typo in view
-- [#1650](https://github.com/blockscout/blockscout/pull/1650) - Add petersburg evm version to smart contract verifier
-- [#1657](https://github.com/blockscout/blockscout/pull/1657) - Force consensus loss for parent block if its hash mismatches parent_hash
+ - [#1630](https://github.com/blockscout/blockscout/pull/1630) - (Fix) colour for release link in the footer
+ - [#1621](https://github.com/blockscout/blockscout/pull/1621) - Modify query to fetch failed contract creations
+ - [#1614](https://github.com/blockscout/blockscout/pull/1614) - Do not fetch burn address token balance
+ - [#1639](https://github.com/blockscout/blockscout/pull/1614) - Optimize token holder count updates when importing address current balances
+ - [#1643](https://github.com/blockscout/blockscout/pull/1643) - Set internal_transactions_indexed_at for empty blocks
+ - [#1647](https://github.com/blockscout/blockscout/pull/1647) - Fix typo in view
+ - [#1650](https://github.com/blockscout/blockscout/pull/1650) - Add petersburg evm version to smart contract verifier
+ - [#1657](https://github.com/blockscout/blockscout/pull/1657) - Force consensus loss for parent block if its hash mismatches parent_hash
 
 ### Chore
 
@@ -1474,78 +1474,78 @@ Reverting of synchronous block counter, implemented in #1848
 
 ### Fixes
 
-- [#1615](https://github.com/blockscout/blockscout/pull/1615) - Add more logging to code fixer process
-- [#1613](https://github.com/blockscout/blockscout/pull/1613) - Fix USD fee value
-- [#1577](https://github.com/blockscout/blockscout/pull/1577) - Add process to fix contract with code
-- [#1583](https://github.com/blockscout/blockscout/pull/1583) - Chunk JSON-RPC batches in case connection times out
+ - [#1615](https://github.com/blockscout/blockscout/pull/1615) - Add more logging to code fixer process
+ - [#1613](https://github.com/blockscout/blockscout/pull/1613) - Fix USD fee value
+ - [#1577](https://github.com/blockscout/blockscout/pull/1577) - Add process to fix contract with code
+ - [#1583](https://github.com/blockscout/blockscout/pull/1583) - Chunk JSON-RPC batches in case connection times out
 
 ### Chore
 
-- [#1610](https://github.com/blockscout/blockscout/pull/1610) - Add PIRL to Readme
+ - [#1610](https://github.com/blockscout/blockscout/pull/1610) - Add PIRL to Readme
 
 
 ## 1.3.6-beta
 
 ### Features
 
-- [#1589](https://github.com/blockscout/blockscout/pull/1589) - RPC endpoint to list addresses
-- [#1567](https://github.com/blockscout/blockscout/pull/1567) - Allow setting different configuration just for realtime fetcher
-- [#1562](https://github.com/blockscout/blockscout/pull/1562) - Add incoming transactions count to contract view
-- [#1608](https://github.com/blockscout/blockscout/pull/1608) - Add listcontracts RPC Endpoint
+ - [#1589](https://github.com/blockscout/blockscout/pull/1589) - RPC endpoint to list addresses
+ - [#1567](https://github.com/blockscout/blockscout/pull/1567) - Allow setting different configuration just for realtime fetcher
+ - [#1562](https://github.com/blockscout/blockscout/pull/1562) - Add incoming transactions count to contract view
+ - [#1608](https://github.com/blockscout/blockscout/pull/1608) - Add listcontracts RPC Endpoint
 
 ### Fixes
 
-- [#1595](https://github.com/blockscout/blockscout/pull/1595) - Reduce block_rewards in the catchup fetcher
-- [#1590](https://github.com/blockscout/blockscout/pull/1590) - Added guard for fetching blocks with invalid number
-- [#1588](https://github.com/blockscout/blockscout/pull/1588) - Fix usd value on address page
-- [#1586](https://github.com/blockscout/blockscout/pull/1586) - Exact timestamp display
-- [#1581](https://github.com/blockscout/blockscout/pull/1581) - Consider `creates` param when fetching transactions
-- [#1559](https://github.com/blockscout/blockscout/pull/1559) - Change v column type for Transactions table
+ - [#1595](https://github.com/blockscout/blockscout/pull/1595) - Reduce block_rewards in the catchup fetcher
+ - [#1590](https://github.com/blockscout/blockscout/pull/1590) - Added guard for fetching blocks with invalid number
+ - [#1588](https://github.com/blockscout/blockscout/pull/1588) - Fix usd value on address page
+ - [#1586](https://github.com/blockscout/blockscout/pull/1586) - Exact timestamp display
+ - [#1581](https://github.com/blockscout/blockscout/pull/1581) - Consider `creates` param when fetching transactions
+ - [#1559](https://github.com/blockscout/blockscout/pull/1559) - Change v column type for Transactions table
 
 ### Chore
 
-- [#1579](https://github.com/blockscout/blockscout/pull/1579) - Add SpringChain to the list of Additional Chains Utilizing BlockScout
-- [#1578](https://github.com/blockscout/blockscout/pull/1578) - Refine contributing procedure
-- [#1572](https://github.com/blockscout/blockscout/pull/1572) - Add option to disable block rewards in indexer config
+ - [#1579](https://github.com/blockscout/blockscout/pull/1579) - Add SpringChain to the list of Additional Chains Utilizing BlockScout
+ - [#1578](https://github.com/blockscout/blockscout/pull/1578) - Refine contributing procedure
+ - [#1572](https://github.com/blockscout/blockscout/pull/1572) - Add option to disable block rewards in indexer config
 
 
 ## 1.3.5-beta
 
 ### Features
 
-- [#1560](https://github.com/blockscout/blockscout/pull/1560) - Allow executing smart contract functions in arbitrarily sized batches
-- [#1543](https://github.com/blockscout/blockscout/pull/1543) - Use trace_replayBlockTransactions API for faster tracing
-- [#1558](https://github.com/blockscout/blockscout/pull/1558) - Allow searching by token symbol
-- [#1551](https://github.com/blockscout/blockscout/pull/1551) Exact date and time for Transaction details page
-- [#1547](https://github.com/blockscout/blockscout/pull/1547) - Verify smart contracts with evm versions
-- [#1540](https://github.com/blockscout/blockscout/pull/1540) - Fetch ERC721 token balances if sender is '0x0..0'
-- [#1539](https://github.com/blockscout/blockscout/pull/1539) - Add the link to release in the footer
-- [#1519](https://github.com/blockscout/blockscout/pull/1519) - Create contract methods
-- [#1496](https://github.com/blockscout/blockscout/pull/1496) - Remove dropped/replaced transactions in pending transactions list
-- [#1492](https://github.com/blockscout/blockscout/pull/1492) - Disable usd value for an empty exchange rate
-- [#1466](https://github.com/blockscout/blockscout/pull/1466) - Decoding candidates for unverified contracts
+ - [#1560](https://github.com/blockscout/blockscout/pull/1560) - Allow executing smart contract functions in arbitrarily sized batches
+ - [#1543](https://github.com/blockscout/blockscout/pull/1543) - Use trace_replayBlockTransactions API for faster tracing
+ - [#1558](https://github.com/blockscout/blockscout/pull/1558) - Allow searching by token symbol
+ - [#1551](https://github.com/blockscout/blockscout/pull/1551) Exact date and time for Transaction details page
+ - [#1547](https://github.com/blockscout/blockscout/pull/1547) - Verify smart contracts with evm versions
+ - [#1540](https://github.com/blockscout/blockscout/pull/1540) - Fetch ERC721 token balances if sender is '0x0..0'
+ - [#1539](https://github.com/blockscout/blockscout/pull/1539) - Add the link to release in the footer
+ - [#1519](https://github.com/blockscout/blockscout/pull/1519) - Create contract methods
+ - [#1496](https://github.com/blockscout/blockscout/pull/1496) - Remove dropped/replaced transactions in pending transactions list
+ - [#1492](https://github.com/blockscout/blockscout/pull/1492) - Disable usd value for an empty exchange rate
+ - [#1466](https://github.com/blockscout/blockscout/pull/1466) - Decoding candidates for unverified contracts
 
 ### Fixes
-- [#1545](https://github.com/blockscout/blockscout/pull/1545) - Fix scheduling of latest block polling in Realtime Fetcher
-- [#1554](https://github.com/blockscout/blockscout/pull/1554) - Encode integer parameters when calling smart contract functions
-- [#1537](https://github.com/blockscout/blockscout/pull/1537) - Fix test that depended on date
-- [#1534](https://github.com/blockscout/blockscout/pull/1534) - Render a nicer error when creator cannot be determined
-- [#1527](https://github.com/blockscout/blockscout/pull/1527) - Add index to value_fetched_at
-- [#1518](https://github.com/blockscout/blockscout/pull/1518) - Select only distinct failed transactions
-- [#1516](https://github.com/blockscout/blockscout/pull/1516) - Fix coin balance params reducer for pending transaction
-- [#1511](https://github.com/blockscout/blockscout/pull/1511) - Set correct log level for production
-- [#1510](https://github.com/blockscout/blockscout/pull/1510) - Fix test that fails every 1st day of the month
-- [#1509](https://github.com/blockscout/blockscout/pull/1509) - Add index to blocks' consensus
-- [#1508](https://github.com/blockscout/blockscout/pull/1508) - Remove duplicated indexes
-- [#1505](https://github.com/blockscout/blockscout/pull/1505) - Use https instead of ssh for absinthe libs
-- [#1501](https://github.com/blockscout/blockscout/pull/1501) - Constructor_arguments must be type `text`
-- [#1498](https://github.com/blockscout/blockscout/pull/1498) - Add index for created_contract_address_hash in transactions
-- [#1493](https://github.com/blockscout/blockscout/pull/1493) - Do not do work in process initialization
-- [#1487](https://github.com/blockscout/blockscout/pull/1487) - Limit geth sync to 128 blocks
-- [#1484](https://github.com/blockscout/blockscout/pull/1484) - Allow decoding input as utf-8
-- [#1479](https://github.com/blockscout/blockscout/pull/1479) - Remove smoothing from coin balance chart
+ - [#1545](https://github.com/blockscout/blockscout/pull/1545) - Fix scheduling of latest block polling in Realtime Fetcher
+ - [#1554](https://github.com/blockscout/blockscout/pull/1554) - Encode integer parameters when calling smart contract functions
+ - [#1537](https://github.com/blockscout/blockscout/pull/1537) - Fix test that depended on date
+ - [#1534](https://github.com/blockscout/blockscout/pull/1534) - Render a nicer error when creator cannot be determined
+ - [#1527](https://github.com/blockscout/blockscout/pull/1527) - Add index to value_fetched_at
+ - [#1518](https://github.com/blockscout/blockscout/pull/1518) - Select only distinct failed transactions
+ - [#1516](https://github.com/blockscout/blockscout/pull/1516) - Fix coin balance params reducer for pending transaction
+ - [#1511](https://github.com/blockscout/blockscout/pull/1511) - Set correct log level for production
+ - [#1510](https://github.com/blockscout/blockscout/pull/1510) - Fix test that fails every 1st day of the month
+ - [#1509](https://github.com/blockscout/blockscout/pull/1509) - Add index to blocks' consensus
+ - [#1508](https://github.com/blockscout/blockscout/pull/1508) - Remove duplicated indexes
+ - [#1505](https://github.com/blockscout/blockscout/pull/1505) - Use https instead of ssh for absinthe libs
+ - [#1501](https://github.com/blockscout/blockscout/pull/1501) - Constructor_arguments must be type `text`
+ - [#1498](https://github.com/blockscout/blockscout/pull/1498) - Add index for created_contract_address_hash in transactions
+ - [#1493](https://github.com/blockscout/blockscout/pull/1493) - Do not do work in process initialization
+ - [#1487](https://github.com/blockscout/blockscout/pull/1487) - Limit geth sync to 128 blocks
+ - [#1484](https://github.com/blockscout/blockscout/pull/1484) - Allow decoding input as utf-8
+ - [#1479](https://github.com/blockscout/blockscout/pull/1479) - Remove smoothing from coin balance chart
 
 ### Chore
-- [https://github.com/blockscout/blockscout/pull/1532](https://github.com/blockscout/blockscout/pull/1532) - Upgrade elixir to 1.8.1
-- [https://github.com/blockscout/blockscout/pull/1553](https://github.com/blockscout/blockscout/pull/1553) - Dockerfile: remove 1.7.1 version pin FROM bitwalker/alpine-elixir-phoenix
-- [https://github.com/blockscout/blockscout/pull/1465](https://github.com/blockscout/blockscout/pull/1465) - Resolve lodash security alert
+ - [https://github.com/blockscout/blockscout/pull/1532](https://github.com/blockscout/blockscout/pull/1532) - Upgrade elixir to 1.8.1
+ - [https://github.com/blockscout/blockscout/pull/1553](https://github.com/blockscout/blockscout/pull/1553) - Dockerfile: remove 1.7.1 version pin FROM bitwalker/alpine-elixir-phoenix
+ - [https://github.com/blockscout/blockscout/pull/1465](https://github.com/blockscout/blockscout/pull/1465) - Resolve lodash security alert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#5105](https://github.com/blockscout/blockscout/pull/5105) - Redesign token page
 - [#5016](https://github.com/blockscout/blockscout/pull/5016) - Add view for internal transactions error
 - [#4690](https://github.com/blockscout/blockscout/pull/4690) - Improve pagination: introduce pagination with random access to pages; Integrate it to the Transactions List page
+- [#6168](https://github.com/blockscout/blockscout/pull/6168) - Token instance fetcher checks instance owner and updates current token balance
 
 ### Fixes
 - [#5216](https://github.com/blockscout/blockscout/pull/5216) - Add token-transfers-toggle.js to the `block_transaction/index.html.eex`
@@ -78,7 +79,7 @@
 
 ### Fixes
 - [#5045](https://github.com/blockscout/blockscout/pull/5045) - Contracts interaction improvements
-- [#5032](https://github.com/blockscout/blockscout/pull/5032) - Fix token transfer csv export 
+- [#5032](https://github.com/blockscout/blockscout/pull/5032) - Fix token transfer csv export
 - [#5020](https://github.com/blockscout/blockscout/pull/5020) - Token instance image display imrovement
 - [#5019](https://github.com/blockscout/blockscout/pull/5019) - Fix fetch_last_token_balance function termination
 - [#5011](https://github.com/blockscout/blockscout/pull/5011) - Fix `0x0` implementation address
@@ -221,7 +222,7 @@
 - [#4488](https://github.com/blockscout/blockscout/pull/4488) - Tx page: handle empty to_address
 - [#4483](https://github.com/blockscout/blockscout/pull/4483) - Fix copy-paste typo in `token_transfers_counter.ex`
 - [#4473](https://github.com/blockscout/blockscout/pull/4473), [#4481](https://github.com/blockscout/blockscout/pull/4481) - Search autocomplete: fix for address/block/tx hash
-- [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: fix Cannot read property toLowerCase of undefined 
+- [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: fix Cannot read property toLowerCase of undefined
 - [#4456](https://github.com/blockscout/blockscout/pull/4456) - URL encoding for NFT media files URLs
 - [#4453](https://github.com/blockscout/blockscout/pull/4453) - Unescape characters for string output type in the contract response
 - [#4401](https://github.com/blockscout/blockscout/pull/4401) - Fix displaying of token holders with the same amount
@@ -273,7 +274,7 @@
 - [#4299](https://github.com/blockscout/blockscout/pull/4299) - Added [Sourcify](https://sourcify.dev) verification API endpoint
 - [#4267](https://github.com/blockscout/blockscout/pull/4267) - Extend verification through [Sourcify](https://sourcify.dev) smart-contract verification: fetch smart contract metadata from Sourcify repo if it has been already verified there
 - [#4241](https://github.com/blockscout/blockscout/pull/4241) - Reload transactions on the main page without reloading of the whole page
-- [#4218](https://github.com/blockscout/blockscout/pull/4218) - Hide long arrays in smart-contracts 
+- [#4218](https://github.com/blockscout/blockscout/pull/4218) - Hide long arrays in smart-contracts
 - [#4205](https://github.com/blockscout/blockscout/pull/4205) - Total transactions fees per day API endpoint
 - [#4158](https://github.com/blockscout/blockscout/pull/4158) - Calculate total fee per day
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
@@ -283,7 +284,7 @@
 - [#4346](https://github.com/blockscout/blockscout/pull/4346) - Fix internal server error on raw-trace transaction page
 - [#4345](https://github.com/blockscout/blockscout/pull/4345) - Fix bug on validator's address transactions page(Support effectiveGasPrice property in receipt (geth specific))
 - [#4342](https://github.com/blockscout/blockscout/pull/4342) - Remove dropped/replaced txs from address transactions page
-- [#4320](https://github.com/blockscout/blockscout/pull/4320) - Fix absence of imported smart-contracts' source code in `getsourcecode` API method 
+- [#4320](https://github.com/blockscout/blockscout/pull/4320) - Fix absence of imported smart-contracts' source code in `getsourcecode` API method
 - [#4274](https://github.com/blockscout/blockscout/pull/4302) - Fix search token-autocomplete
 - [#4316](https://github.com/blockscout/blockscout/pull/4316) - Fix `/decompiled-contracts` bug
 - [#4310](https://github.com/blockscout/blockscout/pull/4310) - Fix logo URL redirection, set font-family defaults for chart.js
@@ -426,7 +427,7 @@
 
 ### Features
 - [#3558](https://github.com/blockscout/blockscout/pull/3558) - Focus to search field with a forward slash key
-- [#3541](https://github.com/blockscout/blockscout/pull/3541) - Staking dapp stats: total number of delegators, total staked amount 
+- [#3541](https://github.com/blockscout/blockscout/pull/3541) - Staking dapp stats: total number of delegators, total staked amount
 - [#3540](https://github.com/blockscout/blockscout/pull/3540) - Apply DarkForest custom theme to NFT instances
 
 ### Fixes
@@ -929,7 +930,7 @@
 - [#2746](https://github.com/blockscout/blockscout/pull/2746) - fixed wrong alignment in logs decoded view
 - [#2745](https://github.com/blockscout/blockscout/pull/2745) - optimize addresses page
 - [#2742](https://github.com/blockscout/blockscout/pull/2742) -
-fixed menu hovers in dark mode desktop view
+  fixed menu hovers in dark mode desktop view
 - [#2737](https://github.com/blockscout/blockscout/pull/2737) - switched hardcoded subnetwork value to elixir expression for mobile menu
 - [#2736](https://github.com/blockscout/blockscout/pull/2736) - do not update cache if no blocks were inserted
 - [#2731](https://github.com/blockscout/blockscout/pull/2731) - fix library verification
@@ -1386,83 +1387,83 @@ Reverting of synchronous block counter, implemented in #1848
 
 ### Fixes
 
- - [#1724](https://github.com/blockscout/blockscout/pull/1724) - Remove internal tx and token balance fetching from realtime fetcher
- - [#1727](https://github.com/blockscout/blockscout/pull/1727) - add logs pagination in rpc api
- - [#1740](https://github.com/blockscout/blockscout/pull/1740) - fix empty block time
- - [#1743](https://github.com/blockscout/blockscout/pull/1743) - sort decompiled smart contracts in lexicographical order
- - [#1756](https://github.com/blockscout/blockscout/pull/1756) - add today's token balance from the previous value
- - [#1769](https://github.com/blockscout/blockscout/pull/1769) - add timestamp to block overview
- - [#1768](https://github.com/blockscout/blockscout/pull/1768) - fix first block parameter
- - [#1778](https://github.com/blockscout/blockscout/pull/1778) - Make websocket optional for realtime fetcher
- - [#1790](https://github.com/blockscout/blockscout/pull/1790) - fix constructor arguments verification
- - [#1793](https://github.com/blockscout/blockscout/pull/1793) - fix top nav autocomplete
- - [#1795](https://github.com/blockscout/blockscout/pull/1795) - fix line numbers for decompiled contracts
- - [#1803](https://github.com/blockscout/blockscout/pull/1803) - use coinmarketcap for total_supply by default
- - [#1802](https://github.com/blockscout/blockscout/pull/1802) - make coinmarketcap's number of pages configurable
- - [#1799](https://github.com/blockscout/blockscout/pull/1799) - Use eth_getUncleByBlockHashAndIndex for uncle block fetching
- - [#1531](https://github.com/blockscout/blockscout/pull/1531) - docker: fix dockerFile for secp256k1 building
- - [#1835](https://github.com/blockscout/blockscout/pull/1835) - fix: ignore `pong` messages without error
+- [#1724](https://github.com/blockscout/blockscout/pull/1724) - Remove internal tx and token balance fetching from realtime fetcher
+- [#1727](https://github.com/blockscout/blockscout/pull/1727) - add logs pagination in rpc api
+- [#1740](https://github.com/blockscout/blockscout/pull/1740) - fix empty block time
+- [#1743](https://github.com/blockscout/blockscout/pull/1743) - sort decompiled smart contracts in lexicographical order
+- [#1756](https://github.com/blockscout/blockscout/pull/1756) - add today's token balance from the previous value
+- [#1769](https://github.com/blockscout/blockscout/pull/1769) - add timestamp to block overview
+- [#1768](https://github.com/blockscout/blockscout/pull/1768) - fix first block parameter
+- [#1778](https://github.com/blockscout/blockscout/pull/1778) - Make websocket optional for realtime fetcher
+- [#1790](https://github.com/blockscout/blockscout/pull/1790) - fix constructor arguments verification
+- [#1793](https://github.com/blockscout/blockscout/pull/1793) - fix top nav autocomplete
+- [#1795](https://github.com/blockscout/blockscout/pull/1795) - fix line numbers for decompiled contracts
+- [#1803](https://github.com/blockscout/blockscout/pull/1803) - use coinmarketcap for total_supply by default
+- [#1802](https://github.com/blockscout/blockscout/pull/1802) - make coinmarketcap's number of pages configurable
+- [#1799](https://github.com/blockscout/blockscout/pull/1799) - Use eth_getUncleByBlockHashAndIndex for uncle block fetching
+- [#1531](https://github.com/blockscout/blockscout/pull/1531) - docker: fix dockerFile for secp256k1 building
+- [#1835](https://github.com/blockscout/blockscout/pull/1835) - fix: ignore `pong` messages without error
 
 ### Chore
 
- - [#1804](https://github.com/blockscout/blockscout/pull/1804) - (Chore) Divide chains by Mainnet/Testnet in menu
- - [#1783](https://github.com/blockscout/blockscout/pull/1783) - Update README with the chains that use Blockscout
- - [#1780](https://github.com/blockscout/blockscout/pull/1780) - Update link to the Github repo in the footer
- - [#1757](https://github.com/blockscout/blockscout/pull/1757) - Change twitter acc link to official Blockscout acc twitter
- - [#1749](https://github.com/blockscout/blockscout/pull/1749) - Replace the link in the footer with the official POA announcements tg channel link
- - [#1718](https://github.com/blockscout/blockscout/pull/1718) - Flatten indexer module hierarchy and supervisor tree
- - [#1753](https://github.com/blockscout/blockscout/pull/1753) - Add a check mark to decompiled contract tab
- - [#1744](https://github.com/blockscout/blockscout/pull/1744) - remove `0x0..0` from tests
- - [#1763](https://github.com/blockscout/blockscout/pull/1763) - Describe indexer structure and list existing fetchers
- - [#1800](https://github.com/blockscout/blockscout/pull/1800) - Disable lazy logging check in Credo
+- [#1804](https://github.com/blockscout/blockscout/pull/1804) - (Chore) Divide chains by Mainnet/Testnet in menu
+- [#1783](https://github.com/blockscout/blockscout/pull/1783) - Update README with the chains that use Blockscout
+- [#1780](https://github.com/blockscout/blockscout/pull/1780) - Update link to the Github repo in the footer
+- [#1757](https://github.com/blockscout/blockscout/pull/1757) - Change twitter acc link to official Blockscout acc twitter
+- [#1749](https://github.com/blockscout/blockscout/pull/1749) - Replace the link in the footer with the official POA announcements tg channel link
+- [#1718](https://github.com/blockscout/blockscout/pull/1718) - Flatten indexer module hierarchy and supervisor tree
+- [#1753](https://github.com/blockscout/blockscout/pull/1753) - Add a check mark to decompiled contract tab
+- [#1744](https://github.com/blockscout/blockscout/pull/1744) - remove `0x0..0` from tests
+- [#1763](https://github.com/blockscout/blockscout/pull/1763) - Describe indexer structure and list existing fetchers
+- [#1800](https://github.com/blockscout/blockscout/pull/1800) - Disable lazy logging check in Credo
 
 
 ## 1.3.9-beta
 
 ### Features
 
- - [#1662](https://github.com/blockscout/blockscout/pull/1662) - allow specifying number of optimization runs
- - [#1654](https://github.com/blockscout/blockscout/pull/1654) - add decompiled code tab
- - [#1661](https://github.com/blockscout/blockscout/pull/1661) - try to compile smart contract with the latest evm version
- - [#1665](https://github.com/blockscout/blockscout/pull/1665) - Add contract verification RPC endpoint.
- - [#1706](https://github.com/blockscout/blockscout/pull/1706) - allow setting update interval for addresses with b
+- [#1662](https://github.com/blockscout/blockscout/pull/1662) - allow specifying number of optimization runs
+- [#1654](https://github.com/blockscout/blockscout/pull/1654) - add decompiled code tab
+- [#1661](https://github.com/blockscout/blockscout/pull/1661) - try to compile smart contract with the latest evm version
+- [#1665](https://github.com/blockscout/blockscout/pull/1665) - Add contract verification RPC endpoint.
+- [#1706](https://github.com/blockscout/blockscout/pull/1706) - allow setting update interval for addresses with b
 
 ### Fixes
 
- - [#1669](https://github.com/blockscout/blockscout/pull/1669) - do not fail if multiple matching tokens are found
- - [#1691](https://github.com/blockscout/blockscout/pull/1691) - decrease token metadata update interval
- - [#1688](https://github.com/blockscout/blockscout/pull/1688) - do not fail if failure reason is atom
- - [#1692](https://github.com/blockscout/blockscout/pull/1692) - exclude decompiled smart contract from encoding
- - [#1684](https://github.com/blockscout/blockscout/pull/1684) - Discard child block with parent_hash not matching hash of imported block
- - [#1699](https://github.com/blockscout/blockscout/pull/1699) - use seconds as transaction cache period measure
- - [#1697](https://github.com/blockscout/blockscout/pull/1697) - fix failing in rpc if balance is empty
- - [#1711](https://github.com/blockscout/blockscout/pull/1711) - rescue failing repo in block number cache update
- - [#1712](https://github.com/blockscout/blockscout/pull/1712) - do not set contract code from transaction input
- - [#1714](https://github.com/blockscout/blockscout/pull/1714) - fix average block time calculation
+- [#1669](https://github.com/blockscout/blockscout/pull/1669) - do not fail if multiple matching tokens are found
+- [#1691](https://github.com/blockscout/blockscout/pull/1691) - decrease token metadata update interval
+- [#1688](https://github.com/blockscout/blockscout/pull/1688) - do not fail if failure reason is atom
+- [#1692](https://github.com/blockscout/blockscout/pull/1692) - exclude decompiled smart contract from encoding
+- [#1684](https://github.com/blockscout/blockscout/pull/1684) - Discard child block with parent_hash not matching hash of imported block
+- [#1699](https://github.com/blockscout/blockscout/pull/1699) - use seconds as transaction cache period measure
+- [#1697](https://github.com/blockscout/blockscout/pull/1697) - fix failing in rpc if balance is empty
+- [#1711](https://github.com/blockscout/blockscout/pull/1711) - rescue failing repo in block number cache update
+- [#1712](https://github.com/blockscout/blockscout/pull/1712) - do not set contract code from transaction input
+- [#1714](https://github.com/blockscout/blockscout/pull/1714) - fix average block time calculation
 
 ### Chore
 
- - [#1693](https://github.com/blockscout/blockscout/pull/1693) - Add a checklist to the PR template
+- [#1693](https://github.com/blockscout/blockscout/pull/1693) - Add a checklist to the PR template
 
 
 ## 1.3.8-beta
 
 ### Features
 
- - [#1611](https://github.com/blockscout/blockscout/pull/1611) - allow setting the first indexing block
- - [#1596](https://github.com/blockscout/blockscout/pull/1596) - add endpoint to create decompiled contracts
- - [#1634](https://github.com/blockscout/blockscout/pull/1634) - add transaction count cache
+- [#1611](https://github.com/blockscout/blockscout/pull/1611) - allow setting the first indexing block
+- [#1596](https://github.com/blockscout/blockscout/pull/1596) - add endpoint to create decompiled contracts
+- [#1634](https://github.com/blockscout/blockscout/pull/1634) - add transaction count cache
 
 ### Fixes
 
- - [#1630](https://github.com/blockscout/blockscout/pull/1630) - (Fix) colour for release link in the footer
- - [#1621](https://github.com/blockscout/blockscout/pull/1621) - Modify query to fetch failed contract creations
- - [#1614](https://github.com/blockscout/blockscout/pull/1614) - Do not fetch burn address token balance
- - [#1639](https://github.com/blockscout/blockscout/pull/1614) - Optimize token holder count updates when importing address current balances
- - [#1643](https://github.com/blockscout/blockscout/pull/1643) - Set internal_transactions_indexed_at for empty blocks
- - [#1647](https://github.com/blockscout/blockscout/pull/1647) - Fix typo in view
- - [#1650](https://github.com/blockscout/blockscout/pull/1650) - Add petersburg evm version to smart contract verifier
- - [#1657](https://github.com/blockscout/blockscout/pull/1657) - Force consensus loss for parent block if its hash mismatches parent_hash
+- [#1630](https://github.com/blockscout/blockscout/pull/1630) - (Fix) colour for release link in the footer
+- [#1621](https://github.com/blockscout/blockscout/pull/1621) - Modify query to fetch failed contract creations
+- [#1614](https://github.com/blockscout/blockscout/pull/1614) - Do not fetch burn address token balance
+- [#1639](https://github.com/blockscout/blockscout/pull/1614) - Optimize token holder count updates when importing address current balances
+- [#1643](https://github.com/blockscout/blockscout/pull/1643) - Set internal_transactions_indexed_at for empty blocks
+- [#1647](https://github.com/blockscout/blockscout/pull/1647) - Fix typo in view
+- [#1650](https://github.com/blockscout/blockscout/pull/1650) - Add petersburg evm version to smart contract verifier
+- [#1657](https://github.com/blockscout/blockscout/pull/1657) - Force consensus loss for parent block if its hash mismatches parent_hash
 
 ### Chore
 
@@ -1473,78 +1474,78 @@ Reverting of synchronous block counter, implemented in #1848
 
 ### Fixes
 
- - [#1615](https://github.com/blockscout/blockscout/pull/1615) - Add more logging to code fixer process
- - [#1613](https://github.com/blockscout/blockscout/pull/1613) - Fix USD fee value
- - [#1577](https://github.com/blockscout/blockscout/pull/1577) - Add process to fix contract with code
- - [#1583](https://github.com/blockscout/blockscout/pull/1583) - Chunk JSON-RPC batches in case connection times out
+- [#1615](https://github.com/blockscout/blockscout/pull/1615) - Add more logging to code fixer process
+- [#1613](https://github.com/blockscout/blockscout/pull/1613) - Fix USD fee value
+- [#1577](https://github.com/blockscout/blockscout/pull/1577) - Add process to fix contract with code
+- [#1583](https://github.com/blockscout/blockscout/pull/1583) - Chunk JSON-RPC batches in case connection times out
 
 ### Chore
 
- - [#1610](https://github.com/blockscout/blockscout/pull/1610) - Add PIRL to Readme
+- [#1610](https://github.com/blockscout/blockscout/pull/1610) - Add PIRL to Readme
 
 
 ## 1.3.6-beta
 
 ### Features
 
- - [#1589](https://github.com/blockscout/blockscout/pull/1589) - RPC endpoint to list addresses
- - [#1567](https://github.com/blockscout/blockscout/pull/1567) - Allow setting different configuration just for realtime fetcher
- - [#1562](https://github.com/blockscout/blockscout/pull/1562) - Add incoming transactions count to contract view
- - [#1608](https://github.com/blockscout/blockscout/pull/1608) - Add listcontracts RPC Endpoint
+- [#1589](https://github.com/blockscout/blockscout/pull/1589) - RPC endpoint to list addresses
+- [#1567](https://github.com/blockscout/blockscout/pull/1567) - Allow setting different configuration just for realtime fetcher
+- [#1562](https://github.com/blockscout/blockscout/pull/1562) - Add incoming transactions count to contract view
+- [#1608](https://github.com/blockscout/blockscout/pull/1608) - Add listcontracts RPC Endpoint
 
 ### Fixes
 
- - [#1595](https://github.com/blockscout/blockscout/pull/1595) - Reduce block_rewards in the catchup fetcher
- - [#1590](https://github.com/blockscout/blockscout/pull/1590) - Added guard for fetching blocks with invalid number
- - [#1588](https://github.com/blockscout/blockscout/pull/1588) - Fix usd value on address page
- - [#1586](https://github.com/blockscout/blockscout/pull/1586) - Exact timestamp display
- - [#1581](https://github.com/blockscout/blockscout/pull/1581) - Consider `creates` param when fetching transactions
- - [#1559](https://github.com/blockscout/blockscout/pull/1559) - Change v column type for Transactions table
+- [#1595](https://github.com/blockscout/blockscout/pull/1595) - Reduce block_rewards in the catchup fetcher
+- [#1590](https://github.com/blockscout/blockscout/pull/1590) - Added guard for fetching blocks with invalid number
+- [#1588](https://github.com/blockscout/blockscout/pull/1588) - Fix usd value on address page
+- [#1586](https://github.com/blockscout/blockscout/pull/1586) - Exact timestamp display
+- [#1581](https://github.com/blockscout/blockscout/pull/1581) - Consider `creates` param when fetching transactions
+- [#1559](https://github.com/blockscout/blockscout/pull/1559) - Change v column type for Transactions table
 
 ### Chore
 
- - [#1579](https://github.com/blockscout/blockscout/pull/1579) - Add SpringChain to the list of Additional Chains Utilizing BlockScout
- - [#1578](https://github.com/blockscout/blockscout/pull/1578) - Refine contributing procedure
- - [#1572](https://github.com/blockscout/blockscout/pull/1572) - Add option to disable block rewards in indexer config
+- [#1579](https://github.com/blockscout/blockscout/pull/1579) - Add SpringChain to the list of Additional Chains Utilizing BlockScout
+- [#1578](https://github.com/blockscout/blockscout/pull/1578) - Refine contributing procedure
+- [#1572](https://github.com/blockscout/blockscout/pull/1572) - Add option to disable block rewards in indexer config
 
 
 ## 1.3.5-beta
 
 ### Features
 
- - [#1560](https://github.com/blockscout/blockscout/pull/1560) - Allow executing smart contract functions in arbitrarily sized batches
- - [#1543](https://github.com/blockscout/blockscout/pull/1543) - Use trace_replayBlockTransactions API for faster tracing
- - [#1558](https://github.com/blockscout/blockscout/pull/1558) - Allow searching by token symbol
- - [#1551](https://github.com/blockscout/blockscout/pull/1551) Exact date and time for Transaction details page
- - [#1547](https://github.com/blockscout/blockscout/pull/1547) - Verify smart contracts with evm versions
- - [#1540](https://github.com/blockscout/blockscout/pull/1540) - Fetch ERC721 token balances if sender is '0x0..0'
- - [#1539](https://github.com/blockscout/blockscout/pull/1539) - Add the link to release in the footer
- - [#1519](https://github.com/blockscout/blockscout/pull/1519) - Create contract methods
- - [#1496](https://github.com/blockscout/blockscout/pull/1496) - Remove dropped/replaced transactions in pending transactions list
- - [#1492](https://github.com/blockscout/blockscout/pull/1492) - Disable usd value for an empty exchange rate
- - [#1466](https://github.com/blockscout/blockscout/pull/1466) - Decoding candidates for unverified contracts
+- [#1560](https://github.com/blockscout/blockscout/pull/1560) - Allow executing smart contract functions in arbitrarily sized batches
+- [#1543](https://github.com/blockscout/blockscout/pull/1543) - Use trace_replayBlockTransactions API for faster tracing
+- [#1558](https://github.com/blockscout/blockscout/pull/1558) - Allow searching by token symbol
+- [#1551](https://github.com/blockscout/blockscout/pull/1551) Exact date and time for Transaction details page
+- [#1547](https://github.com/blockscout/blockscout/pull/1547) - Verify smart contracts with evm versions
+- [#1540](https://github.com/blockscout/blockscout/pull/1540) - Fetch ERC721 token balances if sender is '0x0..0'
+- [#1539](https://github.com/blockscout/blockscout/pull/1539) - Add the link to release in the footer
+- [#1519](https://github.com/blockscout/blockscout/pull/1519) - Create contract methods
+- [#1496](https://github.com/blockscout/blockscout/pull/1496) - Remove dropped/replaced transactions in pending transactions list
+- [#1492](https://github.com/blockscout/blockscout/pull/1492) - Disable usd value for an empty exchange rate
+- [#1466](https://github.com/blockscout/blockscout/pull/1466) - Decoding candidates for unverified contracts
 
 ### Fixes
- - [#1545](https://github.com/blockscout/blockscout/pull/1545) - Fix scheduling of latest block polling in Realtime Fetcher
- - [#1554](https://github.com/blockscout/blockscout/pull/1554) - Encode integer parameters when calling smart contract functions
- - [#1537](https://github.com/blockscout/blockscout/pull/1537) - Fix test that depended on date
- - [#1534](https://github.com/blockscout/blockscout/pull/1534) - Render a nicer error when creator cannot be determined
- - [#1527](https://github.com/blockscout/blockscout/pull/1527) - Add index to value_fetched_at
- - [#1518](https://github.com/blockscout/blockscout/pull/1518) - Select only distinct failed transactions
- - [#1516](https://github.com/blockscout/blockscout/pull/1516) - Fix coin balance params reducer for pending transaction
- - [#1511](https://github.com/blockscout/blockscout/pull/1511) - Set correct log level for production
- - [#1510](https://github.com/blockscout/blockscout/pull/1510) - Fix test that fails every 1st day of the month
- - [#1509](https://github.com/blockscout/blockscout/pull/1509) - Add index to blocks' consensus
- - [#1508](https://github.com/blockscout/blockscout/pull/1508) - Remove duplicated indexes
- - [#1505](https://github.com/blockscout/blockscout/pull/1505) - Use https instead of ssh for absinthe libs
- - [#1501](https://github.com/blockscout/blockscout/pull/1501) - Constructor_arguments must be type `text`
- - [#1498](https://github.com/blockscout/blockscout/pull/1498) - Add index for created_contract_address_hash in transactions
- - [#1493](https://github.com/blockscout/blockscout/pull/1493) - Do not do work in process initialization
- - [#1487](https://github.com/blockscout/blockscout/pull/1487) - Limit geth sync to 128 blocks
- - [#1484](https://github.com/blockscout/blockscout/pull/1484) - Allow decoding input as utf-8
- - [#1479](https://github.com/blockscout/blockscout/pull/1479) - Remove smoothing from coin balance chart
+- [#1545](https://github.com/blockscout/blockscout/pull/1545) - Fix scheduling of latest block polling in Realtime Fetcher
+- [#1554](https://github.com/blockscout/blockscout/pull/1554) - Encode integer parameters when calling smart contract functions
+- [#1537](https://github.com/blockscout/blockscout/pull/1537) - Fix test that depended on date
+- [#1534](https://github.com/blockscout/blockscout/pull/1534) - Render a nicer error when creator cannot be determined
+- [#1527](https://github.com/blockscout/blockscout/pull/1527) - Add index to value_fetched_at
+- [#1518](https://github.com/blockscout/blockscout/pull/1518) - Select only distinct failed transactions
+- [#1516](https://github.com/blockscout/blockscout/pull/1516) - Fix coin balance params reducer for pending transaction
+- [#1511](https://github.com/blockscout/blockscout/pull/1511) - Set correct log level for production
+- [#1510](https://github.com/blockscout/blockscout/pull/1510) - Fix test that fails every 1st day of the month
+- [#1509](https://github.com/blockscout/blockscout/pull/1509) - Add index to blocks' consensus
+- [#1508](https://github.com/blockscout/blockscout/pull/1508) - Remove duplicated indexes
+- [#1505](https://github.com/blockscout/blockscout/pull/1505) - Use https instead of ssh for absinthe libs
+- [#1501](https://github.com/blockscout/blockscout/pull/1501) - Constructor_arguments must be type `text`
+- [#1498](https://github.com/blockscout/blockscout/pull/1498) - Add index for created_contract_address_hash in transactions
+- [#1493](https://github.com/blockscout/blockscout/pull/1493) - Do not do work in process initialization
+- [#1487](https://github.com/blockscout/blockscout/pull/1487) - Limit geth sync to 128 blocks
+- [#1484](https://github.com/blockscout/blockscout/pull/1484) - Allow decoding input as utf-8
+- [#1479](https://github.com/blockscout/blockscout/pull/1479) - Remove smoothing from coin balance chart
 
 ### Chore
- - [https://github.com/blockscout/blockscout/pull/1532](https://github.com/blockscout/blockscout/pull/1532) - Upgrade elixir to 1.8.1
- - [https://github.com/blockscout/blockscout/pull/1553](https://github.com/blockscout/blockscout/pull/1553) - Dockerfile: remove 1.7.1 version pin FROM bitwalker/alpine-elixir-phoenix
- - [https://github.com/blockscout/blockscout/pull/1465](https://github.com/blockscout/blockscout/pull/1465) - Resolve lodash security alert
+- [https://github.com/blockscout/blockscout/pull/1532](https://github.com/blockscout/blockscout/pull/1532) - Upgrade elixir to 1.8.1
+- [https://github.com/blockscout/blockscout/pull/1553](https://github.com/blockscout/blockscout/pull/1553) - Dockerfile: remove 1.7.1 version pin FROM bitwalker/alpine-elixir-phoenix
+- [https://github.com/blockscout/blockscout/pull/1465](https://github.com/blockscout/blockscout/pull/1465) - Resolve lodash security alert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#5155](https://github.com/blockscout/blockscout/pull/5155) - Fix get_implementation_abi_from_proxy/2 implementation
 - [#5154](https://github.com/blockscout/blockscout/pull/5154) - Fix token counters bug
 - [#4862](https://github.com/blockscout/blockscout/pull/4862) - Fix internal transactions pagination
+- [#6090](https://github.com/blockscout/blockscout/pull/6090) - Fix metadata fetching for ERC-1155 tokens instances 
 
 ### Chore
 - [#5227](https://github.com/blockscout/blockscout/pull/5227) - Major update of css-loader npm package

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5038,16 +5038,22 @@ defmodule Explorer.Chain do
         on: token.contract_address_hash == token_transfer.token_contract_address_hash,
         left_join: instance in Instance,
         on:
-          token_transfer.token_id == instance.token_id and
-            token_transfer.token_contract_address_hash == instance.token_contract_address_hash,
-        where: is_nil(instance.token_id) and not is_nil(token_transfer.token_id),
-        select: %{contract_address_hash: token_transfer.token_contract_address_hash, token_id: token_transfer.token_id}
+          token_transfer.token_contract_address_hash == instance.token_contract_address_hash and
+            (token_transfer.token_id == instance.token_id or
+               fragment("? @> ARRAY[?::decimal]", token_transfer.token_ids, instance.token_id)),
+        where:
+          is_nil(instance.token_id) and (not is_nil(token_transfer.token_id) or not is_nil(token_transfer.token_ids)),
+        select: %{
+          contract_address_hash: token_transfer.token_contract_address_hash,
+          token_id: token_transfer.token_id,
+          token_ids: token_transfer.token_ids
+        }
       )
 
     distinct_query =
       from(
         q in subquery(query),
-        distinct: [q.contract_address_hash, q.token_id]
+        distinct: [q.contract_address_hash, q.token_id, q.token_ids]
       )
 
     Repo.stream_reduce(distinct_query, initial, reducer)

--- a/apps/explorer/lib/explorer/token/instance_owner_reader.ex
+++ b/apps/explorer/lib/explorer/token/instance_owner_reader.ex
@@ -1,0 +1,73 @@
+defmodule Explorer.Token.InstanceOwnerReader do
+  @moduledoc """
+  Reads Token Instance owner using Smart Contract function from the blockchain.
+  """
+
+  require Logger
+
+  alias Explorer.SmartContract.Reader
+
+  @owner_function_signature "6352211e"
+
+  @owner_function_abi [
+    %{
+      "type" => "function",
+      "stateMutability" => "view",
+      "payable" => false,
+      "outputs" => [
+        %{
+          "type" => "address",
+          "name" => "owner"
+        }
+      ],
+      "name" => "ownerOf",
+      "inputs" => [
+        %{
+          "type" => "uint256",
+          "name" => "tokenId"
+        }
+      ]
+    }
+  ]
+
+  @spec get_owner_of([%{token_contract_address_hash: String.t(), token_id: integer}]) :: [
+          {:ok, String.t()} | {:error, String.t()}
+        ]
+  def get_owner_of(instance_owner_requests) do
+    instance_owner_requests
+    |> Enum.map(&format_owner_request/1)
+    |> Reader.query_contracts(@owner_function_abi)
+    |> Enum.zip(instance_owner_requests)
+    |> Enum.reduce([], fn {result, request}, acc ->
+      case format_owner_result(result, request) do
+        {:ok, ok_result} ->
+          [ok_result] ++ acc
+
+        {:error, error_message} ->
+          Logger.error("Failed to get owner of token_id #{request.token_id}, reason: #{error_message}")
+          acc
+      end
+    end)
+  end
+
+  defp format_owner_request(%{token_contract_address_hash: token_contract_address_hash, token_id: token_id}) do
+    %{
+      contract_address: token_contract_address_hash,
+      method_id: @owner_function_signature,
+      args: [token_id]
+    }
+  end
+
+  defp format_owner_result({:ok, [owner]}, request) do
+    {:ok,
+     %{
+       token_contract_address_hash: request.token_contract_address_hash,
+       token_id: request.token_id,
+       owner: owner
+     }}
+  end
+
+  defp format_owner_result({:error, error_message}, _request) do
+    {:error, error_message}
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4663,7 +4663,7 @@ defmodule Explorer.ChainTest do
   end
 
   describe "stream_unfetched_token_instances/2" do
-    test "reduces wuth given reducer and accumulator" do
+    test "reduces with given reducer and accumulator for ERC-721 token" do
       token_contract_address = insert(:contract_address)
       token = insert(:token, contract_address: token_contract_address, type: "ERC-721")
 
@@ -4689,7 +4689,33 @@ defmodule Explorer.ChainTest do
       assert result.contract_address_hash == token_transfer.token_contract_address_hash
     end
 
-    test "does not fetch token transfers without token id" do
+    test "reduces with given reducer and accumulator for ERC-1155 token" do
+      token_contract_address = insert(:contract_address)
+      token = insert(:token, contract_address: token_contract_address, type: "ERC-1155")
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(insert(:block, number: 1))
+
+      token_transfer =
+        insert(
+          :token_transfer,
+          block_number: 1000,
+          to_address: build(:address),
+          transaction: transaction,
+          token_contract_address: token_contract_address,
+          token: token,
+          token_id: nil,
+          token_ids: [11]
+        )
+
+      assert {:ok, [result]} = Chain.stream_unfetched_token_instances([], &[&1 | &2])
+      assert result.token_ids == token_transfer.token_ids
+      assert result.contract_address_hash == token_transfer.token_contract_address_hash
+    end
+
+    test "does not fetch token transfers without token id or token_ids" do
       token_contract_address = insert(:contract_address)
       token = insert(:token, contract_address: token_contract_address, type: "ERC-721")
 
@@ -4706,7 +4732,8 @@ defmodule Explorer.ChainTest do
         # block: transaction.block,
         token_contract_address: token_contract_address,
         token: token,
-        token_id: nil
+        token_id: nil,
+        token_ids: nil
       )
 
       assert {:ok, []} = Chain.stream_unfetched_token_instances([], &[&1 | &2])

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -50,7 +50,20 @@ defmodule Indexer.Fetcher.TokenInstance do
   end
 
   @impl BufferedTask
-  def run([%{contract_address_hash: token_contract_address_hash, token_id: token_id}], _json_rpc_named_arguments) do
+  def run([%{contract_address_hash: hash, token_id: token_id, token_ids: token_ids}], _json_rpc_named_arguments) do
+    all_token_ids =
+      cond do
+        is_nil(token_id) -> token_ids
+        is_nil(token_ids) -> [token_id]
+        true -> [token_id] ++ token_ids
+      end
+
+    Enum.each(all_token_ids, &fetch_instance(hash, &1))
+
+    :ok
+  end
+
+  defp fetch_instance(token_contract_address_hash, token_id) do
     case InstanceMetadataRetriever.fetch_metadata(to_string(token_contract_address_hash), Decimal.to_integer(token_id)) do
       {:ok, %{metadata: metadata}} ->
         params = %{
@@ -82,8 +95,6 @@ defmodule Indexer.Fetcher.TokenInstance do
 
         :ok
     end
-
-    :ok
   end
 
   @doc """

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -8,8 +8,9 @@ defmodule Indexer.Fetcher.TokenInstance do
 
   require Logger
 
-  alias Explorer.Chain
-  alias Explorer.Token.InstanceMetadataRetriever
+  alias Explorer.{Chain, Repo}
+  alias Explorer.Chain.{Cache.BlockNumber, Token}
+  alias Explorer.Token.{InstanceMetadataRetriever, InstanceOwnerReader}
   alias Indexer.BufferedTask
 
   use BufferedTask
@@ -59,6 +60,7 @@ defmodule Indexer.Fetcher.TokenInstance do
       end
 
     Enum.each(all_token_ids, &fetch_instance(hash, &1))
+    update_current_token_balances(hash, all_token_ids)
 
     :ok
   end
@@ -95,6 +97,39 @@ defmodule Indexer.Fetcher.TokenInstance do
 
         :ok
     end
+  end
+
+  defp update_current_token_balances(token_contract_address_hash, token_ids) do
+    import_params =
+      token_ids
+      |> Enum.map(&instance_owner_request(token_contract_address_hash, &1))
+      |> InstanceOwnerReader.get_owner_of()
+      |> Enum.map(&current_token_balances_import_params/1)
+
+    Chain.import(%{
+      address_current_token_balances: %{
+        params: import_params
+      }
+    })
+  end
+
+  defp instance_owner_request(token_contract_address_hash, token_id) do
+    %{
+      token_contract_address_hash: token_contract_address_hash,
+      token_id: Decimal.to_integer(token_id)
+    }
+  end
+
+  defp current_token_balances_import_params(%{token_contract_address_hash: hash, token_id: token_id, owner: owner}) do
+    %{
+      value: Decimal.new(1),
+      block_number: BlockNumber.get_max(),
+      value_fetched_at: DateTime.utc_now(),
+      token_id: token_id,
+      token_type: Repo.get_by(Token, contract_address_hash: hash).type,
+      address_hash: owner,
+      token_contract_address_hash: hash
+    }
   end
 
   @doc """

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -103,9 +103,13 @@ defmodule Indexer.Fetcher.TokenInstance do
   def async_fetch(token_transfers) when is_list(token_transfers) do
     data =
       token_transfers
-      |> Enum.reject(fn token_transfer -> is_nil(token_transfer.token_id) end)
+      |> Enum.reject(fn token_transfer -> is_nil(token_transfer.token_id) and is_nil(token_transfer.token_ids) end)
       |> Enum.map(fn token_transfer ->
-        %{contract_address_hash: token_transfer.token_contract_address_hash, token_id: token_transfer.token_id}
+        %{
+          contract_address_hash: token_transfer.token_contract_address_hash,
+          token_id: token_transfer.token_id,
+          token_ids: token_transfer.token_ids
+        }
       end)
       |> Enum.uniq()
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -115,7 +115,7 @@ defmodule Indexer.Fetcher.TokenInstance do
 
   defp instance_owner_request(token_contract_address_hash, token_id) do
     %{
-      token_contract_address_hash: token_contract_address_hash,
+      token_contract_address_hash: to_string(token_contract_address_hash),
       token_id: Decimal.to_integer(token_id)
     }
   end

--- a/apps/indexer/test/indexer/fetcher/token_instance_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance_test.exs
@@ -1,0 +1,48 @@
+defmodule Indexer.Fetcher.TokenInstanceTest do
+  use EthereumJSONRPC.Case, async: false
+  use Explorer.DataCase
+
+  import Mox
+
+  alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Explorer.Repo
+  alias Indexer.Fetcher.TokenInstance
+
+  describe "run/2" do
+    test "updates current token balance" do
+      token = insert(:token, type: "ERC-1155")
+      token_contract_address_hash = token.contract_address_hash
+      instance = insert(:token_instance, token_contract_address_hash: token_contract_address_hash)
+      token_id = instance.token_id
+      address = insert(:address, hash: "0x57e93bb58268de818b42e3795c97bad58afcd3fe")
+      address_hash = address.hash
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn [%{id: 0, method: "eth_call", params: [%{data: "0xc87b56dd" <> _}, _]}], _ ->
+        {:ok,
+         [
+           %{
+             id: 0,
+             result:
+               "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000027b7d000000000000000000000000000000000000000000000000000000000000"
+           }
+         ]}
+      end)
+      |> expect(:json_rpc, fn [%{id: 0, method: "eth_call", params: [%{data: "0x6352211e" <> _}, _]}], _ ->
+        {:ok, [%{id: 0, result: "0x00000000000000000000000057e93bb58268de818b42e3795c97bad58afcd3fe"}]}
+      end)
+
+      TokenInstance.run(
+        [%{contract_address_hash: token_contract_address_hash, token_id: nil, token_ids: [token_id]}],
+        nil
+      )
+
+      assert %{
+               token_id: ^token_id,
+               token_type: "ERC-1155",
+               token_contract_address_hash: ^token_contract_address_hash,
+               address_hash: ^address_hash
+             } = Repo.one(CurrentTokenBalance)
+    end
+  end
+end

--- a/apps/indexer/test/indexer/fetcher/token_instance_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance_test.exs
@@ -4,6 +4,8 @@ defmodule Indexer.Fetcher.TokenInstanceTest do
 
   import Mox
 
+  alias Explorer.Chain
+  alias Explorer.Chain.Address
   alias Explorer.Chain.Address.CurrentTokenBalance
   alias Explorer.Repo
   alias Indexer.Fetcher.TokenInstance
@@ -43,6 +45,43 @@ defmodule Indexer.Fetcher.TokenInstanceTest do
                token_contract_address_hash: ^token_contract_address_hash,
                address_hash: ^address_hash
              } = Repo.one(CurrentTokenBalance)
+    end
+
+    test "updates current token balance with missing address" do
+      token = insert(:token, type: "ERC-1155")
+      token_contract_address_hash = token.contract_address_hash
+      instance = insert(:token_instance, token_contract_address_hash: token_contract_address_hash)
+      token_id = instance.token_id
+      {:ok, address_hash} = Chain.string_to_address_hash("0x57e93bb58268de818b42e3795c97bad58afcd3fe")
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn [%{id: 0, method: "eth_call", params: [%{data: "0xc87b56dd" <> _}, _]}], _ ->
+        {:ok,
+         [
+           %{
+             id: 0,
+             result:
+               "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000027b7d000000000000000000000000000000000000000000000000000000000000"
+           }
+         ]}
+      end)
+      |> expect(:json_rpc, fn [%{id: 0, method: "eth_call", params: [%{data: "0x6352211e" <> _}, _]}], _ ->
+        {:ok, [%{id: 0, result: "0x00000000000000000000000057e93bb58268de818b42e3795c97bad58afcd3fe"}]}
+      end)
+
+      TokenInstance.run(
+        [%{contract_address_hash: token_contract_address_hash, token_id: token_id, token_ids: nil}],
+        nil
+      )
+
+      assert %{
+               token_id: ^token_id,
+               token_type: "ERC-1155",
+               token_contract_address_hash: ^token_contract_address_hash,
+               address_hash: ^address_hash
+             } = Repo.one(CurrentTokenBalance)
+
+      assert %Address{} = Repo.get_by(Address, hash: address_hash)
     end
   end
 end


### PR DESCRIPTION
This PR brings all the upstream fixes to token instance fetcher since ERC-1155 support merge.