### PR TITLE
Remove md5 column from smart_contract

### DIFF
--- a/apps/explorer/priv/repo/migrations/20221020131800_smart_contracts_remove_md5.exs
+++ b/apps/explorer/priv/repo/migrations/20221020131800_smart_contracts_remove_md5.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.SmartContractsRemoveMd5 do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TABLE smart_contracts DROP COLUMN IF EXISTS contract_byte_code_md5;")
+  end
+end


### PR DESCRIPTION
### Description
Code is removed in this https://github.com/celo-org/blockscout/pull/790. This migration should run after the new version of the code is deployed.

### Other changes
No.

### Tested
Locally.