### PR TITLE
Fix error message on write contract page

### DIFF
--- a/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
@@ -225,7 +225,7 @@ const sanctionedAddresses = [
 const sanctionText = 'The wallet address has been sanctioned by the U.S. Department of the Treasury. All U.S. persons are prohibited from accessing, receiving, accepting, or facilitating any property and interests in property (including use of any technology, software or software patch(es)) of these designated digital wallet addresses. These prohibitions include the making of any contribution or provision of funds, goods, or services by, to, or for the benefit of any blocked person and the receipt of any contribution or provision of funds, goods, or services from any such person and all designated digital asset wallets.'
 
 function isSanctioned (address) {
-  return sanctionedAddresses.includes(address.toLowerCase())
+  return address && sanctionedAddresses.includes(address.toLowerCase())
 }
 
 function onTransactionHash (txHash, functionName) {

--- a/apps/explorer/lib/explorer/celo/account_reader.ex
+++ b/apps/explorer/lib/explorer/celo/account_reader.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Celo.AccountReader do
   require Logger
   alias Explorer.Celo.SignerCache
 
-  use Bitwise
+  import Bitwise
 
   import Explorer.Celo.{EpochUtil, Util}
 

--- a/apps/explorer/lib/explorer/celo/contract_cache/address_cache.ex
+++ b/apps/explorer/lib/explorer/celo/contract_cache/address_cache.ex
@@ -18,7 +18,7 @@ defmodule Explorer.Celo.AddressCache do
   @callback update_cache(String.t(), String.t()) :: any()
 
   # credo:disable-for-next-line
-  @implementation Application.fetch_env!(:explorer, __MODULE__)
+  @implementation Application.compile_env!(:explorer, __MODULE__)
 
   defdelegate contract_address(contract_name), to: @implementation
   defdelegate is_core_contract_address?(address), to: @implementation


### PR DESCRIPTION
### Description

The warning modal is displaying an error for an invalid access due to the sanctioned address test not working when no address is provided. This adds a simple test for the existence of the address before checking if it's sanctioned.
 
 ### Other changes

* Fixes some warnings that prevent compilation

### Tested

* Tested locally
* Can correctly send a transaction via updated javascript

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/604
