### PR TITLE
Fix performance issues while loading address epoch transactions

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -99,6 +99,8 @@ defmodule BlockScoutWeb.Chain do
     Map.put(next_page_params, "items_count", items_count(next_page_params) + Enum.count(list))
   end
 
+  defp items_count(%{"items_count" => it}) when is_binary(it), do: items_count(%{items_count: it})
+
   defp items_count(%{items_count: it}) when is_binary(it) do
     case Integer.parse(it) do
       {items_count, _} -> items_count

--- a/apps/block_scout_web/lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex
@@ -26,14 +26,12 @@
       <span class="tile-address-wrapper d-flex flex-md-row mt-3 mt-md-0 pl-2">
         <img src="/images/icons/arrow.png" width="28px" height="22.4px">
         <div class="d-flex align-items-end ml-2 pt-2">
-          <%= with {:ok, address} <- Chain.hash_to_address(@epoch_transaction.account_hash) do %>
-            <%= render BlockScoutWeb.AddressView,
-              "_link.html",
-              address: address,
-              contract: false,
-              use_custom_tooltip: false,
-              truncate: false %>
-          <% end %>
+          <%= render BlockScoutWeb.AddressView,
+            "_link.html",
+            address: @epoch_transaction.address,
+            contract: false,
+            use_custom_tooltip: false,
+            truncate: false %>
         </div>
       </span>
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
@@ -51,14 +49,12 @@
       <span class="tile-address-wrapper d-flex flex-md-row mt-3 mt-md-0 pl-2">
         <img src="/images/icons/arrow.png" width="28px" height="22.4px">
         <div class="d-flex align-items-end ml-2 pt-2">
-          <%= with {:ok, address} <- Chain.hash_to_address(@epoch_transaction.account_hash) do %>
-            <%= render BlockScoutWeb.AddressView,
-              "_link.html",
-              address: address,
-              contract: false,
-              use_custom_tooltip: false,
-              truncate: false %>
-          <% end %>
+          <%= render BlockScoutWeb.AddressView,
+            "_link.html",
+            address: @epoch_transaction.address,
+            contract: false,
+            use_custom_tooltip: false,
+            truncate: false %>
         </div>
       </span>
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
@@ -78,25 +74,21 @@
           <img src="/images/icons/arrow.png" width="28px" height="22.4px">
           <div class="d-flex align-items-end ml-2 pt-2">
             <div>
-              <%= with {:ok, address} <- Chain.hash_to_address(@epoch_transaction.associated_account_hash) do %>
-                <%= render BlockScoutWeb.AddressView,
-                  "_link.html",
-                  address: address,
-                  contract: false,
-                  use_custom_tooltip: false,
-                  truncate: false %>
-            <% end %>
+              <%= render BlockScoutWeb.AddressView,
+                "_link.html",
+                address: @epoch_transaction.associated_address,
+                contract: false,
+                use_custom_tooltip: false,
+                truncate: false %>
 
             &rarr;
 
-            <%= with {:ok, address} <- Chain.hash_to_address(@epoch_transaction.account_hash) do %>
-                <%= render BlockScoutWeb.AddressView,
-                  "_link.html",
-                  address: address,
-                  contract: false,
-                  use_custom_tooltip: false,
-                  truncate: false %>
-            <% end %>
+            <%= render BlockScoutWeb.AddressView,
+              "_link.html",
+              address: @epoch_transaction.address,
+              contract: false,
+              use_custom_tooltip: false,
+              truncate: false %>
             </div>
           </div>
         </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex
@@ -1,7 +1,7 @@
 <div class="tile tile-type-epoch-transaction fade-in" data-test="epoch_transaction"
-     data-key="<%= @epoch_transaction.block_number %>_<%= if @epoch_transaction.reward_type == "group", do: @epoch_transaction.associated_account_name, else: @epoch_transaction.account_hash %>"
+     data-key="<%= @epoch_transaction.block_number %>_<%= if @epoch_transaction.reward_type == "group", do: @epoch_transaction.associated_address.celo_account.name, else: @epoch_transaction.account_hash %>"
      data-epoch-transaction-block-number="<%= @epoch_transaction.block_number %>"
