### PR TITLE
Epoch API: Support for both timestamps + block numbers in "from" and …

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/epoch_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/epoch_controller.ex
@@ -207,7 +207,7 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
   defp fetch_date(date_param) do
     {:date_param,
      case DateTime.from_iso8601(date_param) do
-       {:ok, datetime} -> {:ok, datetime}
+       {:ok, datetime, _} -> {:ok, datetime}
        _ -> {:error, :invalid_format}
      end}
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/epoch_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/epoch_controller.ex
@@ -13,19 +13,23 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
          {:address_param, group_address_param} <- get_address(params, "groupAddress"),
          {:voter_format, {:ok, voter_hash_list}} <- to_address_hash_list(address_param, :voter_format),
          {:group_format, {:ok, group_hash_list}} <- to_address_hash_list(group_address_param, :group_format),
-         {:block_number_param, {:ok, from}} <- fetch_block_number(params["from"]),
-         {:block_number_param, {:ok, to}} <- fetch_block_number(params["to"]),
+         {:block_number_param, {:ok, block_number_from}} <- fetch_block_number(params["blockNumberFrom"]),
+         {:block_number_param, {:ok, block_number_to}} <- fetch_block_number(params["blockNumberTo"]),
+         {:date_param, {:ok, date_from}} <- fetch_date(params["dateFrom"]),
+         {:date_param, {:ok, date_to}} <- fetch_date(params["dateTo"]),
          %{page_size: page_size, page_number: page_number} <-
            GenericPagingOptions.extract_paging_options_from_params(params, @api_voter_rewards_max_page_size),
          rewards <-
            CeloElectionRewards.get_epoch_rewards(
+             "voter",
              voter_hash_list,
-             ["voter"],
              group_hash_list,
-             from,
-             to,
              page_number,
-             page_size
+             page_size,
+             block_number_from: block_number_from,
+             block_number_to: block_number_to,
+             date_from: date_from,
+             date_to: date_to
            ) do
       render(conn, :getvoterrewards, rewards: rewards)
     else
@@ -43,6 +47,9 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
 
       {:block_number_param, {:error, :invalid_number}} ->
         render(conn, :error, error: "Block number must be greater than 0")
+
+      {:date_param, {:error, :invalid_format}} ->
+        render(conn, :error, error: "Wrong format for date provided")
     end
   end
 
@@ -51,19 +58,23 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
          {:address_param, group_address_param} <- get_address(params, "groupAddress"),
          {:validator_format, {:ok, validator_hash_list}} <- to_address_hash_list(address_param, :validator_format),
          {:group_format, {:ok, group_hash_list}} <- to_address_hash_list(group_address_param, :group_format),
-         {:block_number_param, {:ok, from}} <- fetch_block_number(params["from"]),
-         {:block_number_param, {:ok, to}} <- fetch_block_number(params["to"]),
+         {:block_number_param, {:ok, block_number_from}} <- fetch_block_number(params["blockNumberFrom"]),
+         {:block_number_param, {:ok, block_number_to}} <- fetch_block_number(params["blockNumberTo"]),
+         {:date_param, {:ok, date_from}} <- fetch_date(params["dateFrom"]),
+         {:date_param, {:ok, date_to}} <- fetch_date(params["dateTo"]),
          %{page_size: page_size, page_number: page_number} <-
            GenericPagingOptions.extract_paging_options_from_params(params, @api_validator_rewards_max_page_size),
          rewards <-
            CeloElectionRewards.get_epoch_rewards(
+             "validator",
              validator_hash_list,
-             ["validator"],
              group_hash_list,
-             from,
-             to,
              page_number,
-             page_size
+             page_size,
+             block_number_from: block_number_from,
+             block_number_to: block_number_to,
+             date_from: date_from,
+             date_to: date_to
            ) do
       render(conn, :getvalidatorrewards, rewards: rewards)
     else
@@ -81,6 +92,9 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
 
       {:block_number_param, {:error, :invalid_number}} ->
         render(conn, :error, error: "Block number must be greater than 0")
+
+      {:date_param, {:error, :invalid_format}} ->
+        render(conn, :error, error: "Wrong format for date provided")
     end
   end
 
@@ -90,19 +104,23 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
          {:group_format, {:ok, group_hash_list}} <- to_address_hash_list(group_address_param, :group_format),
          {:validator_format, {:ok, validator_hash_list}} <-
            to_address_hash_list(validator_address_param, :validator_format),
