### PR TITLE
Stop fetching celo token balances for all addresses in block

### DIFF
--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -50,6 +50,8 @@ config :explorer, Explorer.Tracer, disabled?: false
 
 config :explorer, Explorer.Staking.ContractState, enabled: false
 
+config :explorer, Explorer.Chain.Cache.MinMissingBlockNumber, enabled: false
+
 config :logger, :explorer,
   level: :warn,
   path: Path.absname("logs/test/explorer.log")

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -99,7 +99,6 @@ config :logger, :logger_backend, level: :error
 #       block_number step count error_count shrunk import_id transaction_id)a,
 #  metadata_filter: [application: :indexer]
 
-config :indexer, Indexer.Block.Fetcher, enable_gold_token: true
 config :indexer, Indexer.Prometheus.MetricsCron, metrics_fetcher_blocks_count: 1000
 config :indexer, Indexer.Prometheus.MetricsCron, metrics_cron_interval: System.get_env("METRICS_CRON_INTERVAL") || "2"
 

--- a/apps/indexer/config/test.exs
+++ b/apps/indexer/config/test.exs
@@ -6,8 +6,6 @@ config :indexer, :environment, :test
 
 config :indexer, Indexer.Fetcher.CeloValidatorHistory.Supervisor, disabled?: true
 
-config :indexer, Indexer.Block.Fetcher, enable_gold_token: true
-
 config :indexer,
   block_transformer: Indexer.Transform.Blocks.Base
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -307,7 +307,6 @@ defmodule Indexer.Block.Fetcher do
 
          # extract address token balances from token transfers
          address_token_balances = AddressTokenBalances.params_set(%{token_transfers_params: token_transfers}),