-     data-epoch-transaction-group="<%= if @epoch_transaction.reward_type == "group", do: @epoch_transaction.account_hash, else: @epoch_transaction.associated_account_name %>">
+     data-epoch-transaction-group="<%= if @epoch_transaction.reward_type == "group", do: @epoch_transaction.account_hash, else: @epoch_transaction.associated_address.celo_account.name %>">
   <div class="row tile-body">
     <!-- Color Block -->
     <div class="tile-transaction-type-block col-md-2 d-flex flex-row flex-md-column">
@@ -37,7 +37,7 @@
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
         <%= gettext "Validator Group:" %>&nbsp;
         <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @epoch_transaction.associated_account_hash), "data-test": "address_hash_link", class: assigns[:class] do %>
-          <%= @epoch_transaction.associated_account_name %>
+          <%= @epoch_transaction.associated_address.celo_account.name %>
         <% end %>
       </span>
       <% end %>
@@ -60,7 +60,7 @@
       <span class="d-flex flex-md-row flex-column mt-3 mt-md-0">
         <%= gettext "Validator Group:" %>&nbsp;
         <%= link to: address_path(BlockScoutWeb.Endpoint, :show, @epoch_transaction.associated_account_hash), "data-test": "address_hash_link", class: assigns[:class] do %>
-          <%= @epoch_transaction.associated_account_name %>
+          <%= @epoch_transaction.associated_address.celo_account.name %>
         <% end %>
       </span>
       <% end %>
@@ -106,7 +106,7 @@
           to: block_path(BlockScoutWeb.Endpoint, :show, @epoch_transaction.block_number)
         ) %>
       </span>
-      <span class="mr-2 mr-md-0 order-2" in-tile data-from-now="<%= @epoch_transaction.date %>"></span>
+      <span class="mr-2 mr-md-0 order-2" in-tile data-from-now="<%= @epoch_transaction.block_timestamp %>"></span>
       <span class="mr-2 mr-md-0 order-0 order-md-3">
           <span class="badge badge-success tile-badge"><%= gettext "IN" %></span>
       </span>

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/reward_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/reward_view.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.API.RPC.RewardView do
   use BlockScoutWeb, :view
 
   alias BlockScoutWeb.API.RPC.RPCView
+  alias Explorer.Celo.EpochUtil
 
   def render("getvoterrewardsforgroup.json", %{rewards: rewards}) do
     prepared_rewards = prepare_voter_rewards_for_group(rewards)
@@ -36,8 +37,8 @@ defmodule BlockScoutWeb.API.RPC.RewardView do
     %{
       amount: to_string(reward.amount),
       blockNumber: to_string(reward.block_number),
-      date: reward.date,
-      epochNumber: to_string(reward.epoch_number)
+      date: reward.block_timestamp,
+      epochNumber: to_string(EpochUtil.epoch_by_block_number(reward.block_number))
     }
   end
 
@@ -64,9 +65,9 @@ defmodule BlockScoutWeb.API.RPC.RewardView do
       account: to_string(reward.account_hash),
       amount: to_string(reward.amount),
       blockNumber: to_string(reward.block_number),
-      date: reward.date,
-      epochNumber: to_string(reward.epoch_number),
-      group: to_string(reward.associated_account_name)
+      date: reward.block_timestamp,
+      epochNumber: to_string(EpochUtil.epoch_by_block_number(reward.block_number)),
+      group: to_string(reward.associated_address.celo_account.name)
     }
   end
 
@@ -74,10 +75,10 @@ defmodule BlockScoutWeb.API.RPC.RewardView do
     %{
       amount: to_string(reward.amount),
       blockNumber: to_string(reward.block_number),
-      date: reward.date,
-      epochNumber: to_string(reward.epoch_number),
+      date: reward.block_timestamp,
+      epochNumber: to_string(EpochUtil.epoch_by_block_number(reward.block_number)),
       group: to_string(reward.account_hash),
-      validator: to_string(reward.associated_account_name)
+      validator: to_string(reward.associated_address.celo_account.name)
     }
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/epoch_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/epoch_transaction_view.ex
@@ -2,7 +2,6 @@ defmodule BlockScoutWeb.EpochTransactionView do
   use BlockScoutWeb, :view
 
   alias Explorer.Celo.EpochUtil
