### PR TITLE
CoinMarketCap api for tokensupply endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -14,6 +14,7 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
       case Map.get(params, "cmc", nil) do
         nil ->
           render(conn, "tokensupply.json", total_supply: Decimal.to_string(token.total_supply))
+
         _ ->
           conn
           |> put_resp_content_type("text/plain")

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -11,7 +11,14 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
     with {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
          {:format, {:ok, address_hash}} <- to_address_hash(contractaddress_param),
          {:token, {:ok, token}} <- {:token, Chain.token_from_address_hash(address_hash)} do
-      render(conn, "tokensupply.json", total_supply: Decimal.to_string(token.total_supply))
+      case Map.get(params, "cmc", nil) do
+        nil ->
+          render(conn, "tokensupply.json", total_supply: Decimal.to_string(token.total_supply))
+        _ ->
+          conn
+          |> put_resp_content_type("text/plain")
+          |> send_resp(200, Decimal.to_string(token.total_supply))
+      end
     else
       {:contractaddress_param, :error} ->
         render(conn, :error, error: "Query parameter contract address is required")

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -83,6 +83,23 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
       assert response["message"] == "OK"
       assert :ok = ExJsonSchema.Validator.validate(tokensupply_schema(), response)
     end
+
+
+    test "with coinmarketcap param", %{conn: conn} do
+      token = insert(:token, %{total_supply: 777.777})
+
+      params = %{
+        "module" => "stats",
+        "action" => "tokensupply",
+        "cmc" => true,
+        "contractaddress" => to_string(token.contract_address_hash)
+      }
+
+      assert "777.777" ==
+               conn
+               |> get("/api", params)
+               |> text_response(200)
+    end
   end
 
   describe "ethsupplyexchange" do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -84,7 +84,6 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(tokensupply_schema(), response)
     end
 
-
     test "with coinmarketcap param", %{conn: conn} do
       token = insert(:token, %{total_supply: 777.777})
 


### PR DESCRIPTION
### Description

If the `cmc` param is passed to the `tokensupply` method of the api, the result will be returned as `text/plain` instead of json as required by coinmarketcap's system. 
 
e.g.

* http://localhost:4011/api?module=stats&action=tokensupply&contractaddress=0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73
    * works as before, returns json
* http://localhost:4011/api?module=stats&action=tokensupply&contractaddress=0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73&cmc=true
    * returns only the value as text ( no string quotes or javascript object wrapper )

### Tested

* tested locally
* added unit test

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/585
