### PR TITLE
Fixed incorrectly parsed flag when event stream is disabled

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -134,7 +134,7 @@ config :explorer, Explorer.Counters.BlockPriorityFeeCounter,
   enabled: true,
   enable_consolidation: true
 
-config :explorer, Explorer.Celo.Events.ContractEventStream, enabled: System.get_env("ENABLE_EVENT_STREAM", nil) != nil
+config :explorer, Explorer.Celo.Events.ContractEventStream, enabled: System.get_env("ENABLE_EVENT_STREAM", "false") == "true"
 
 bridge_market_cap_update_interval =
   if System.get_env("BRIDGE_MARKET_CAP_UPDATE_INTERVAL") do

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -134,7 +134,8 @@ config :explorer, Explorer.Counters.BlockPriorityFeeCounter,
   enabled: true,
   enable_consolidation: true
 
-config :explorer, Explorer.Celo.Events.ContractEventStream, enabled: System.get_env("ENABLE_EVENT_STREAM", "false") == "true"
+config :explorer, Explorer.Celo.Events.ContractEventStream,
+  enabled: System.get_env("ENABLE_EVENT_STREAM", "false") == "true"
 
 bridge_market_cap_update_interval =
   if System.get_env("BRIDGE_MARKET_CAP_UPDATE_INTERVAL") do


### PR DESCRIPTION
### Description

When `ENABLE_EVENT_STREAM` is set to `"false"`, it still gets enabled and since `BEANSTALKD_HOST` and `BEANSTALKD_PORT` are missing, the indexer fails with
```
{"error":{"initial_call":null,"reason":"** (MatchError) no match of right hand side value: :error
    (explorer 0.0.1) lib/explorer/celo/events/contract_event_stream.ex:45: Explorer.Celo.Events.ContractEventStream.handle_continue/2
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:437: :gen_server.loop/7
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
"},"logging.googleapis.com/sourceLocation":{"file":"gen_server.erl","line":949,"function":"gen_server.error_info/7"},"message":"GenServer Explorer.Celo.Events.ContractEventStream terminating
** (MatchError) no match of right hand side value: :error
    (explorer 0.0.1) lib/explorer/celo/events/contract_event_stream.ex:45: Explorer.Celo.Events.ContractEventStream.handle_continue/2
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:437: :gen_server.loop/7
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:continue, :connect_to_beanstalk}
State: %{buffer: [], timer: #Reference<0.652357563.2525757442.54506>}","severity":"ERROR","time":"2022-11-14T14:40:57.448Z"}
```

 ### Other changes

No.