-         {:block_number_param, {:ok, from}} <- fetch_block_number(params["from"]),
-         {:block_number_param, {:ok, to}} <- fetch_block_number(params["to"]),
+         {:block_number_param, {:ok, block_number_from}} <- fetch_block_number(params["blockNumberFrom"]),
+         {:block_number_param, {:ok, block_number_to}} <- fetch_block_number(params["blockNumberTo"]),
+         {:date_param, {:ok, date_from}} <- fetch_date(params["dateFrom"]),
+         {:date_param, {:ok, date_to}} <- fetch_date(params["dateTo"]),
          %{page_size: page_size, page_number: page_number} <-
            GenericPagingOptions.extract_paging_options_from_params(params, @api_group_rewards_max_page_size),
          rewards <-
            CeloElectionRewards.get_epoch_rewards(
+             "group",
              group_hash_list,
-             ["group"],
              validator_hash_list,
-             from,
-             to,
              page_number,
-             page_size
+             page_size,
+             block_number_from: block_number_from,
+             block_number_to: block_number_to,
+             date_from: date_from,
+             date_to: date_to
            ) do
       render(conn, :getgrouprewards, rewards: rewards)
     else
@@ -120,6 +138,9 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
 
       {:block_number_param, {:error, :invalid_number}} ->
         render(conn, :error, error: "Block number must be greater than 0")
+
+      {:date_param, {:error, :invalid_format}} ->
+        render(conn, :error, error: "Wrong format for date provided")
     end
   end
 
@@ -177,6 +198,16 @@ defmodule BlockScoutWeb.API.RPC.EpochController do
      case Integer.parse(block_number) do
        {int, ""} when int < 1 -> {:error, :invalid_number}
        {int, ""} -> {:ok, int}
+       _ -> {:error, :invalid_format}
+     end}
+  end
+
+  defp fetch_date(nil), do: {:date_param, {:ok, nil}}
+
+  defp fetch_date(date_param) do
+    {:date_param,
+     case DateTime.from_iso8601(date_param) do
+       {:ok, datetime} -> {:ok, datetime}
        _ -> {:error, :invalid_format}
      end}
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/epoch_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/epoch_view.ex
@@ -63,8 +63,10 @@ defmodule BlockScoutWeb.API.RPC.EpochView do
     %{
       totalRewardAmounts: rewards.total_amount |> prepare_amounts(currency),
       totalRewardCount: to_string(rewards.total_count),
-      from: to_string(rewards.from),
-      to: to_string(rewards.to),
+      blockNumberFrom: to_string(rewards.blockNumberFrom),
+      blockNumberTo: to_string(rewards.blockNumberTo),
+      dateFrom: to_string(rewards.dateFrom),
+      dateTo: to_string(rewards.dateTo),
       rewards: Enum.map(rewards.rewards, fn reward -> prepare_rewards_response_item(reward, meta, currency) end)
     }
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/epoch_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/epoch_view.ex
@@ -63,10 +63,6 @@ defmodule BlockScoutWeb.API.RPC.EpochView do
     %{
       totalRewardAmounts: rewards.total_amount |> prepare_amounts(currency),
       totalRewardCount: to_string(rewards.total_count),
-      blockNumberFrom: to_string(rewards.blockNumberFrom),
-      blockNumberTo: to_string(rewards.blockNumberTo),
-      dateFrom: to_string(rewards.dateFrom),
-      dateTo: to_string(rewards.dateTo),
       rewards: Enum.map(rewards.rewards, fn reward -> prepare_rewards_response_item(reward, meta, currency) end)
     }
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/epoch_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/epoch_controller_test.exs
@@ -39,14 +39,14 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
     end
 
-    test "with an invalid 'from' param", %{conn: conn} do
+    test "with an invalid 'blockNumberFrom' param", %{conn: conn} do
       response =
         conn
         |> get("/api", %{
           "module" => "epoch",
           "action" => "getvoterrewards",
           "voterAddress" => "0x0000000000000000000000000000000000000001",
-          "from" => "invalid"
+          "blockNumberFrom" => "invalid"
         })
         |> json_response(200)
 
@@ -58,18 +58,56 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
     end
 
-    test "with an invalid 'to' param", %{conn: conn} do
+    test "with an invalid 'blockNumberTo' param", %{conn: conn} do
       response =
         conn
         |> get("/api", %{
           "module" => "epoch",
           "action" => "getvoterrewards",
           "voterAddress" => "0x0000000000000000000000000000000000000001",
-          "to" => "invalid"
+          "blockNumberTo" => "invalid"
         })
         |> json_response(200)
 
       assert response["message"] =~ "Wrong format for block number provided"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+
