### PR TITLE
Epoch API: Add support for missing locked/activated gold

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/epoch_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/epoch_view.ex
@@ -67,9 +67,17 @@ defmodule BlockScoutWeb.API.RPC.EpochView do
     }
   end
 
-  defp prepare_rewards_response_item(reward, meta, currency) do
+  defp extract_locked_and_activated_gold_wei(%{account_locked_gold: nil, account_activated_gold: nil}), do: {nil, nil}
+
+  defp extract_locked_and_activated_gold_wei(reward) do
     {:ok, reward_address_locked_gold_wei} = Wei.cast(reward.account_locked_gold)
     {:ok, reward_address_activated_gold_wei} = Wei.cast(reward.account_activated_gold)
+
+    {reward_address_locked_gold_wei, reward_address_activated_gold_wei}
+  end
+
+  defp prepare_rewards_response_item(reward, meta, currency) do
+    {reward_address_locked_gold_wei, reward_address_activated_gold_wei} = extract_locked_and_activated_gold_wei(reward)
 
     %{
       amounts: reward.amount |> prepare_amounts(currency),
@@ -87,6 +95,12 @@ defmodule BlockScoutWeb.API.RPC.EpochView do
 
   defp prepare_amounts(amount, :celo), do: amount |> to_celo_wei_amount
   defp prepare_amounts(amount, :cusd), do: amount |> to_currency_amount("cUSD")
+
+  defp to_celo_wei_amount(nil = _wei),
+    do: %{
+      celo: "unknown",
+      wei: "unknown"
+    }
 
   defp to_celo_wei_amount(wei),
     do: %{

--- a/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
@@ -152,7 +152,7 @@ defmodule Explorer.Chain.CeloElectionRewards do
 
   def base_api_address_query do
     from(rewards in __MODULE__,
-      join: celo_account_epoch in CeloAccountEpoch,
+      left_join: celo_account_epoch in CeloAccountEpoch,
       on:
         rewards.account_hash == celo_account_epoch.account_hash and
           celo_account_epoch.block_hash == rewards.block_hash,

--- a/apps/explorer/test/explorer/chain/csv_export/epoch_transactions_csv_exporter_test.exs
+++ b/apps/explorer/test/explorer/chain/csv_export/epoch_transactions_csv_exporter_test.exs
@@ -65,6 +65,7 @@ defmodule Explorer.CSV.Export.EpochTransactionsCsvExporterTest do
           account_hash: to_address.hash,
           associated_account_hash: from_address_hash_voter,
           block_number: block.number,
+          block_hash: block.hash,
           block_timestamp: block.timestamp,
           amount: 123_456_789_012_345_678_901,
           reward_type: "voter"
@@ -87,6 +88,7 @@ defmodule Explorer.CSV.Export.EpochTransactionsCsvExporterTest do
           associated_account_hash: from_address_hash_voter,
           block_number: block_2.number,
           block_timestamp: block_2.timestamp,
+          block_hash: block_2.hash,
           amount: 123_456_789_012_345_678_901,
           reward_type: "voter"
         )
@@ -98,6 +100,7 @@ defmodule Explorer.CSV.Export.EpochTransactionsCsvExporterTest do
         associated_account_hash: from_address_hash_voter,
         block_number: ignored_block_before.number,
         block_timestamp: ignored_block_before.timestamp,
+        block_hash: ignored_block_before.hash,
         amount: 123_456_789_012_345_678_901,
         reward_type: "voter"
       )
@@ -108,6 +111,7 @@ defmodule Explorer.CSV.Export.EpochTransactionsCsvExporterTest do
         associated_account_hash: from_address_hash_voter,
         block_number: ignored_block_after.number,
         block_timestamp: ignored_block_after.timestamp,
+        block_hash: ignored_block_after.hash,
         amount: 123_456_789_012_345_678_901,
         reward_type: "voter"
       )
@@ -119,6 +123,7 @@ defmodule Explorer.CSV.Export.EpochTransactionsCsvExporterTest do
           associated_account_hash: from_address_hash_validator,
           block_number: block_2.number,
           block_timestamp: block_2.timestamp,
+          block_hash: block_2.hash,
           amount: 456_789_012_345_678_901_234,
           reward_type: "validator"
         )
@@ -130,6 +135,7 @@ defmodule Explorer.CSV.Export.EpochTransactionsCsvExporterTest do
         account_hash: from_address_hash_validator,
         block_number: block.number,
         block_timestamp: block.timestamp,
+        block_hash: block.hash,
         amount: 789_012_345_678_901_234_567,
         reward_type: "validator"
       )
@@ -141,6 +147,7 @@ defmodule Explorer.CSV.Export.EpochTransactionsCsvExporterTest do
           associated_account_hash: from_address_hash_group,
           block_number: block.number,
           block_timestamp: block.timestamp,
+          block_hash: block.hash,
           amount: 789_012_345_678_901_234_567,
           reward_type: "group"
         )


### PR DESCRIPTION
### Description

This PR aims to handle unlikely event when locked/activated gold information is not indexed for an account for which data is being fetched with the API. 
 
### Tested

Tested locally.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/562