-
          {:ok, inserted} <-
            __MODULE__.import(
              state,

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -256,7 +256,7 @@ defmodule Indexer.Block.Fetcher do
          %{mint_transfers: mint_transfers} = MintTransfers.parse(logs),
          %FetchedBeneficiaries{params_set: beneficiary_params_set, errors: beneficiaries_errors} =
            fetch_beneficiaries(blocks, json_rpc_named_arguments),
-         tokens = [normal_tokens | %{contract_address_hash: celo_token, type: "ERC-20"}],
+         tokens = [normal_tokens | [%{contract_address_hash: celo_token, type: "ERC-20"}]],
          token_transfers = normal_token_transfers ++ celo_token_transfers,
          addresses =
            Addresses.extract_addresses(%{

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -219,7 +219,7 @@ defmodule Indexer.Block.Fetcher do
          transactions_with_receipts = Receipts.put(transactions_params_without_receipts, receipts),
          %{token_transfers: normal_token_transfers, tokens: normal_tokens} = TokenTransfers.parse(logs),
 
-         #Get required core contract addresses from the registry
+         # Get required core contract addresses from the registry
          {:ok, celo_token} = Util.get_address("GoldToken"),
          {:ok, stable_token_usd} = Util.get_address("StableToken"),
          {:ok, oracle_address} = Util.get_address("SortedOracles"),

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -308,9 +308,6 @@ defmodule Indexer.Block.Fetcher do
          # extract address token balances from token transfers
          address_token_balances = AddressTokenBalances.params_set(%{token_transfers_params: token_transfers}),
 
-         # 20/10/22 : Assert that celo token balances are still inserted correctly and remove the referenced code below
-         # address_token_balances = add_celo_token_balances(celo_token, addresses, address_token_balances_from_transfers),
-
          {:ok, inserted} <-
            __MODULE__.import(
              state,

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -308,7 +308,7 @@ defmodule Indexer.Block.Fetcher do
          # extract address token balances from token transfers
          address_token_balances = AddressTokenBalances.params_set(%{token_transfers_params: token_transfers}),
 
-         # TODO 20/10/22 : Assert that celo token balances are still inserted correctly and remove the referenced code below
+         # 20/10/22 : Assert that celo token balances are still inserted correctly and remove the referenced code below
          # address_token_balances = add_celo_token_balances(celo_token, addresses, address_token_balances_from_transfers),
 
          {:ok, inserted} <-

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -256,7 +256,7 @@ defmodule Indexer.Block.Fetcher do
          %{mint_transfers: mint_transfers} = MintTransfers.parse(logs),
          %FetchedBeneficiaries{params_set: beneficiary_params_set, errors: beneficiaries_errors} =
            fetch_beneficiaries(blocks, json_rpc_named_arguments),
-         tokens = normal_tokens ++ [%{contract_address_hash: celo_token, type: "ERC-20"}],
+         tokens = [normal_tokens | %{contract_address_hash: celo_token, type: "ERC-20"}],
          token_transfers = normal_token_transfers ++ celo_token_transfers,
          addresses =
            Addresses.extract_addresses(%{

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -164,22 +164,6 @@ defmodule Indexer.Block.Fetcher do
     end)
   end
 
-  defp add_celo_token_balances(celo_token, addresses, acc) do
-    Enum.reduce(addresses, acc, fn
-      %{fetched_coin_balance_block_number: bn, hash: hash}, acc ->
-        MapSet.put(acc, %{
-          address_hash: hash,
-          token_contract_address_hash: celo_token,
-          block_number: bn,
-          token_type: "ERC-20",
-          token_id: nil
-        })
-
-      _, acc ->
-        acc
-    end)
-  end
-
   @decorate span(tracer: Tracer)
   @spec fetch_and_import_range(t, Range.t()) ::
           {:ok, %{inserted: %{}, errors: [EthereumJSONRPC.Transport.error()]}}
@@ -196,24 +180,33 @@ defmodule Indexer.Block.Fetcher do
       )
       when callback_module != nil do
     with {:blocks,
-          {:ok,
-           %Blocks{
-             blocks_params: blocks_params,
-             transactions_params: transactions_params_without_receipts,
-             block_second_degree_relations_params: block_second_degree_relations_params,
-             errors: blocks_errors
-           }}} <- {:blocks, EthereumJSONRPC.fetch_blocks_by_range(range, json_rpc_named_arguments)},
+          {
+            :ok,
+            # Fetch blocks and associated block data (transactions included)
+            %Blocks{
+              blocks_params: blocks_params,
+              transactions_params: transactions_params_without_receipts,
+              block_second_degree_relations_params: block_second_degree_relations_params,
+              errors: blocks_errors
+            }
+          }} <- {:blocks, EthereumJSONRPC.fetch_blocks_by_range(range, json_rpc_named_arguments)},
          blocks = TransformBlocks.transform_blocks(blocks_params),
 
-         # Fetch and process logs
+         # Fetch and process logs + tx receipts
          {:logs, {:ok, %{logs: epoch_logs}}} <- {:logs, EthereumJSONRPC.fetch_logs(range, json_rpc_named_arguments)},
          {:receipts, {:ok, receipt_params}} <- {:receipts, Receipts.fetch(state, transactions_params_without_receipts)},
          %{logs: tx_logs, receipts: receipts} = receipt_params,
          logs = tx_logs ++ process_extra_logs(epoch_logs),
+
+         # combine transactions with receipts
+         transactions_with_receipts = Receipts.put(transactions_params_without_receipts, receipts),
+
+         # extract token transfers from logs
+         %{token_transfers: normal_token_transfers, tokens: normal_tokens} = TokenTransfers.parse(logs),
+
+         # extract celo core contract events from logs
          new_core_contracts = process_celo_core_contracts(logs),
          celo_contract_events = EventMap.celo_rpc_to_event_params(logs),
-         transactions_with_receipts = Receipts.put(transactions_params_without_receipts, receipts),
-         %{token_transfers: normal_token_transfers, tokens: normal_tokens} = TokenTransfers.parse(logs),
 
          # Get required core contract addresses from the registry
          {:ok, celo_token} = Util.get_address("GoldToken"),
@@ -221,9 +214,10 @@ defmodule Indexer.Block.Fetcher do
          {:ok, oracle_address} = Util.get_address("SortedOracles"),
 
          # Create CELO token transfers from native tx values
-         %{token_transfers: celo_token_transfers} = TokenTransfers.parse_tx(transactions_with_receipts, celo_token),
+         %{token_transfers: native_celo_token_transfers} =
+           TokenTransfers.parse_tx(transactions_with_receipts, celo_token),
 
-         # Non CELO fees should be handled by events
+         # extract various celo protocol data from logs + oracles
          %{
            accounts: celo_accounts,
            validators: celo_validators,
@@ -238,6 +232,8 @@ defmodule Indexer.Block.Fetcher do
            withdrawals: celo_withdrawals,
            unlocked: celo_unlocked
          } = CeloAccounts.parse(logs, oracle_address),
+
+         # extract cusd + CELO exchange rates from above
          market_history =
            exchange_rates
            |> Enum.filter(fn el -> el.token == stable_token_usd end)
@@ -253,11 +249,19 @@ defmodule Indexer.Block.Fetcher do
             else
               []
             end),
+
+         # extract token minting transfers (bridged)
          %{mint_transfers: mint_transfers} = MintTransfers.parse(logs),
+
+         # fetch block reward beneficiaries
          %FetchedBeneficiaries{params_set: beneficiary_params_set, errors: beneficiaries_errors} =
            fetch_beneficiaries(blocks, json_rpc_named_arguments),
+
+         # fold celo transfers into list of token transfers (treat native chain asset as erc-20)
          tokens = [%{contract_address_hash: celo_token, type: "ERC-20"} | normal_tokens],
-         token_transfers = normal_token_transfers ++ celo_token_transfers,
+         token_transfers = normal_token_transfers ++ native_celo_token_transfers,
+
+         # extract all referenced addresses from data
          addresses =
            Addresses.extract_addresses(%{
              block_reward_contract_beneficiaries: MapSet.to_list(beneficiary_params_set),
@@ -270,9 +274,13 @@ defmodule Indexer.Block.Fetcher do
              # The address of the CELO token has to be added to the addresses table
              celo_token: [%{hash: celo_token, block_number: last_block}]
            }),
+
+         # get celo transfers (erc-20)
          celo_transfers =
            normal_token_transfers
            |> Enum.filter(fn %{token_contract_address_hash: contract} -> contract == celo_token end),
+
+         # extract (instant) coin balances from above data
          coin_balances_params_set =
            %{
              beneficiary_params: MapSet.to_list(beneficiary_params_set),
@@ -282,20 +290,27 @@ defmodule Indexer.Block.Fetcher do
              transactions_params: transactions_with_receipts
            }
            |> AddressCoinBalances.params_set(),
+
+         # extract daily coin balance from above instant balances
          coin_balances_params_daily_set =
            %{
              coin_balances_params: coin_balances_params_set,
              blocks: blocks
            }
            |> AddressCoinBalancesDaily.params_set(),
+
+         # calculate gas payment beneficiaries
          beneficiaries_with_gas_payment <-
            beneficiary_params_set
            |> add_gas_payments(transactions_with_receipts, blocks)
            |> BlockReward.reduce_uncle_rewards(),
-         address_token_balances_from_transfers =
-           AddressTokenBalances.params_set(%{token_transfers_params: token_transfers}),
-         # Also update the CELO token balances
-         address_token_balances = add_celo_token_balances(celo_token, addresses, address_token_balances_from_transfers),
+
+         # extract address token balances from token transfers
+         address_token_balances = AddressTokenBalances.params_set(%{token_transfers_params: token_transfers}),
+
+         # TODO 20/10/22 : Assert that celo token balances are still inserted correctly and remove the referenced code below
+         # address_token_balances = add_celo_token_balances(celo_token, addresses, address_token_balances_from_transfers),
+
          {:ok, inserted} <-
            __MODULE__.import(
              state,

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -180,10 +180,6 @@ defmodule Indexer.Block.Fetcher do
     end)
   end
 
-  defp config(key) do
-    Application.get_env(:indexer, __MODULE__, [])[key]
-  end
-
   @decorate span(tracer: Tracer)
   @spec fetch_and_import_range(t, Range.t()) ::
           {:ok, %{inserted: %{}, errors: [EthereumJSONRPC.Transport.error()]}}
@@ -260,13 +256,7 @@ defmodule Indexer.Block.Fetcher do
          %{mint_transfers: mint_transfers} = MintTransfers.parse(logs),
          %FetchedBeneficiaries{params_set: beneficiary_params_set, errors: beneficiaries_errors} =
            fetch_beneficiaries(blocks, json_rpc_named_arguments),
-         tokens =
-           normal_tokens ++
-             (if celo_token_enabled do
-                [%{contract_address_hash: celo_token, type: "ERC-20"}]
-              else
-                []
-              end),
+         tokens = normal_tokens ++ [%{contract_address_hash: celo_token, type: "ERC-20"}],
          token_transfers = normal_token_transfers ++ celo_token_transfers,
          addresses =
            Addresses.extract_addresses(%{

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -256,7 +256,7 @@ defmodule Indexer.Block.Fetcher do
          %{mint_transfers: mint_transfers} = MintTransfers.parse(logs),
          %FetchedBeneficiaries{params_set: beneficiary_params_set, errors: beneficiaries_errors} =
            fetch_beneficiaries(blocks, json_rpc_named_arguments),
-         tokens = [normal_tokens | [%{contract_address_hash: celo_token, type: "ERC-20"}]],
+         tokens = [%{contract_address_hash: celo_token, type: "ERC-20"} | normal_tokens],
          token_transfers = normal_token_transfers ++ celo_token_transfers,
          addresses =
            Addresses.extract_addresses(%{

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -16,8 +16,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
   alias Explorer.Chain.{Block, Transaction}
   alias Explorer.Chain.Cache.{Accounts, Blocks}
   alias Indexer.{BufferedTask, Tracer}
-  alias Indexer.Fetcher.TokenBalance
   alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
+  alias Indexer.Fetcher.TokenBalance
   alias Indexer.Transform.{Addresses, TokenTransfers}
 
   use BufferedTask

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -255,7 +255,6 @@ defmodule Indexer.Fetcher.InternalTransaction do
     # Gold token special updates
     token_transfers =
       with {:ok, gold_token} <- Util.get_address("GoldToken") do
-
         %{token_transfers: celo_token_transfers} =
           TokenTransfers.parse_itx(internal_transactions_params_without_failed_creations, gold_token)
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -250,8 +250,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
     # Gold token special updates
     {:ok, gold_token} = Util.get_address("GoldToken")
 
-    token_transfers =
-      %{token_transfers: celo_token_transfers} =
+    %{token_transfers: token_transfers} =
       TokenTransfers.parse_itx(internal_transactions_params_without_failed_creations, gold_token)
 
     token_transfers_addresses_params =

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -16,6 +16,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
   alias Explorer.Chain.{Block, Transaction}
   alias Explorer.Chain.Cache.{Accounts, Blocks}
   alias Indexer.{BufferedTask, Tracer}
+  alias Indexer.Fetcher.TokenBalance
   alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
   alias Indexer.Transform.{Addresses, TokenTransfers}
 
@@ -248,7 +249,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
       })
 
     # Enqueue fetching of celo balances for addresses referenced in itx
-    fetch_celo_balances_for(addresses_params)
+    {:ok, gold_token} = Util.get_address("GoldToken")
+    fetch_celo_balances_for(addresses_params, gold_token)
 
     %{token_transfers: token_transfers} =
       TokenTransfers.parse_itx(internal_transactions_params_without_failed_creations, gold_token)
@@ -326,9 +328,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
     end)
   end
 
-  defp fetch_celo_balances_for(addresses) do
-    {:ok, gold_token} = Util.get_address("GoldToken")
-
+  defp fetch_celo_balances_for(addresses, gold_token) do
     addresses
     |> add_gold_token_balances(gold_token, MapSet.new())
     |> MapSet.to_list()

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -17,7 +17,6 @@ defmodule Indexer.Fetcher.InternalTransaction do
   alias Explorer.Chain.Cache.{Accounts, Blocks}
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
-  alias Indexer.Fetcher.TokenBalance
   alias Indexer.Transform.{Addresses, TokenTransfers}
 
   use BufferedTask
@@ -238,10 +237,6 @@ defmodule Indexer.Fetcher.InternalTransaction do
   # block_hash is required for TokenTransfers.parse_itx
   defp add_block_hash(block_hash, internal_transactions) do
     Enum.map(internal_transactions, fn a -> Map.put(a, :block_hash, block_hash) end)
-  end
-
-  defp decode("0x" <> str) do
-    %{bytes: Base.decode16!(str, case: :mixed)}
   end
 
   defp import_internal_transaction(internal_transactions_params, unique_numbers) do

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -248,15 +248,11 @@ defmodule Indexer.Fetcher.InternalTransaction do
       })
 
     # Gold token special updates
-    token_transfers =
-      with {:ok, gold_token} <- Util.get_address("GoldToken") do
-        %{token_transfers: celo_token_transfers} =
-          TokenTransfers.parse_itx(internal_transactions_params_without_failed_creations, gold_token)
+    {:ok, gold_token} = Util.get_address("GoldToken")
 
-        celo_token_transfers
-      else
-        _ -> []
-      end
+    token_transfers =
+      %{token_transfers: celo_token_transfers} =
+      TokenTransfers.parse_itx(internal_transactions_params_without_failed_creations, gold_token)
 
     token_transfers_addresses_params =
       Addresses.extract_addresses(%{

--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -123,7 +123,7 @@ defmodule Indexer.Fetcher.TokenBalance do
         :ok
 
       {:error, reason} ->
-        Logger.debug(fn -> ["failed to import token balances: ", inspect(reason)] end,
+        Logger.error(fn -> ["failed to import token balances: ", inspect(reason)] end,
           error_count: Enum.count(token_balances_params)
         )
 

--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -34,6 +34,8 @@ defmodule Indexer.Fetcher.TokenBalance do
   @max_retries 3
 
   @spec async_fetch([]) :: :ok
+  def async_fetch([]), do: :ok
+
   def async_fetch(token_balances) do
     formatted_params = Enum.map(token_balances, &entry/1)
     BufferedTask.buffer(__MODULE__, formatted_params, :infinity)

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -353,7 +353,7 @@ defmodule Indexer.Block.FetcherTest do
               unprefixed_celo_token_address_hash,
               event_first_topic,
               event_data,
-              15
+              14
             )
 
           variant ->

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -119,7 +119,7 @@ defmodule Indexer.Block.FetcherTest do
               unprefixed_celo_token_address_hash,
               event_first_topic,
               event_data,
-              16
+              14
             )
 
           variant ->
@@ -332,7 +332,6 @@ defmodule Indexer.Block.FetcherTest do
       set_test_address(to_string(celo_token_address.hash))
 
       block_number = @first_full_block_number
-      #          insert(:celo_unlocked, %{account_address: "0xC257274276a4E539741Ca11b590B9447B26A8051", amount: 3840})
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         case Keyword.fetch!(json_rpc_named_arguments, :variant) do
@@ -354,7 +353,7 @@ defmodule Indexer.Block.FetcherTest do
               unprefixed_celo_token_address_hash,
               event_first_topic,
               event_data,
-              16
+              15
             )
 
           variant ->

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -119,7 +119,7 @@ defmodule Indexer.Block.FetcherTest do
               unprefixed_celo_token_address_hash,
               event_first_topic,
               event_data,
-              18
+              16
             )
 
           variant ->