+      assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
+    end
+
+    test "with an invalid 'dateFrom' param", %{conn: conn} do
+      response =
+        conn
+        |> get("/api", %{
+          "module" => "epoch",
+          "action" => "getvoterrewards",
+          "voterAddress" => "0x0000000000000000000000000000000000000001",
+          "dateFrom" => "invalid"
+        })
+        |> json_response(200)
+
+      assert response["message"] =~ "Wrong format for date provided"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+
+      assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
+    end
+
+    test "with an invalid 'dateTo' param", %{conn: conn} do
+      response =
+        conn
+        |> get("/api", %{
+          "module" => "epoch",
+          "action" => "getvoterrewards",
+          "voterAddress" => "0x0000000000000000000000000000000000000001",
+          "dateTo" => "invalid"
+        })
+        |> json_response(200)
+
+      assert response["message"] =~ "Wrong format for date provided"
       assert response["status"] == "0"
       assert Map.has_key?(response, "result")
       refute response["result"]
@@ -84,7 +122,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvoterrewards",
           "voterAddress" => "0x0000000000000000000000000000000000000001",
-          "from" => "-1"
+          "blockNumberFrom" => "-1"
         })
         |> json_response(200)
 
@@ -103,7 +141,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvoterrewards",
           "voterAddress" => "0x0000000000000000000000000000000000000001",
-          "to" => "0"
+          "blockNumberTo" => "0"
         })
         |> json_response(200)
 
@@ -192,8 +230,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "wei" => "0"
         },
         "totalRewardCount" => "0",
-        "from" => "17280",
-        "to" => "#{block_number + 17279}"
+        "blockNumberFrom" => "",
+        "blockNumberTo" => "#{block_number + 17279}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -202,7 +242,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvoterrewards",
           "voterAddress" => "0x0000000000000000000000000000000000000002",
-          "to" => "#{block_number + 17279}"
+          "blockNumberTo" => "#{block_number + 17279}"
         })
         |> json_response(200)
 
@@ -234,8 +274,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "wei" => "0"
         },
         "totalRewardCount" => "0",
-        "from" => "123456789",
-        "to" => "#{block_number}"
+        "blockNumberFrom" => "123456789",
+        "blockNumberTo" => "",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -244,7 +286,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvoterrewards",
           "voterAddress" => "0x0000000000000000000000000000000000000002",
-          "from" => "123456789"
+          "blockNumberFrom" => "123456789"
         })
         |> json_response(200)
 
@@ -297,8 +339,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "wei" => "0"
         },
         "totalRewardCount" => "0",
-        "from" => "17280",
-        "to" => "#{block_number}"
+        "blockNumberFrom" => "",
+        "blockNumberTo" => "",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -357,8 +401,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "wei" => to_string(total_rewards)
         },
         "totalRewardCount" => "4",
-        "from" => "#{block_1.number - 1}",
-        "to" => "#{block_2.number + 1}"
+        "blockNumberFrom" => "#{block_1.number - 1}",
+        "blockNumberTo" => "#{block_2.number + 1}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_first_page =
@@ -368,8 +414,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getvoterrewards",
           "voterAddress" => to_string(voter_2_hash),
           "page_size" => "3",
-          "from" => "#{block_1.number - 1}",
-          "to" => "#{block_2.number + 1}"
+          "blockNumberFrom" => "#{block_1.number - 1}",
+          "blockNumberTo" => "#{block_2.number + 1}"
         })
         |> json_response(200)
 
@@ -390,8 +436,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "wei" => to_string(total_rewards)
         },
         "totalRewardCount" => "4",
-        "from" => "#{block_1.number - 1}",
-        "to" => "#{block_2.number + 1}"
+        "blockNumberFrom" => "#{block_1.number - 1}",
+        "blockNumberTo" => "#{block_2.number + 1}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_second_page =
@@ -402,8 +450,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "voterAddress" => to_string(voter_2_hash),
           "page_number" => "2",
           "page_size" => "3",
-          "from" => "#{block_1.number - 1}",
-          "to" => "#{block_2.number + 1}"
+          "blockNumberFrom" => "#{block_1.number - 1}",
+          "blockNumberTo" => "#{block_2.number + 1}"
         })
         |> json_response(200)
 
@@ -429,8 +477,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "wei" => to_string(total_rewards_single_group_multiple_voters)
         },
         "totalRewardCount" => "2",
-        "from" => "#{block_3.number}",
-        "to" => "#{block_3.number}"
+        "blockNumberFrom" => "#{block_3.number}",
+        "blockNumberTo" => "#{block_3.number}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_single_group_multiple_voters =
@@ -440,8 +490,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getvoterrewards",
           "voterAddress" => "#{to_string(voter_2_hash)},#{to_string(voter_1_hash)}",
           "groupAddress" => to_string(group_2_hash),
-          "from" => "#{block_3.number}",
-          "to" => "#{block_3.number}"
+          "blockNumberFrom" => "#{block_3.number}",
+          "blockNumberTo" => "#{block_3.number}"
         })
         |> json_response(200)
 
