### PR TITLE
Temporarily increase concurrency for token instance fetching

### DIFF
--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -248,7 +248,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
           fetcher: :token_instances
         )
 
-        {:ok, error: @non_200_response_error}
+        {:ok, %{error: @non_200_response_error}}
 
       {:error, %Error{reason: reason}} ->
         Logger.info(
@@ -256,7 +256,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
           fetcher: :token_instances
         )
 
-        {:ok, error: @library_error}
+        {:ok, %{error: @library_error}}
     end
   rescue
     e ->
@@ -264,7 +264,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
         fetcher: :token_instances
       )
 
-      {:ok, error: @unhandled_error}
+      {:ok, %{error: @unhandled_error}}
   end
 
   defp decode_json(body) do

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -61,9 +61,6 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
 
   @no_uri_error "no uri"
   @vm_execution_error "VM execution error"
-  @unhandled_error "unhandled error"
-  @non_200_response_error "non 200 HTTP response"
-  @library_error "library error"
 
   # https://eips.ethereum.org/EIPS/eip-1155#metadata
   @erc1155_token_id_placeholder "{id}"
@@ -253,7 +250,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
           fetcher: :token_instances
         )
 
-        {:ok, %{error: @non_200_response_error}}
+        {:error, body}
 
       {:error, %Error{reason: reason}} ->
         Logger.info(
@@ -261,7 +258,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
           fetcher: :token_instances
         )
 
-        {:ok, %{error: @library_error}}
+        {:error, reason}
     end
   rescue
     e ->
@@ -269,7 +266,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
         fetcher: :token_instances
       )
 
-      {:ok, %{error: @unhandled_error}}
+      {:error, :request_error}
   end
 
   defp decode_json(body) do

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -8,6 +8,8 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
   alias Explorer.SmartContract.Reader
   alias HTTPoison.{Error, Response}
 
+  @timeout 60_000
+
   @token_uri "c87b56dd"
 
   @abi [
@@ -226,7 +228,10 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
   defp fetch_metadata_inner(uri, hex_token_id) do
     prepared_uri = substitute_token_id_to_token_uri(uri, hex_token_id)
 
-    case HTTPoison.get(prepared_uri) do
+    case HTTPoison.get(prepared_uri,
+           timeout: @timeout,
+           recv_timeout: @timeout
+         ) do
       {:ok, %Response{body: body, status_code: 200, headers: headers}} ->
         if Enum.member?(headers, {"Content-Type", "image/png"}) do
           json = %{"image" => prepared_uri}

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -241,10 +241,10 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
         check_type(json, hex_token_id)
 
       {:ok, %Response{body: body}} ->
-        {:error, body}
+        {:ok, error: inspect(body)}
 
       {:error, %Error{reason: reason}} ->
-        {:error, reason}
+        {:ok, error: inspect(reason)}
     end
   rescue
     e ->

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -17,8 +17,8 @@ defmodule Indexer.Fetcher.TokenInstance do
 
   @defaults [
     flush_interval: 300,
-    max_batch_size: 1,
-    max_concurrency: 10,
+    max_batch_size: 5,
+    max_concurrency: 100,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -18,7 +18,7 @@ defmodule Indexer.Fetcher.TokenInstance do
   @defaults [
     flush_interval: 300,
     max_batch_size: 1,
-    max_concurrency: 100,
+    max_concurrency: 10,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -16,12 +16,9 @@ defmodule Indexer.Fetcher.TokenInstance do
   use BufferedTask
 
   @defaults [
-    flush_interval: :timer.seconds(5),
-    poll: true,
-    poll_interval: :timer.minutes(20),
-    dedup_entries: true,
+    flush_interval: 300,
     max_batch_size: 1,
-    max_concurrency: 3,
+    max_concurrency: 10,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -19,6 +19,7 @@ defmodule Indexer.Fetcher.TokenInstance do
     flush_interval: :timer.seconds(5),
     poll: true,
     poll_interval: :timer.minutes(20),
+    dedup_entries: true,
     max_batch_size: 1,
     max_concurrency: 3,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -16,9 +16,9 @@ defmodule Indexer.Fetcher.TokenInstance do
   use BufferedTask
 
   @defaults [
-    flush_interval: 300,
+    flush_interval: 1000,
     max_batch_size: 1,
-    max_concurrency: 10,
+    max_concurrency: 3,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor
   ]
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -16,7 +16,9 @@ defmodule Indexer.Fetcher.TokenInstance do
   use BufferedTask
 
   @defaults [
-    flush_interval: 1000,
+    flush_interval: :timer.seconds(5),
+    poll: true,
+    poll_interval: :timer.minutes(20),
     max_batch_size: 1,
     max_concurrency: 3,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -17,7 +17,7 @@ defmodule Indexer.Fetcher.TokenInstance do
 
   @defaults [
     flush_interval: 300,
-    max_batch_size: 5,
+    max_batch_size: 1,
     max_concurrency: 100,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor
   ]


### PR DESCRIPTION
Temporarily increasing concurrency for token instance fetching in an attempt to fetch "correct" metadata that is blocked by the "faulty" one.