### PR TITLE
Loading epoch transactions for an address does not finish

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address_epoch_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_epoch_transaction/index.html.eex
@@ -18,30 +18,33 @@
   <section data-page="address-epoch-transactions">
     <div class="card">
       <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
-      <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
+      <div class="card-body" data-async-listing="<%= @current_path %>">
+
         <div data-selector="channel-batching-message" class="d-none">
           <div data-selector="reload-button" class="alert alert-info">
             <a href="#" class="alert-link"><span data-selector="channel-batching-count"></span> <%= gettext "More epoch transactions have come in" %></a>
           </div>
         </div>
+
         <div data-selector="channel-disconnected-message" class="d-none">
           <div data-selector="reload-button" class="alert alert-danger">
             <a href="#" class="alert-link"><%= gettext "Connection Lost, click to load newer epoch transactions" %></a>
           </div>
         </div>
+
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
-      </div>
 
         <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
+
         <div data-empty-response-message style="display: none;">
           <div class="tile tile-muted text-center">
             <span data-selector="empty-epoch-transactions-list"><%= gettext "There are no epoch transactions for this address." %></span>
           </div>
         </div>
 
-        <div data-items>
+        <div data-selector="address-epoch-transactions-list" data-items>
           <%= render BlockScoutWeb.CommonComponentsView, "_tile-loader.html" %>
         </div>
 
@@ -51,6 +54,7 @@
 
       </div>
     </div>
+
     <script defer data-cfasync="false" src="<%= static_path(@conn, "/js/address-epoch-transactions.js") %>"></script>
     <script defer data-cfasync="false" src="<%= static_path(@conn, "/js/token-transfers-toggle.js") %>"></script>
   </section>

--- a/apps/block_scout_web/lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex
@@ -37,7 +37,7 @@
         </div>
       </span>
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
-        <%= gettext "Validator Group:" %>
+        <%= gettext "Validator Group:" %>&nbsp;
         <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @epoch_transaction.associated_account_hash), "data-test": "address_hash_link", class: assigns[:class] do %>
           <%= @epoch_transaction.associated_account_name %>
         <% end %>
@@ -62,7 +62,7 @@
         </div>
       </span>
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
-        <%= gettext "Validator Group:" %>
+        <%= gettext "Validator Group:" %>&nbsp;
         <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @epoch_transaction.associated_account_hash), "data-test": "address_hash_link", class: assigns[:class] do %>
           <%= @epoch_transaction.associated_account_name %>
         <% end %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -691,7 +691,7 @@ msgid "Connection Lost, click to load newer blocks"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:29
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:31
 msgid "Connection Lost, click to load newer epoch transactions"
 msgstr ""
 
@@ -1695,7 +1695,7 @@ msgid "More"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:24
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:25
 msgid "More epoch transactions have come in"
 msgstr ""
 
@@ -2245,7 +2245,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_coin_balance/index.html.eex:30
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:36 lib/block_scout_web/templates/address_internal_transaction/index.html.eex:50
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:38 lib/block_scout_web/templates/address_internal_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/address_logs/index.html.eex:23 lib/block_scout_web/templates/address_signed/index.html.eex:23
 #: lib/block_scout_web/templates/address_token/index.html.eex:60 lib/block_scout_web/templates/address_token_transfer/index.html.eex:58
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:50 lib/block_scout_web/templates/address_validation/index.html.eex:20
@@ -2541,7 +2541,7 @@ msgid "There are no downtime blocks for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:40
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:43
 msgid "There are no epoch transactions for this address."
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -692,7 +692,7 @@ msgid "Connection Lost, click to load newer blocks"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:29
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:31
 msgid "Connection Lost, click to load newer epoch transactions"
 msgstr ""
 
@@ -1696,7 +1696,7 @@ msgid "More"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:24
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:25
 msgid "More epoch transactions have come in"
 msgstr ""
 
@@ -2246,7 +2246,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_coin_balance/index.html.eex:30
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:36 lib/block_scout_web/templates/address_internal_transaction/index.html.eex:50
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:38 lib/block_scout_web/templates/address_internal_transaction/index.html.eex:50
 #: lib/block_scout_web/templates/address_logs/index.html.eex:23 lib/block_scout_web/templates/address_signed/index.html.eex:23
 #: lib/block_scout_web/templates/address_token/index.html.eex:60 lib/block_scout_web/templates/address_token_transfer/index.html.eex:58
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:50 lib/block_scout_web/templates/address_validation/index.html.eex:20
@@ -2542,7 +2542,7 @@ msgid "There are no downtime blocks for this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:40
+#: lib/block_scout_web/templates/address_epoch_transaction/index.html.eex:43
 msgid "There are no epoch transactions for this address."
 msgstr ""
 


### PR DESCRIPTION
### Description

Epoch transactions were not loading due to malformed HTML. Also by removing `data-async-load` attribute from the container we can avoid making duplicate initial calls.
 
### Tested

Tested locally.

### Issues

Fixes https://github.com/celo-org/data-services/issues/539