@@ -488,14 +538,14 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
     end
 
-    test "with an invalid 'from' param", %{conn: conn} do
+    test "with an invalid 'blockNumberFrom' param", %{conn: conn} do
       response =
         conn
         |> get("/api", %{
           "module" => "epoch",
           "action" => "getvalidatorrewards",
           "validatorAddress" => "0x0000000000000000000000000000000000000001",
-          "from" => "invalid"
+          "blockNumberFrom" => "invalid"
         })
         |> json_response(200)
 
@@ -507,18 +557,56 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
     end
 
-    test "with an invalid 'to' param", %{conn: conn} do
+    test "with an invalid 'blockNumberTo' param", %{conn: conn} do
       response =
         conn
         |> get("/api", %{
           "module" => "epoch",
           "action" => "getvalidatorrewards",
           "validatorAddress" => "0x0000000000000000000000000000000000000001",
-          "to" => "invalid"
+          "blockNumberTo" => "invalid"
         })
         |> json_response(200)
 
       assert response["message"] =~ "Wrong format for block number provided"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+
+      assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
+    end
+
+    test "with an invalid 'dateFrom' param", %{conn: conn} do
+      response =
+        conn
+        |> get("/api", %{
+          "module" => "epoch",
+          "action" => "getvalidatorrewards",
+          "validatorAddress" => "0x0000000000000000000000000000000000000001",
+          "dateFrom" => "invalid"
+        })
+        |> json_response(200)
+
+      assert response["message"] =~ "Wrong format for date provided"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+
+      assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
+    end
+
+    test "with an invalid 'dateTo' param", %{conn: conn} do
+      response =
+        conn
+        |> get("/api", %{
+          "module" => "epoch",
+          "action" => "getvalidatorrewards",
+          "validatorAddress" => "0x0000000000000000000000000000000000000001",
+          "dateTo" => "invalid"
+        })
+        |> json_response(200)
+
+      assert response["message"] =~ "Wrong format for date provided"
       assert response["status"] == "0"
       assert Map.has_key?(response, "result")
       refute response["result"]
@@ -533,7 +621,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvalidatorrewards",
           "validatorAddress" => "0x0000000000000000000000000000000000000001",
-          "from" => "-1"
+          "blockNumberFrom" => "-1"
         })
         |> json_response(200)
 
@@ -552,7 +640,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvalidatorrewards",
           "validatorAddress" => "0x0000000000000000000000000000000000000001",
-          "to" => "0"
+          "blockNumberTo" => "0"
         })
         |> json_response(200)
 
@@ -638,8 +726,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
         "totalRewardCount" => "0",
-        "from" => "17280",
-        "to" => "#{block_number + 17279}"
+        "blockNumberFrom" => "",
+        "blockNumberTo" => "#{block_number + 17279}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -648,7 +738,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvalidatorrewards",
           "validatorAddress" => "0x0000000000000000000000000000000000000002",
-          "to" => "#{block_number + 17279}"
+          "blockNumberTo" => "#{block_number + 17279}"
         })
         |> json_response(200)
 
@@ -677,8 +767,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
         "totalRewardCount" => "0",
-        "from" => "123456789",
-        "to" => "#{block_number}"
+        "blockNumberFrom" => "123456789",
+        "blockNumberTo" => "",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -687,7 +779,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getvalidatorrewards",
           "validatorAddress" => "0x0000000000000000000000000000000000000002",
-          "from" => "123456789"
+          "blockNumberFrom" => "123456789"
         })
         |> json_response(200)
 
@@ -712,8 +804,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
         "totalRewardCount" => "0",
-        "from" => "17280",
-        "to" => "#{block_number}"
+        "blockNumberFrom" => "",
+        "blockNumberTo" => "",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -769,8 +863,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:validator, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
         "totalRewardCount" => "4",
-        "from" => "#{block_1.number - 1}",
-        "to" => "#{block_2.number + 1}"
+        "blockNumberFrom" => "#{block_1.number - 1}",
+        "blockNumberTo" => "#{block_2.number + 1}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_first_page =
@@ -780,8 +876,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getvalidatorrewards",
           "validatorAddress" => to_string(validator_2_hash),
           "page_size" => "3",
-          "from" => "#{block_1.number - 1}",
-          "to" => "#{block_2.number + 1}"
+          "blockNumberFrom" => "#{block_1.number - 1}",
+          "blockNumberTo" => "#{block_2.number + 1}"
         })
         |> json_response(200)
 
@@ -799,8 +895,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:validator, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
         "totalRewardCount" => "4",