@@ -354,7 +354,7 @@ defmodule Indexer.Block.FetcherTest do
               unprefixed_celo_token_address_hash,
               event_first_topic,
               event_data,
-              18
+              16
             )
 
           variant ->

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -284,6 +284,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
 
       set_test_address()
       CoinBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
       assert %{block_hash: block_hash} = Repo.get(PendingBlockOperation, block_hash)
 
@@ -407,6 +408,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       ]
 
       CoinBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+      TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
       assert :ok ==
                InternalTransaction.run(

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -66,7 +66,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       end
     end
 
-    empty_address_cache()
+    set_test_address()
     CoinBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
     PendingTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
@@ -106,7 +106,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
     block_number = 1_000_006
     block = insert(:block, number: block_number)
     insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
-    empty_address_cache()
+    set_test_address()
 
     assert :ok = InternalTransaction.run([block_number], json_rpc_named_arguments)
 
@@ -173,7 +173,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
         end
       end
 
-      empty_address_cache()
+      set_test_address()
 
       block = insert(:block)
       block_hash = block.hash
@@ -282,7 +282,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
         end
       end
 
-      empty_address_cache()
+      set_test_address()
       CoinBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
       assert %{block_hash: block_hash} = Repo.get(PendingBlockOperation, block_hash)
@@ -341,7 +341,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       assert %{block_hash: ^valid_block_hash2} = Repo.get(PendingBlockOperation, valid_block_hash2)
       assert %{block_hash: ^empty_block_hash} = Repo.get(PendingBlockOperation, empty_block_hash)
 
-      empty_address_cache()
+      set_test_address()
 
       EthereumJSONRPC.Mox
       |> expect(:json_rpc, fn [%{id: id, method: "debug_traceTransaction"}], _options ->


### PR DESCRIPTION
### Description

It looks like we have been fetching celo token balances for all addresses found within a block. This should obviously only be done for addresses affected by a celo transfer. This PR stops that + a lot of smaller changes.
 
 ### Other changes

* Documents the block fetching process with comments explaining each step 
* Removes some conditional `gold_token_enabled` functionality
    * For celo this is always, and must always be enabled
* Disable min missing block process for tests
* Adjust tests to fit new behavior
    * Mostly making less rpc calls during the test flow

### Tested

* Ran test suite

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/455
