### PR TITLE
Add lock to celo_transaction_stats table before update.

### DIFF
--- a/apps/explorer/priv/repo/migrations/20221214162647_lock_stats_table.exs
+++ b/apps/explorer/priv/repo/migrations/20221214162647_lock_stats_table.exs
@@ -31,7 +31,6 @@ defmodule Explorer.Repo.Local.Migrations.LockStatsTable do
     END IF;
     END;$$;
     """)
-
   end
 
   def down do

--- a/apps/explorer/priv/repo/migrations/20221214162647_lock_stats_table.exs
+++ b/apps/explorer/priv/repo/migrations/20221214162647_lock_stats_table.exs
@@ -1,0 +1,65 @@
+defmodule Explorer.Repo.Local.Migrations.LockStatsTable do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE OR REPLACE FUNCTION celo_transaction_stats_trigger_func() RETURNS trigger
+    LANGUAGE plpgsql AS
+    $$BEGIN
+
+    LOCK TABLE celo_transaction_stats IN EXCLUSIVE MODE;
+
+    IF TG_OP = 'INSERT' THEN
+      UPDATE celo_transaction_stats SET value = value + 1 WHERE stat_type = 'total_transaction_count';
+      UPDATE celo_transaction_stats SET value = value + coalesce(NEW.gas_used, 0) WHERE stat_type = 'total_gas_used';
+
+      RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+      UPDATE celo_transaction_stats SET value = value - 1 WHERE stat_type = 'total_transaction_count';
+      UPDATE celo_transaction_stats SET value = value - coalesce(OLD.gas_used, 0) WHERE stat_type = 'total_gas_used';
+
+      RETURN OLD;
+    ELSIF TG_OP = 'UPDATE' THEN
+      UPDATE celo_transaction_stats SET value = value + (coalesce(NEW.gas_used, 0) - coalesce(OLD.gas_used, 0)) WHERE stat_type = 'total_gas_used';
+
+      RETURN NEW;
+    ELSIF TG_OP = 'TRUNCATE' THEN
+      UPDATE celo_transaction_stats SET value = 0 WHERE stat_type = 'total_transaction_count';
+      UPDATE celo_transaction_stats SET value = 0 WHERE stat_type = 'total_gas_used';
+
+      RETURN NULL;
+    END IF;
+    END;$$;
+    """)
+
+  end
+
+  def down do
+    execute("""
+    CREATE OR REPLACE FUNCTION celo_transaction_stats_trigger_func() RETURNS trigger
+    LANGUAGE plpgsql AS
+    $$BEGIN
+    IF TG_OP = 'INSERT' THEN
+      UPDATE celo_transaction_stats SET value = value + 1 WHERE stat_type = 'total_transaction_count';
+      UPDATE celo_transaction_stats SET value = value + coalesce(NEW.gas_used, 0) WHERE stat_type = 'total_gas_used';
+
+      RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+      UPDATE celo_transaction_stats SET value = value - 1 WHERE stat_type = 'total_transaction_count';
+      UPDATE celo_transaction_stats SET value = value - coalesce(OLD.gas_used, 0) WHERE stat_type = 'total_gas_used';
+
+      RETURN OLD;
+    ELSIF TG_OP = 'UPDATE' THEN
+      UPDATE celo_transaction_stats SET value = value + (coalesce(NEW.gas_used, 0) - coalesce(OLD.gas_used, 0)) WHERE stat_type = 'total_gas_used';
+
+      RETURN NEW;
+    ELSIF TG_OP = 'TRUNCATE' THEN
+      UPDATE celo_transaction_stats SET value = 0 WHERE stat_type = 'total_transaction_count';
+      UPDATE celo_transaction_stats SET value = 0 WHERE stat_type = 'total_gas_used';
+
+      RETURN NULL;
+    END IF;
+    END;$$;
+    """)
+  end
+end


### PR DESCRIPTION
### Description

Prevents deadlocks on `celo_transaction_stats` table by having the update procedure lock the table in `EXCLUSIVE` mode  (read only, writes only for the tx with the lock, only `ACCESS EXCLUSIVE` is higher lock) for the duration of the update. 

### Tested

> Unable to reproduce this locally....

* Tested on rc1staging
    * Deactivate indexer for an hour to build up backlog
    * Restart to assert deadlocks happen
    * Deactivate again
    * Apply migration
    * Restart and notice no more deadlocks

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/554
 - Fixes https://github.com/celo-org/data-services/issues/326
 - Fixes https://github.com/celo-org/data-services/issues/411