-        "from" => "#{block_1.number - 1}",
-        "to" => "#{block_2.number + 1}"
+        "blockNumberFrom" => "#{block_1.number - 1}",
+        "blockNumberTo" => "#{block_2.number + 1}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_second_page =
@@ -811,8 +909,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "validatorAddress" => to_string(validator_2_hash),
           "page_number" => "2",
           "page_size" => "3",
-          "from" => "#{block_1.number - 1}",
-          "to" => "#{block_2.number + 1}"
+          "blockNumberFrom" => "#{block_1.number - 1}",
+          "blockNumberTo" => "#{block_2.number + 1}"
         })
         |> json_response(200)
 
@@ -835,8 +933,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:validator, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards_single_group_multiple_voters |> Wei.to(:ether))},
         "totalRewardCount" => "2",
-        "from" => "#{block_3.number}",
-        "to" => "#{block_3.number}"
+        "blockNumberFrom" => "#{block_3.number}",
+        "blockNumberTo" => "#{block_3.number}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_single_group_multiple_voters =
@@ -846,8 +946,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getvalidatorrewards",
           "validatorAddress" => "#{to_string(validator_2_hash)},#{to_string(validator_1_hash)}",
           "groupAddress" => to_string(group_2_hash),
-          "from" => "#{block_3.number}",
-          "to" => "#{block_3.number}"
+          "blockNumberFrom" => "#{block_3.number}",
+          "blockNumberTo" => "#{block_3.number}"
         })
         |> json_response(200)
 
@@ -894,14 +994,14 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
     end
 
-    test "with an invalid 'from' param", %{conn: conn} do
+    test "with an invalid 'blockNumberFrom' param", %{conn: conn} do
       response =
         conn
         |> get("/api", %{
           "module" => "epoch",
           "action" => "getgrouprewards",
           "groupAddress" => "0x0000000000000000000000000000000000000001",
-          "from" => "invalid"
+          "blockNumberFrom" => "invalid"
         })
         |> json_response(200)
 
@@ -913,18 +1013,56 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
     end
 
-    test "with an invalid 'to' param", %{conn: conn} do
+    test "with an invalid 'blockNumberTo' param", %{conn: conn} do
       response =
         conn
         |> get("/api", %{
           "module" => "epoch",
           "action" => "getgrouprewards",
           "groupAddress" => "0x0000000000000000000000000000000000000001",
-          "to" => "invalid"
+          "blockNumberTo" => "invalid"
         })
         |> json_response(200)
 
       assert response["message"] =~ "Wrong format for block number provided"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+
+      assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
+    end
+
+    test "with an invalid 'dateFrom' param", %{conn: conn} do
+      response =
+        conn
+        |> get("/api", %{
+          "module" => "epoch",
+          "action" => "getgrouprewards",
+          "groupAddress" => "0x0000000000000000000000000000000000000001",
+          "dateFrom" => "invalid"
+        })
+        |> json_response(200)
+
+      assert response["message"] =~ "Wrong format for date provided"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+
+      assert :ok = ExJsonSchema.Validator.validate(rewards_schema(), response)
+    end
+
+    test "with an invalid 'dateTo' param", %{conn: conn} do
+      response =
+        conn
+        |> get("/api", %{
+          "module" => "epoch",
+          "action" => "getgrouprewards",
+          "groupAddress" => "0x0000000000000000000000000000000000000001",
+          "dateTo" => "invalid"
+        })
+        |> json_response(200)
+
+      assert response["message"] =~ "Wrong format for date provided"
       assert response["status"] == "0"
       assert Map.has_key?(response, "result")
       refute response["result"]
@@ -939,7 +1077,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getgrouprewards",
           "groupAddress" => "0x0000000000000000000000000000000000000001",
-          "from" => "-1"
+          "blockNumberFrom" => "-1"
         })
         |> json_response(200)
 
@@ -958,7 +1096,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getgrouprewards",
           "groupAddress" => "0x0000000000000000000000000000000000000001",
-          "to" => "0"
+          "blockNumberTo" => "0"
         })
         |> json_response(200)
 
@@ -1044,8 +1182,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
         "totalRewardCount" => "0",
-        "from" => "17280",
-        "to" => "#{block_number + 17279}"
+        "blockNumberFrom" => "",
+        "blockNumberTo" => "#{block_number + 17279}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -1054,7 +1194,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getgrouprewards",
           "groupAddress" => "0x0000000000000000000000000000000000000002",
-          "to" => "#{block_number + 17279}"
+          "blockNumberTo" => "#{block_number + 17279}"
         })
         |> json_response(200)
 
@@ -1083,8 +1223,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
         "totalRewardCount" => "0",