-  alias Explorer.Chain
   alias Explorer.Chain.Wei
 
   @visible_rewards_batch_size 20

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -279,7 +279,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_link.html.eex:2
-#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:91 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:113
+#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:91 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:105
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:58 lib/block_scout_web/templates/internal_transaction/_tile.html.eex:32
 #: lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex:43
 msgid "Block #%{number}"
@@ -942,7 +942,7 @@ msgid "Enter the Vyper Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:87 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:109
+#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:87 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:101
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:54
 msgid "Epoch #"
 msgstr ""
@@ -1144,7 +1144,7 @@ msgid "IMPORTANT: This information is a best guess based on similar functions fr
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:97 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:119
+#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:97 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:111
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:64 lib/block_scout_web/templates/internal_transaction/_tile.html.eex:42
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:86
 msgid "IN"
@@ -1749,7 +1749,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:24 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:24
-#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:48 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:73
+#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:46 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:69
 msgid "Rewards: "
 msgstr ""
 
@@ -2518,8 +2518,8 @@ msgid "Validator Group Rewards"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:40
-#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:65
+#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:38
+#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:61
 msgid "Validator Group:"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -280,7 +280,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/block/_link.html.eex:2
-#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:91 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:113
+#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:91 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:105
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:58 lib/block_scout_web/templates/internal_transaction/_tile.html.eex:32
 #: lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex:43
 msgid "Block #%{number}"
@@ -943,7 +943,7 @@ msgid "Enter the Vyper Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:87 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:109
+#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:87 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:101
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:54
 msgid "Epoch #"
 msgstr ""
@@ -1145,7 +1145,7 @@ msgid "IMPORTANT: This information is a best guess based on similar functions fr
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:97 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:119
+#: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:97 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:111
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:64 lib/block_scout_web/templates/internal_transaction/_tile.html.eex:42
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:86
 msgid "IN"
@@ -1750,7 +1750,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/epoch_transaction/_election_aggregated_tile.html.eex:24 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:24
-#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:48 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:73
+#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:46 lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:69
 msgid "Rewards: "
 msgstr ""
 
@@ -2519,8 +2519,8 @@ msgid "Validator Group Rewards"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:40
-#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:65
+#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:38
+#: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:61
 msgid "Validator Group:"
 msgstr ""
 

--- a/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
@@ -143,6 +143,7 @@ defmodule Explorer.Chain.CeloElectionRewards do
           reward_type: rewards.reward_type
         },
         order_by: [desc: rewards.block_number, asc: rewards.reward_type],
+        preload: [:address, :associated_address],
         where: rewards.account_hash in ^account_hash_list,
         where: rewards.reward_type in ^reward_type_list
       )

--- a/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
@@ -15,7 +15,7 @@ defmodule Explorer.Chain.CeloElectionRewards do
     ]
 
   alias Explorer.Celo.EpochUtil
-  alias Explorer.Chain.{Block, CeloAccount, CeloAccountEpoch, Hash, Wei}
+  alias Explorer.Chain.{Block, CeloAccountEpoch, Hash, Wei}
   alias Explorer.Repo
 
   @required_attrs ~w(account_hash amount associated_account_hash block_number block_timestamp block_hash reward_type)a

--- a/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
+++ b/apps/explorer/lib/explorer/chain/celo/celo_election_rewards.ex
@@ -130,20 +130,8 @@ defmodule Explorer.Chain.CeloElectionRewards do
   def base_address_query(account_hash_list, reward_type_list) do
     query =
       from(rewards in __MODULE__,
-        join: acc in CeloAccount,
-        on: rewards.associated_account_hash == acc.address,
-        select: %{
-          account_hash: rewards.account_hash,
-          amount: rewards.amount,
-          associated_account_name: acc.name,
-          associated_account_hash: rewards.associated_account_hash,
-          block_number: rewards.block_number,
-          date: rewards.block_timestamp,
-          epoch_number: fragment("? / 17280", rewards.block_number),
-          reward_type: rewards.reward_type
-        },
         order_by: [desc: rewards.block_number, asc: rewards.reward_type],
-        preload: [:address, :associated_address],
+        preload: [:address, [associated_address: :celo_account]],
         where: rewards.account_hash in ^account_hash_list,
         where: rewards.reward_type in ^reward_type_list
       )


### PR DESCRIPTION
### Description

Address epoch transaction page were loading quite slow because of numerous queries made to `addresses` table, this PR adds preloading of those in a single query.
 
### Tested

Tested locally.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/580
