### PR TITLE
Feature/normalise ingestion metrics

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/celo_epoch_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/celo_epoch_rewards.ex
@@ -37,7 +37,7 @@ defmodule Explorer.Chain.Import.Runner.CeloEpochRewards do
     insert_options = Util.make_insert_options(option_key(), @timeout, options)
 
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
-    Multi.run(multi, :insert_voter_reward_items, fn repo, _ ->
+    Multi.run(multi, :celo_epoch_rewards, fn repo, _ ->
       insert(repo, changes_list, insert_options)
     end)
   end

--- a/apps/explorer/lib/explorer/chain/import/runner/celo_params.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/celo_params.ex
@@ -37,7 +37,7 @@ defmodule Explorer.Chain.Import.Runner.CeloParams do
     insert_options = Util.make_insert_options(option_key(), @timeout, options)
 
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
-    Multi.run(multi, :insert_params_items, fn repo, _ ->
+    Multi.run(multi, :insert_celo_params_items, fn repo, _ ->
       insert(repo, changes_list, insert_options)
     end)
   end

--- a/apps/explorer/lib/explorer/chain/import/runner/celo_signers.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/celo_signers.ex
@@ -37,7 +37,7 @@ defmodule Explorer.Chain.Import.Runner.CeloSigners do
     insert_options = Util.make_insert_options(option_key(), @timeout, options)
 
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
-    Multi.run(multi, :insert_signer_items, fn repo, _ ->
+    Multi.run(multi, :insert_celo_signer_items, fn repo, _ ->
       insert(repo, changes_list, insert_options)
     end)
   end

--- a/apps/explorer/lib/explorer/chain/import/runner/celo_unlocked.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/celo_unlocked.ex
@@ -35,7 +35,7 @@ defmodule Explorer.Chain.Import.Runner.CeloUnlocked do
     insert_options = Util.make_insert_options(option_key(), @timeout, options)
 
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
-    Multi.run(multi, :insert_pending_items, fn repo, _ ->
+    Multi.run(multi, :celo_unlocked, fn repo, _ ->
       insert(repo, changes_list, insert_options)
     end)
   end

--- a/apps/explorer/lib/explorer/chain/import/runner/celo_voters.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/celo_voters.ex
@@ -41,7 +41,7 @@ defmodule Explorer.Chain.Import.Runner.CeloVoters do
     |> Multi.run(:acquire_all_items, fn repo, _ ->
       acquire_all_items(repo)
     end)
-    |> Multi.run(:insert_items, fn repo, _ ->
+    |> Multi.run(:insert_celo_voters, fn repo, _ ->
       insert(repo, changes_list, insert_options)
     end)
   end

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -99,34 +99,6 @@ config :logger, :logger_backend, level: :error
 #       block_number step count error_count shrunk import_id transaction_id)a,
 #  metadata_filter: [application: :indexer]
 
-config :indexer, Indexer.Prometheus.MetricsCron, metrics_fetcher_blocks_count: 1000
-config :indexer, Indexer.Prometheus.MetricsCron, metrics_cron_interval: System.get_env("METRICS_CRON_INTERVAL") || "2"
-
-config :indexer, :telemetry_config, [
-  [
-    name: [:blockscout, :ingested],
-    type: :summary,
-    label: "indexer_import_ingested",
-    meta: %{
-      help: "Blockchain primitives ingested via `Import.all` by type",
-      metric_labels: [:type]
-    }
-  ],
-  [
-    name: [:blockscout, :chain_event_send],
-    type: :counter,
-    label: "indexer_chain_events_sent",
-    meta: %{
-      help: "Number of chain events sent via pubsub"
-    }
-  ]
-]
-
-config :prometheus, Indexer.Prometheus.Exporter,
-  path: "/metrics/indexer",
-  format: :text,
-  registry: :default
-
 indexer_empty_blocks_sanitizer_batch_size =
   if System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE") do
     case Integer.parse(System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE")) do
@@ -141,6 +113,8 @@ config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer.Supervisor,
   disabled?: System.get_env("INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER", "false") == "true"
 
 config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer, batch_size: indexer_empty_blocks_sanitizer_batch_size
+
+import_config "telemetry/telemetry.exs"
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/indexer/config/telemetry/telemetry.exs
+++ b/apps/indexer/config/telemetry/telemetry.exs
@@ -11,7 +11,7 @@ config :indexer, :telemetry_config, [
     meta: %{
       help: "Blockchain primitives ingested via `Import.all` by type",
       metric_labels: [:type],
-      function: Indexer.Celo.Telemetry.Helper.filter_imports/1
+      function: &Indexer.Celo.Telemetry.Helper.filter_imports/1
     }
   ],
   [

--- a/apps/indexer/config/telemetry/telemetry.exs
+++ b/apps/indexer/config/telemetry/telemetry.exs
@@ -1,0 +1,30 @@
+import Config
+
+config :indexer, Indexer.Prometheus.MetricsCron, metrics_fetcher_blocks_count: 1000
+config :indexer, Indexer.Prometheus.MetricsCron, metrics_cron_interval: System.get_env("METRICS_CRON_INTERVAL") || "2"
+
+config :indexer, :telemetry_config, [
+  [
+    name: [:blockscout, :ingested],
+    type: :summary,
+    label: "indexer_import_ingested",
+    meta: %{
+      help: "Blockchain primitives ingested via `Import.all` by type",
+      metric_labels: [:type],
+      function: Indexer.Celo.Telemetry.Helper.filter_imports/1
+    }
+  ],
+  [
+    name: [:blockscout, :chain_event_send],
+    type: :counter,
+    label: "indexer_chain_events_sent",
+    meta: %{
+      help: "Number of chain events sent via pubsub"
+    }
+  ]
+]
+
+config :prometheus, Indexer.Prometheus.Exporter,
+       path: "/metrics/indexer",
+       format: :text,
+       registry: :default

--- a/apps/indexer/config/telemetry/telemetry.exs
+++ b/apps/indexer/config/telemetry/telemetry.exs
@@ -25,6 +25,6 @@ config :indexer, :telemetry_config, [
 ]
 
 config :prometheus, Indexer.Prometheus.Exporter,
-       path: "/metrics/indexer",
-       format: :text,
-       registry: :default
+  path: "/metrics/indexer",
+  format: :text,
+  registry: :default

--- a/apps/indexer/lib/indexer/celo/telemetry/helper.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/helper.ex
@@ -35,7 +35,7 @@ defmodule Indexer.Celo.Telemetry.Helper do
 
   defp take_import({:address_coin_balances_daily, _} = address_coin_balances_daily), do: address_coin_balances_daily
   defp take_import({:address_coin_balances, _} = address_coin_balances), do: address_coin_balances
-  defp take_import({:insert_names, count} = an), do: {:address_names, count}
+  defp take_import({:insert_names, count}), do: {:address_names, count}
   defp take_import({:address_token_balances, _} = address_token_balances), do: address_token_balances
 
   defp take_import({:address_current_token_balances, _} = address_current_token_balances),

--- a/apps/indexer/lib/indexer/celo/telemetry/helper.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/helper.ex
@@ -9,11 +9,10 @@ defmodule Indexer.Celo.Telemetry.Helper do
     changes
     |> Enum.reduce(%{}, fn import, acc ->
       case take_import(import) do
-        {key, count} ->  Map.put(acc, key, count)
+        {key, count} -> Map.put(acc, key, count)
         nil -> acc
       end
     end)
-
   end
 
   defp take_import({:insert_celo_election_rewards_items, count}), do: {:celo_election_rewards, count}
@@ -27,25 +26,28 @@ defmodule Indexer.Celo.Telemetry.Helper do
   defp take_import({:insert_wallets, count}), do: {:celo_wallets, count}
   defp take_import({:insert_celo_voters, count}), do: {:celo_voters, count}
   defp take_import({:insert_account_epoch_items, count}), do: {:celo_account_epoch, count}
-  defp take_import(cl = {:celo_unlocked, _}), do: cl
-  defp take_import(cce = {:celo_contract_event, _}), do: cce
-  defp take_import(ccc = {:celo_core_contracts, _}), do: ccc
-  defp take_import(epoch_rewards = {:celo_epoch_rewards, _}), do: epoch_rewards
+  defp take_import({:celo_unlocked, _} = cl), do: cl
+  defp take_import({:celo_contract_event, _} = cce), do: cce
+  defp take_import({:celo_core_contracts, _} = ccc), do: ccc
+  defp take_import({:celo_epoch_rewards, _} = epoch_rewards), do: epoch_rewards
 
   defp take_import({:tracked_contract_events, count}), do: {:contract_event, count}
 
-  defp take_import(address_coin_balances_daily = {:address_coin_balances_daily, _}), do: address_coin_balances_daily
-  defp take_import(address_coin_balances = {:address_coin_balances, _}), do: address_coin_balances
-  defp take_import(an = {:insert_names, count}), do: {:address_names, count}
-  defp take_import(address_token_balances = {:address_token_balances, _}), do: address_token_balances
-  defp take_import(address_current_token_balances = {:address_current_token_balances, _}), do: address_current_token_balances
-  defp take_import(addresses = {:addresses, _}), do: addresses
-  defp take_import(tx = {:transactions, _}), do: tx
-  defp take_import(blocks = {:blocks, _}), do: blocks
-  defp take_import(tt = {:token_transfers, _}), do: tt
-  defp take_import(t = {:tokens, _}), do: t
-  defp take_import(logs = {:logs, _}), do: logs
-  defp take_import(itx = {:internal_transactions, _}), do: itx
+  defp take_import({:address_coin_balances_daily, _} = address_coin_balances_daily), do: address_coin_balances_daily
+  defp take_import({:address_coin_balances, _} = address_coin_balances), do: address_coin_balances
+  defp take_import({:insert_names, count} = an), do: {:address_names, count}
+  defp take_import({:address_token_balances, _} = address_token_balances), do: address_token_balances
+
+  defp take_import({:address_current_token_balances, _} = address_current_token_balances),
+    do: address_current_token_balances
+
+  defp take_import({:addresses, _} = addresses), do: addresses
+  defp take_import({:transactions, _} = tx), do: tx
+  defp take_import({:blocks, _} = blocks), do: blocks
+  defp take_import({:token_transfers, _} = tt), do: tt
+  defp take_import({:tokens, _} = t), do: t
+  defp take_import({:logs, _} = logs), do: logs
+  defp take_import({:internal_transactions, _} = itx), do: itx
 
   defp take_import(_), do: nil
 end

--- a/apps/indexer/lib/indexer/celo/telemetry/helper.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/helper.ex
@@ -34,6 +34,11 @@ defmodule Indexer.Celo.Telemetry.Helper do
 
   defp take_import({:tracked_contract_events, count}), do: {:contract_event, count}
 
+  defp take_import(address_coin_balances_daily = {:address_coin_balances_daily, _}), do: address_coin_balances_daily
+  defp take_import(address_coin_balances = {:address_coin_balances, _}), do: address_coin_balances
+  defp take_import(an = {:insert_names, count}), do: {:address_names, count}
+  defp take_import(address_token_balances = {:address_token_balances, _}), do: address_token_balances
+  defp take_import(address_current_token_balances = {:address_current_token_balances, _}), do: address_current_token_balances
   defp take_import(addresses = {:addresses, _}), do: addresses
   defp take_import(tx = {:transactions, _}), do: tx
   defp take_import(blocks = {:blocks, _}), do: blocks

--- a/apps/indexer/lib/indexer/celo/telemetry/helper.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/helper.ex
@@ -1,4 +1,10 @@
 defmodule Indexer.Celo.Telemetry.Helper do
+  @moduledoc "Helper functions for telemetry event processing"
+
+  @doc """
+    Filters out changes from the full list of imports to only those that we care about
+    This is necessary as Import.all will return a mapping of each Ecto.Multi stage id to count of rows affected
+  """
   def filter_imports(changes) do
     changes
     |> Enum.reduce(%{}, fn import, acc ->

--- a/apps/indexer/lib/indexer/celo/telemetry/helper.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/helper.ex
@@ -16,12 +16,31 @@ defmodule Indexer.Celo.Telemetry.Helper do
 
   end
 
-  defp take_import(epoch_rewards = {:celo_epoch_rewards, _}), do: epoch_rewards
+  defp take_import({:insert_celo_election_rewards_items, count}), do: {:celo_election_rewards, count}
+  defp take_import({:insert_celo_params_items, count}), do: {:celo_params, count}
+  defp take_import({:insert_celo_signer_items, count}), do: {:celo_signers, count}
+  defp take_import({:insert_validator_group_items, count}), do: {:celo_validator_group, count}
+  defp take_import({:insert_validator_history_items, count}), do: {:celo_validator_history, count}
+  defp take_import({:insert_validator_status_items, count}), do: {:celo_validator_status, count}
+  defp take_import({:insert_celo_accounts, count}), do: {:celo_accounts, count}
+  defp take_import({:insert_celo_validators, count}), do: {:celo_validators, count}
+  defp take_import({:insert_wallets, count}), do: {:celo_wallets, count}
+  defp take_import({:insert_celo_voters, count}), do: {:celo_voters, count}
   defp take_import({:insert_account_epoch_items, count}), do: {:celo_account_epoch, count}
+  defp take_import(cl = {:celo_unlocked, _}), do: cl
+  defp take_import(cce = {:celo_contract_event, _}), do: cce
+  defp take_import(ccc = {:celo_core_contracts, _}), do: ccc
+  defp take_import(epoch_rewards = {:celo_epoch_rewards, _}), do: epoch_rewards
+
+  defp take_import({:tracked_contract_events, count}), do: {:contract_event, count}
+
   defp take_import(addresses = {:addresses, _}), do: addresses
   defp take_import(tx = {:transactions, _}), do: tx
   defp take_import(blocks = {:blocks, _}), do: blocks
+  defp take_import(tt = {:token_transfers, _}), do: tt
   defp take_import(t = {:tokens, _}), do: t
+  defp take_import(logs = {:logs, _}), do: logs
   defp take_import(itx = {:internal_transactions, _}), do: itx
+
   defp take_import(_), do: nil
 end

--- a/apps/indexer/lib/indexer/celo/telemetry/helper.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/helper.ex
@@ -1,0 +1,21 @@
+defmodule Indexer.Celo.Telemetry.Helper do
+  def filter_imports(changes) do
+    changes
+    |> Enum.reduce(%{}, fn import, acc ->
+      case take_import(import) do
+        {key, count} ->  Map.put(acc, key, count)
+        nil -> acc
+      end
+    end)
+
+  end
+
+  defp take_import(epoch_rewards = {:celo_epoch_rewards, _}), do: epoch_rewards
+  defp take_import({:insert_account_epoch_items, count}), do: {:celo_account_epoch, count}
+  defp take_import(addresses = {:addresses, _}), do: addresses
+  defp take_import(tx = {:transactions, _}), do: tx
+  defp take_import(blocks = {:blocks, _}), do: blocks
+  defp take_import(t = {:tokens, _}), do: t
+  defp take_import(itx = {:internal_transactions, _}), do: itx
+  defp take_import(_), do: nil
+end

--- a/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
@@ -20,7 +20,7 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
     end
   end
 
-  def attach_event(name, :summary, label, %{metric_labels: metric_labels, help: help} = _meta) do
+  def attach_event(name, :summary, label, %{metric_labels: metric_labels, help: help} = meta) do
     Logger.info("Attach event #{name |> inspect()}")
 
     Summary.declare(
@@ -29,10 +29,12 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
       help: help
     )
 
-    :telemetry.attach(handler_id(name), name, &__MODULE__.handle_event/4, %{type: :summary, label: label})
+    handler_meta = meta |> Map.merge(%{type: :summary, label: label})
+
+    :telemetry.attach(handler_id(name), name, &__MODULE__.handle_event/4, handler_meta)
   end
 
-  def attach_event(name, :counter, label, %{help: help} = _meta) do
+  def attach_event(name, :counter, label, %{help: help} = meta) do
     Logger.info("Attach event #{name |> inspect()}")
 
     Counter.declare(
@@ -40,7 +42,9 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
       help: help
     )
 
-    :telemetry.attach(handler_id(name), name, &__MODULE__.handle_event/4, %{type: :counter, label: label})
+    handler_meta = meta |> Map.merge(%{type: :counter, label: label})
+
+    :telemetry.attach(handler_id(name), name, &__MODULE__.handle_event/4, handler_meta)
   end
 
   def attach_event(name, :histogram, label, %{buckets: buckets, metric_labels: metric_labels, help: help} = _meta) do
@@ -65,9 +69,11 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
     Counter.inc(name: label)
   end
 
-  def handle_event(_name, measurements, _metadata, %{type: :histogram, label: label})
+  def handle_event(_name, measurements, _metadata, %{type: :histogram, label: label} = meta)
       when is_map(measurements) do
+
     measurements
+    |> process_measurements(meta)
     |> Enum.each(fn {name, value} ->
       Histogram.observe(
         [name: label, labels: [name]],
@@ -76,9 +82,11 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
     end)
   end
 
-  def handle_event(_name, measurements, _metadata, %{type: :summary, label: label})
+  def handle_event(_name, measurements, _metadata, %{type: :summary, label: label} = meta)
       when is_map(measurements) do
+
     measurements
+    |> process_measurements(meta)
     |> Enum.each(fn {name, value} ->
       Summary.observe(
         [name: label, labels: [name]],
@@ -90,6 +98,12 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
   def handle_event(name, _measurements, _metadata, _config) do
     Logger.error("unhandled metric #{name |> inspect()}")
   end
+
+  defp process_measurements(measurements, %{function: function}) do
+    function.(measurements)
+  end
+
+  defp process_measurements(measurements, _), do: measurements
 
   defp process_config(event) do
     name = Keyword.get(event, :name, {:error, "no event name"})

--- a/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/celo_telemetry_instrumenter.ex
@@ -71,7 +71,6 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
 
   def handle_event(_name, measurements, _metadata, %{type: :histogram, label: label} = meta)
       when is_map(measurements) do
-
     measurements
     |> process_measurements(meta)
     |> Enum.each(fn {name, value} ->
@@ -84,7 +83,6 @@ defmodule Indexer.Prometheus.CeloInstrumenter do
 
   def handle_event(_name, measurements, _metadata, %{type: :summary, label: label} = meta)
       when is_map(measurements) do
-
     measurements
     |> process_measurements(meta)
     |> Enum.each(fn {name, value} ->


### PR DESCRIPTION
### Description

Filters and normalises the metrics sent to prometheus from `Import.all`. Previously we were sending everything, which includes intermediate transformations of data. Now we only send metrics representing the insertion of blockchain primitives. 

Additionally a few of the labels lack convention and were duplicated (copy pasted..), metrics are now tagged with their type directly
 
 ### Other changes

* Adds the generic ability to provide a helper function to a telemetry metric definition for processing event measurements
    * Used to implement the feature above

### Tested

* Tested locally and viewed prometheus metrics
* Deployed to rc1staging and saw metrics come in at https://clabs.grafana.net/goto/bZ7O2RHVz?orgId=1 (for rc1staging cluster)

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/431