-        "from" => "123456789",
-        "to" => "#{block_number}"
+        "blockNumberFrom" => "123456789",
+        "blockNumberTo" => "",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -1093,7 +1235,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "module" => "epoch",
           "action" => "getgrouprewards",
           "groupAddress" => "0x0000000000000000000000000000000000000002",
-          "from" => "123456789"
+          "blockNumberFrom" => "123456789"
         })
         |> json_response(200)
 
@@ -1118,8 +1260,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
         "totalRewardCount" => "0",
-        "from" => "17280",
-        "to" => "#{block_number}"
+        "blockNumberFrom" => "",
+        "blockNumberTo" => "",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response =
@@ -1175,8 +1319,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:group, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
         "totalRewardCount" => "4",
-        "from" => "#{block_1.number - 1}",
-        "to" => "#{block_2.number + 1}"
+        "blockNumberFrom" => "#{block_1.number - 1}",
+        "blockNumberTo" => "#{block_2.number + 1}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_first_page =
@@ -1186,8 +1332,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getgrouprewards",
           "groupAddress" => to_string(group_2_hash),
           "page_size" => "3",
-          "from" => "#{block_1.number - 1}",
-          "to" => "#{block_2.number + 1}"
+          "blockNumberFrom" => "#{block_1.number - 1}",
+          "blockNumberTo" => "#{block_2.number + 1}"
         })
         |> json_response(200)
 
@@ -1205,8 +1351,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:group, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
         "totalRewardCount" => "4",
-        "from" => "#{block_1.number - 1}",
-        "to" => "#{block_2.number + 1}"
+        "blockNumberFrom" => "#{block_1.number - 1}",
+        "blockNumberTo" => "#{block_2.number + 1}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_second_page =
@@ -1217,8 +1365,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "groupAddress" => to_string(group_2_hash),
           "page_number" => "2",
           "page_size" => "3",
-          "from" => "#{block_1.number - 1}",
-          "to" => "#{block_2.number + 1}"
+          "blockNumberFrom" => "#{block_1.number - 1}",
+          "blockNumberTo" => "#{block_2.number + 1}"
         })
         |> json_response(200)
 
@@ -1241,8 +1389,10 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:group, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards_single_validator_multiple_voters |> Wei.to(:ether))},
         "totalRewardCount" => "2",
-        "from" => "#{block_3.number}",
-        "to" => "#{block_3.number}"
+        "blockNumberFrom" => "#{block_3.number}",
+        "blockNumberTo" => "#{block_3.number}",
+        "dateFrom" => "",
+        "dateTo" => ""
       }
 
       response_single_group_multiple_validators =
@@ -1252,8 +1402,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getgrouprewards",
           "groupAddress" => "#{to_string(group_2_hash)},#{to_string(group_1_hash)}",
           "validatorAddress" => to_string(validator_2_hash),
-          "from" => "#{block_3.number}",
-          "to" => "#{block_3.number}"
+          "blockNumberFrom" => "#{block_3.number}",
+          "blockNumberTo" => "#{block_3.number}"
         })
         |> json_response(200)
 
@@ -2098,7 +2248,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
   defp rewards_schema do
     resolve_schema(%{
       "type" => ["object", "null"],
-      "required" => ["totalRewardAmounts", "totalRewardCount", "from", "to", "rewards"],
+      "required" => ["totalRewardAmounts", "totalRewardCount", "blockNumberFrom", "blockNumberTo", "rewards"],
       "properties" => %{
         "totalRewardAmounts" => %{
           "type" => "object",
@@ -2109,8 +2259,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           }
         },
         "totalRewardCount" => %{"type" => "string"},
-        "from" => %{"type" => "string"},
-        "to" => %{"type" => "string"},
+        "blockNumberFrom" => %{"type" => "string"},
+        "blockNumberTo" => %{"type" => "string"},
         "rewards" => %{
           "type" => "array",
           "items" => %{

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/epoch_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/epoch_controller_test.exs
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
 
   import Explorer.Factory
 
-  alias Explorer.Chain.{Address, Block, CeloAccountEpoch, CeloElectionRewards, Wei}
+  alias Explorer.Chain.{Address, Block, Wei}
 
   describe "getvoterrewards" do
     setup [:setup_epoch_data]
@@ -229,11 +229,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "celo" => "0",
           "wei" => "0"
         },
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "",
-        "blockNumberTo" => "#{block_number + 17279}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -273,11 +269,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "celo" => "0",
           "wei" => "0"
         },
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "123456789",
-        "blockNumberTo" => "",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -338,11 +330,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "celo" => "0",
           "wei" => "0"
         },
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "",
-        "blockNumberTo" => "",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -400,11 +388,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "celo" => to_string(Wei.to(total_rewards, :ether)),
           "wei" => to_string(total_rewards)
         },
