### PR TITLE
Format output of CMC api to be in "eth" rather than wei

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -85,7 +85,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
     end
 
     test "with coinmarketcap param", %{conn: conn} do
-      token = insert(:token, %{total_supply: 24787584335729452746080877})
+      token = insert(:token, %{total_supply: 24_787_584_335_729_452_746_080_877})
 
       params = %{
         "module" => "stats",
@@ -94,7 +94,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
         "contractaddress" => to_string(token.contract_address_hash)
       }
 
-      assert "24787584.335729454" ==
+      assert "24787584.335729453" ==
                conn
                |> get("/api", params)
                |> text_response(200)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -85,7 +85,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
     end
 
     test "with coinmarketcap param", %{conn: conn} do
-      token = insert(:token, %{total_supply: 777.777})
+      token = insert(:token, %{total_supply: 24787584335729452746080877})
 
       params = %{
         "module" => "stats",
@@ -94,7 +94,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
         "contractaddress" => to_string(token.contract_address_hash)
       }
 
-      assert "777.777" ==
+      assert "24787584.335729454" ==
                conn
                |> get("/api", params)
                |> text_response(200)


### PR DESCRIPTION
### Description

Formats the output of the tokensupply rpc call to be in "eth" rather than wei, as per the request of Coin Market Cap


### Tested

* Modified and passed unit tests

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/594