-        "totalRewardCount" => "4",
-        "blockNumberFrom" => "#{block_1.number - 1}",
-        "blockNumberTo" => "#{block_2.number + 1}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "4"
       }
 
       response_first_page =
@@ -414,8 +398,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getvoterrewards",
           "voterAddress" => to_string(voter_2_hash),
           "page_size" => "3",
-          "blockNumberFrom" => "#{block_1.number - 1}",
-          "blockNumberTo" => "#{block_2.number + 1}"
+          "dateFrom" => "#{block_1.timestamp}",
+          "dateTo" => "#{block_2.timestamp}"
         })
         |> json_response(200)
 
@@ -435,11 +419,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "celo" => to_string(Wei.to(total_rewards, :ether)),
           "wei" => to_string(total_rewards)
         },
-        "totalRewardCount" => "4",
-        "blockNumberFrom" => "#{block_1.number - 1}",
-        "blockNumberTo" => "#{block_2.number + 1}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "4"
       }
 
       response_second_page =
@@ -476,11 +456,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "celo" => to_string(Wei.to(total_rewards_single_group_multiple_voters, :ether)),
           "wei" => to_string(total_rewards_single_group_multiple_voters)
         },
-        "totalRewardCount" => "2",
-        "blockNumberFrom" => "#{block_3.number}",
-        "blockNumberTo" => "#{block_3.number}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "2"
       }
 
       response_single_group_multiple_voters =
@@ -725,11 +701,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       expected_result = %{
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "",
-        "blockNumberTo" => "#{block_number + 17279}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -766,11 +738,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       expected_result = %{
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "123456789",
-        "blockNumberTo" => "",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -803,11 +771,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       expected_result = %{
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "",
-        "blockNumberTo" => "",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -862,11 +826,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           ]
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:validator, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
-        "totalRewardCount" => "4",
-        "blockNumberFrom" => "#{block_1.number - 1}",
-        "blockNumberTo" => "#{block_2.number + 1}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "4"
       }
 
       response_first_page =
@@ -876,8 +836,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getvalidatorrewards",
           "validatorAddress" => to_string(validator_2_hash),
           "page_size" => "3",
-          "blockNumberFrom" => "#{block_1.number - 1}",
-          "blockNumberTo" => "#{block_2.number + 1}"
+          "dateFrom" => "#{to_string(block_1.timestamp)}",
+          "dateTo" => "#{to_string(block_2.timestamp)}"
         })
         |> json_response(200)
 
@@ -894,11 +854,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           ]
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:validator, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
-        "totalRewardCount" => "4",
-        "blockNumberFrom" => "#{block_1.number - 1}",
-        "blockNumberTo" => "#{block_2.number + 1}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "4"
       }
 
       response_second_page =
@@ -932,11 +888,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           ]
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:validator, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards_single_group_multiple_voters |> Wei.to(:ether))},
-        "totalRewardCount" => "2",
-        "blockNumberFrom" => "#{block_3.number}",
-        "blockNumberTo" => "#{block_3.number}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "2"
       }
 
       response_single_group_multiple_voters =
@@ -1181,11 +1133,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       expected_result = %{
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "",
-        "blockNumberTo" => "#{block_number + 17279}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -1222,11 +1170,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       expected_result = %{
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "123456789",
-        "blockNumberTo" => "",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -1259,11 +1203,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
       expected_result = %{
         "rewards" => [],
         "totalRewardAmounts" => %{"cUSD" => "0"},
-        "totalRewardCount" => "0",
-        "blockNumberFrom" => "",
-        "blockNumberTo" => "",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "0"
       }
 
       response =
@@ -1318,11 +1258,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           ]
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:group, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
-        "totalRewardCount" => "4",
-        "blockNumberFrom" => "#{block_1.number - 1}",
-        "blockNumberTo" => "#{block_2.number + 1}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "4"
       }
 
       response_first_page =
@@ -1332,8 +1268,8 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           "action" => "getgrouprewards",
           "groupAddress" => to_string(group_2_hash),
           "page_size" => "3",
-          "blockNumberFrom" => "#{block_1.number - 1}",
-          "blockNumberTo" => "#{block_2.number + 1}"
+          "dateFrom" => "#{block_1.timestamp}",
+          "dateTo" => "#{block_2.timestamp}"
         })
         |> json_response(200)
 
@@ -1350,11 +1286,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           ]
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:group, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards |> Wei.to(:ether))},
-        "totalRewardCount" => "4",
-        "blockNumberFrom" => "#{block_1.number - 1}",
-        "blockNumberTo" => "#{block_2.number + 1}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "4"
       }
 
       response_second_page =
@@ -1388,11 +1320,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           ]
           |> Enum.map(fn tuple -> map_tuple_to_api_item(:group, tuple) end),
         "totalRewardAmounts" => %{"cUSD" => to_string(total_rewards_single_validator_multiple_voters |> Wei.to(:ether))},
-        "totalRewardCount" => "2",
-        "blockNumberFrom" => "#{block_3.number}",
-        "blockNumberTo" => "#{block_3.number}",
-        "dateFrom" => "",
-        "dateTo" => ""
+        "totalRewardCount" => "2"
       }
 
       response_single_group_multiple_validators =
@@ -2248,7 +2176,7 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
   defp rewards_schema do
     resolve_schema(%{
       "type" => ["object", "null"],
-      "required" => ["totalRewardAmounts", "totalRewardCount", "blockNumberFrom", "blockNumberTo", "rewards"],
+      "required" => ["totalRewardAmounts", "totalRewardCount", "rewards"],
       "properties" => %{
         "totalRewardAmounts" => %{
           "type" => "object",
@@ -2259,8 +2187,6 @@ defmodule BlockScoutWeb.API.RPC.EpochControllerTest do
           }
         },
         "totalRewardCount" => %{"type" => "string"},
-        "blockNumberFrom" => %{"type" => "string"},
-        "blockNumberTo" => %{"type" => "string"},
         "rewards" => %{
           "type" => "array",
           "items" => %{

--- a/apps/explorer/lib/explorer/celo/epoch_util.ex
+++ b/apps/explorer/lib/explorer/celo/epoch_util.ex
@@ -29,6 +29,7 @@ defmodule Explorer.Celo.EpochUtil do
     end
   end
 
+  def round_to_closest_epoch_block_number(_block_number = nil, _), do: nil
   def round_to_closest_epoch_block_number(block_number, :up), do: ceil(block_number / 17_280) * 17_280
   def round_to_closest_epoch_block_number(block_number, :down) when block_number < 17_280, do: 17_280
   def round_to_closest_epoch_block_number(block_number, :down), do: floor(block_number / 17_280) * 17_280

--- a/apps/explorer/lib/explorer/celo/epoch_util.ex
+++ b/apps/explorer/lib/explorer/celo/epoch_util.ex
@@ -29,7 +29,7 @@ defmodule Explorer.Celo.EpochUtil do
     end
   end
 
-  def round_to_closest_epoch_block_number(_block_number = nil, _), do: nil
+  def round_to_closest_epoch_block_number(nil = _block_number, _), do: nil
   def round_to_closest_epoch_block_number(block_number, :up), do: ceil(block_number / 17_280) * 17_280
   def round_to_closest_epoch_block_number(block_number, :down) when block_number < 17_280, do: 17_280
   def round_to_closest_epoch_block_number(block_number, :down), do: floor(block_number / 17_280) * 17_280

--- a/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
@@ -15,7 +15,7 @@ defmodule Explorer.Chain.CeloElectionRewards do
     ]
 
   alias Explorer.Celo.EpochUtil
-  alias Explorer.Chain.{Block, CeloAccount, CeloAccountEpoch, CeloEpochRewards, Hash, Wei}
+  alias Explorer.Chain.{Block, CeloAccount, CeloAccountEpoch, Hash, Wei}
   alias Explorer.Repo
 
   @required_attrs ~w(account_hash amount associated_account_hash block_number block_timestamp block_hash reward_type)a

--- a/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
@@ -280,16 +280,16 @@ defmodule Explorer.Chain.CeloElectionRewards do
     }
   end
 
-  defp block_timestamp_query_from(query, _from = nil), do: query
+  defp block_timestamp_query_from(query, nil = _from), do: query
   defp block_timestamp_query_from(query, from), do: query |> where([rewards], rewards.block_timestamp >= ^from)
 
-  defp block_timestamp_query_to(query, _to = nil), do: query
+  defp block_timestamp_query_to(query, nil = _to), do: query
   defp block_timestamp_query_to(query, to), do: query |> where([rewards], rewards.block_timestamp <= ^to)
 
-  defp block_number_query_from(query, _from = nil), do: query
+  defp block_number_query_from(query, nil = _from), do: query
   defp block_number_query_from(query, from), do: query |> where([rewards], rewards.block_number >= ^from)
 
-  defp block_number_query_to(query, _to = nil), do: query
+  defp block_number_query_to(query, nil = _to), do: query
   defp block_number_query_to(query, to), do: query |> where([rewards], rewards.block_number <= ^to)
 
   defp block_timestamp_query(query, from, to),


### PR DESCRIPTION
…"to" params

### Description

Adds support for filtering by both block numbers and timestamp.
 
### Tested

Tested locally.


### Issues

 - Fixes https://github.com/celo-org/data-services/issues/546
