### PR TITLE
Display address tags

### DIFF
--- a/apps/block_scout_web/assets/css/components/_label.scss
+++ b/apps/block_scout_web/assets/css/components/_label.scss
@@ -31,13 +31,31 @@
         background: #153550;
         color: #fff;
     }
-    &.bridged {
-        background: #70aee3;
-        color: #fff;
-    }
-    &.validator {
+    &.validator,
+    &.validator-group,
+    &.validator-signer {
         background: $primary;
         color: #fff;
+    }
+    &.eoa {
+      background: #007bff;
+      color: #fff;
+    }
+    &.contract {
+      background: #923dc3;
+      color: #fff;
+    }
+    &.proxy {
+      background: #2a9e51;
+      color: #fff;
+    }
+    &.black-hole {
+      background: #000;
+      color: #fff;
+    }
+    &.token {
+      background: #5d26c4;
+      color: #fff;
     }
     &.reward,
     &.epoch-number {

--- a/apps/block_scout_web/lib/block_scout_web/models/get_address_tags.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/get_address_tags.ex
@@ -36,7 +36,6 @@ defmodule BlockScoutWeb.Models.GetAddressTags do
         left_join: att in AddressToTag,
         on: tt.id == att.tag_id,
         where: att.address_hash == ^address_hash,
-        where: tt.label != ^"validator",
         select: %{label: tt.label, display_name: tt.display_name, address_hash: att.address_hash}
       )
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -27,6 +27,17 @@
           <% end %>
           <h1 class="card-title lg-card-title mb-2">
             <div class="title-with-label"><%= address_title(@address) %> <%= gettext "Details" %></div>
+              <%= if contract?(@address) do %>
+                <%= render BlockScoutWeb.FormView, "_tag.html", text: "contract", additional_classes: ["contract", "ml-1"] %>
+                <%= if @is_proxy do %>
+                  <%= render BlockScoutWeb.FormView, "_tag.html", text: "proxy", additional_classes: ["proxy", "ml-1"] %>
+                <% end %>
+                <%= if @address.token do %>
+                  <%= render BlockScoutWeb.FormView, "_tag.html", text: "token", additional_classes: ["token", "ml-1"] %>
+                <% end %>
+              <% else %>
+                <%= render BlockScoutWeb.FormView, "_tag.html", text: "EOA", additional_classes: ["eoa", "ml-1"] %>
+              <% end %>
             <%= render BlockScoutWeb.AddressView, "_labels.html", address_hash: @address.hash, tags: @tags %>
             <!-- buttons -->
             <span class="overview-title-buttons float-right">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -93,7 +93,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:225
+#: lib/block_scout_web/templates/layout/app.html.eex:227
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
@@ -209,7 +209,7 @@ msgstr ""
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:239
+#: lib/block_scout_web/templates/address/overview.html.eex:250
 #, elixir-autogen, elixir-format
 msgid "All tokens in the account and total value."
 msgstr ""
@@ -246,7 +246,7 @@ msgid "Back Home"
 msgstr ""
 
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:24
-#: lib/block_scout_web/templates/address/overview.html.eex:150
+#: lib/block_scout_web/templates/address/overview.html.eex:161
 #: lib/block_scout_web/templates/address_token/overview.html.eex:51
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:60
 #, elixir-autogen, elixir-format
@@ -312,7 +312,7 @@ msgstr ""
 msgid "Block Pending"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:42
+#: lib/block_scout_web/templates/layout/app.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Block Proposed, awaiting import..."
 msgstr ""
@@ -334,7 +334,7 @@ msgstr ""
 msgid "Block number containing the transaction."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:322
+#: lib/block_scout_web/templates/address/overview.html.eex:333
 #, elixir-autogen, elixir-format
 msgid "Block number in which the address was updated."
 msgstr ""
@@ -354,13 +354,13 @@ msgstr ""
 msgid "Blocks"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:41
+#: lib/block_scout_web/templates/layout/app.html.eex:43
 #, elixir-autogen, elixir-format
 msgid "Blocks Indexed"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
-#: lib/block_scout_web/templates/address/overview.html.eex:340
+#: lib/block_scout_web/templates/address/overview.html.eex:351
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/views/address_view.ex:438
 #, elixir-autogen, elixir-format
@@ -372,11 +372,11 @@ msgstr ""
 msgid "Blockscout is a tool for inspecting and analyzing EVM based blockchains. Blockchain explorer for the Celo Network."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:179
-#: lib/block_scout_web/templates/address/overview.html.eex:192
-#: lib/block_scout_web/templates/address/overview.html.eex:205
-#: lib/block_scout_web/templates/address/overview.html.eex:218
-#: lib/block_scout_web/templates/address/overview.html.eex:231
+#: lib/block_scout_web/templates/address/overview.html.eex:190
+#: lib/block_scout_web/templates/address/overview.html.eex:203
+#: lib/block_scout_web/templates/address/overview.html.eex:216
+#: lib/block_scout_web/templates/address/overview.html.eex:229
+#: lib/block_scout_web/templates/address/overview.html.eex:242
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:24
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:23
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:29
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Contract Libraries"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:74
+#: lib/block_scout_web/templates/address/overview.html.eex:85
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_name_field.html.eex:3
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:50
 #, elixir-autogen, elixir-format
@@ -654,8 +654,8 @@ msgstr ""
 #: lib/block_scout_web/templates/account/tag_transaction/row.html.eex:11
 #: lib/block_scout_web/templates/account/tag_transaction/row.html.eex:11
 #: lib/block_scout_web/templates/account/watchlist_address/row.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:37
-#: lib/block_scout_web/templates/address/overview.html.eex:38
+#: lib/block_scout_web/templates/address/overview.html.eex:48
+#: lib/block_scout_web/templates/address/overview.html.eex:49
 #: lib/block_scout_web/templates/block/overview.html.eex:159
 #: lib/block_scout_web/templates/block/overview.html.eex:160
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:42
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Create2"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:101
+#: lib/block_scout_web/templates/address/overview.html.eex:112
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:119
+#: lib/block_scout_web/templates/address/overview.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Error: Could not determine contract creator."
 msgstr ""
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Gas Tracker"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:305
+#: lib/block_scout_web/templates/address/overview.html.eex:316
 #: lib/block_scout_web/templates/block/_tile.html.eex:92
 #: lib/block_scout_web/templates/block/overview.html.eex:250
 #: lib/block_scout_web/templates/block/overview.html.eex:352
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Gas Used by Transaction"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:304
+#: lib/block_scout_web/templates/address/overview.html.eex:315
 #, elixir-autogen, elixir-format
 msgid "Gas used by the address."
 msgstr ""
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "If you have just submitted this transaction please wait for at least 30 seconds before refreshing this page."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:132
+#: lib/block_scout_web/templates/address/overview.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Implementation"
 msgstr ""
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Implementation Name:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:131
+#: lib/block_scout_web/templates/address/overview.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Implementation address of the proxy contract."
 msgstr ""
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "It could still be in the TX Pool of a different node, waiting to be broadcasted."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:323
+#: lib/block_scout_web/templates/address/overview.html.eex:334
 #, elixir-autogen, elixir-format
 msgid "Last Balance Update"
 msgstr ""
@@ -1296,7 +1296,7 @@ msgstr ""
 msgid "Learn, Borrow, Earn"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:44
+#: lib/block_scout_web/templates/layout/app.html.eex:46
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "License ID"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:215
+#: lib/block_scout_web/templates/address/overview.html.eex:226
 #, elixir-autogen, elixir-format
 msgid "Lifetime Voting Rewards"
 msgstr ""
@@ -1378,7 +1378,7 @@ msgid "Main Networks"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:51
-#: lib/block_scout_web/templates/layout/app.html.eex:45
+#: lib/block_scout_web/templates/layout/app.html.eex:47
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:83
 #: lib/block_scout_web/views/address_view.ex:203
 #, elixir-autogen, elixir-format
@@ -1547,12 +1547,12 @@ msgstr ""
 msgid "Not unique Token"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:250
+#: lib/block_scout_web/templates/address/overview.html.eex:261
 #, elixir-autogen, elixir-format
 msgid "Number of transactions related to this address."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:277
+#: lib/block_scout_web/templates/address/overview.html.eex:288
 #, elixir-autogen, elixir-format
 msgid "Number of transfers to/from this address."
 msgstr ""
@@ -1671,7 +1671,7 @@ msgid "Press / and focus will be moved to the search field"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:40
-#: lib/block_scout_web/templates/layout/app.html.eex:46
+#: lib/block_scout_web/templates/layout/app.html.eex:48
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:94
 #, elixir-autogen, elixir-format
 msgid "Price"
@@ -2015,12 +2015,12 @@ msgstr ""
 msgid "The hash of the block from which this block was generated."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:73
+#: lib/block_scout_web/templates/address/overview.html.eex:84
 #, elixir-autogen, elixir-format
 msgid "The name found in the source code of the Contract."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:84
+#: lib/block_scout_web/templates/address/overview.html.eex:95
 #, elixir-autogen, elixir-format
 msgid "The name of the validator."
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:54
+#: lib/block_scout_web/templates/address/overview.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Token"
 msgstr ""
@@ -2307,13 +2307,13 @@ msgstr ""
 msgid "Token Transfers"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:53
+#: lib/block_scout_web/templates/address/overview.html.eex:64
 #, elixir-autogen, elixir-format
 msgid "Token name and symbol."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
-#: lib/block_scout_web/templates/address/overview.html.eex:240
+#: lib/block_scout_web/templates/address/overview.html.eex:251
 #: lib/block_scout_web/templates/address_token/overview.html.eex:58
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/tokens/index.html.eex:9
@@ -2448,9 +2448,9 @@ msgid "Transaction type, introduced in EIP-2718."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:251
-#: lib/block_scout_web/templates/address/overview.html.eex:257
-#: lib/block_scout_web/templates/address/overview.html.eex:265
+#: lib/block_scout_web/templates/address/overview.html.eex:262
+#: lib/block_scout_web/templates/address/overview.html.eex:268
+#: lib/block_scout_web/templates/address/overview.html.eex:276
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block/_tabs.html.eex:4
 #: lib/block_scout_web/templates/block/overview.html.eex:120
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:100
+#: lib/block_scout_web/templates/address/overview.html.eex:111
 #, elixir-autogen, elixir-format
 msgid "Transactions and address of creation."
 msgstr ""
@@ -2471,9 +2471,9 @@ msgstr ""
 msgid "Transactions sent"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:278
-#: lib/block_scout_web/templates/address/overview.html.eex:284
-#: lib/block_scout_web/templates/address/overview.html.eex:292
+#: lib/block_scout_web/templates/address/overview.html.eex:289
+#: lib/block_scout_web/templates/address/overview.html.eex:295
+#: lib/block_scout_web/templates/address/overview.html.eex:303
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:50
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:118
 #, elixir-autogen, elixir-format
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "Twitter"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:48
+#: lib/block_scout_web/templates/layout/app.html.eex:50
 #, elixir-autogen, elixir-format
 msgid "Tx/day"
 msgstr ""
@@ -2592,7 +2592,7 @@ msgstr ""
 msgid "Validator Group:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:85
+#: lib/block_scout_web/templates/address/overview.html.eex:96
 #, elixir-autogen, elixir-format
 msgid "Validator Name"
 msgstr ""
@@ -2726,7 +2726,7 @@ msgstr ""
 msgid "Voting Rewards"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:214
+#: lib/block_scout_web/templates/address/overview.html.eex:225
 #, elixir-autogen, elixir-format
 msgid "Voting rewards accumulated over time."
 msgstr ""
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:110
+#: lib/block_scout_web/templates/address/overview.html.eex:121
 #, elixir-autogen, elixir-format
 msgid "at"
 msgstr ""
@@ -2803,7 +2803,12 @@ msgstr ""
 msgid "button"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:231
+#: lib/block_scout_web/templates/stats/index.html.eex:22
+#, elixir-autogen, elixir-format
+msgid "cStables"
+msgstr ""
+
+#: lib/block_scout_web/templates/address/overview.html.eex:242
 #, elixir-autogen, elixir-format
 msgid "cUSD"
 msgstr ""
@@ -2897,19 +2902,19 @@ msgstr "CELO"
 msgid "CRC Worth"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:312
+#: lib/block_scout_web/templates/address/overview.html.eex:323
 #, elixir-autogen, elixir-format
 msgid "Fetching gas used..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:259
-#: lib/block_scout_web/templates/address/overview.html.eex:267
+#: lib/block_scout_web/templates/address/overview.html.eex:270
+#: lib/block_scout_web/templates/address/overview.html.eex:278
 #, elixir-autogen, elixir-format
 msgid "Fetching transactions..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:286
-#: lib/block_scout_web/templates/address/overview.html.eex:294
+#: lib/block_scout_web/templates/address/overview.html.eex:297
+#: lib/block_scout_web/templates/address/overview.html.eex:305
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:122
 #, elixir-autogen, elixir-format
 msgid "Fetching transfers..."
@@ -3030,7 +3035,7 @@ msgstr ""
 msgid "Attestations"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:176
+#: lib/block_scout_web/templates/address/overview.html.eex:187
 #, elixir-autogen, elixir-format
 msgid "Locked CELO Balance"
 msgstr ""
@@ -3045,12 +3050,12 @@ msgstr ""
 msgid "Moola"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:202
+#: lib/block_scout_web/templates/address/overview.html.eex:213
 #, elixir-autogen, elixir-format
 msgid "Pending Unlocked Gold"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:227
+#: lib/block_scout_web/templates/address/overview.html.eex:238
 #, elixir-autogen, elixir-format
 msgid "Total amount of epoch rewards this address has received, all time."
 msgstr ""
@@ -3060,7 +3065,7 @@ msgstr ""
 msgid "Uniswap"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:228
+#: lib/block_scout_web/templates/address/overview.html.eex:239
 #, elixir-autogen, elixir-format
 msgid "Validator Rewards | Voting Rewards"
 msgstr ""
@@ -3080,17 +3085,17 @@ msgstr ""
 msgid "cLabs"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:201
+#: lib/block_scout_web/templates/address/overview.html.eex:212
 #, elixir-autogen, elixir-format
 msgid "Amount of CELO that’s in the process of being unlocked (3 days)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:175
+#: lib/block_scout_web/templates/address/overview.html.eex:186
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO in the protocol"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:188
+#: lib/block_scout_web/templates/address/overview.html.eex:199
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO that has been activated to vote for validator(s)"
 msgstr ""
@@ -3117,7 +3122,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:339
+#: lib/block_scout_web/templates/address/overview.html.eex:350
 #, elixir-autogen, elixir-format
 msgid "Number of blocks validated by this validator."
 msgstr ""
@@ -3137,7 +3142,7 @@ msgstr ""
 msgid "View previous block"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:189
+#: lib/block_scout_web/templates/address/overview.html.eex:200
 #, elixir-autogen, elixir-format
 msgid "Voting CELO Balance"
 msgstr ""
@@ -3168,12 +3173,12 @@ msgstr ""
 msgid "Slow"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:149
+#: lib/block_scout_web/templates/address/overview.html.eex:160
 #, elixir-autogen, elixir-format
 msgid "Address balance in"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:149
+#: lib/block_scout_web/templates/address/overview.html.eex:160
 #, elixir-autogen, elixir-format
 msgid "doesn't include ERC20, ERC721, ERC1155 tokens)."
 msgstr ""
@@ -3667,7 +3672,7 @@ msgstr ""
 msgid "Your name*"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:43
+#: lib/block_scout_web/templates/layout/app.html.eex:45
 #, elixir-autogen, elixir-format
 msgid "Indexing Internal Transactions"
 msgstr ""
@@ -3720,12 +3725,7 @@ msgstr ""
 msgid "View previous epoch"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:119
+#: lib/block_scout_web/templates/address/overview.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Contract was precompiled and created at genesis or contract creation transaction is missing"
-msgstr ""
-
-#: lib/block_scout_web/templates/stats/index.html.eex:22
-#, elixir-autogen, elixir-format
-msgid "Mento"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -93,7 +93,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:227
+#: lib/block_scout_web/templates/layout/app.html.eex:225
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
@@ -312,7 +312,7 @@ msgstr ""
 msgid "Block Pending"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:44
+#: lib/block_scout_web/templates/layout/app.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Block Proposed, awaiting import..."
 msgstr ""
@@ -354,7 +354,7 @@ msgstr ""
 msgid "Blocks"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:43
+#: lib/block_scout_web/templates/layout/app.html.eex:41
 #, elixir-autogen, elixir-format
 msgid "Blocks Indexed"
 msgstr ""
@@ -1296,7 +1296,7 @@ msgstr ""
 msgid "Learn, Borrow, Earn"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:46
+#: lib/block_scout_web/templates/layout/app.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
@@ -1378,7 +1378,7 @@ msgid "Main Networks"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:51
-#: lib/block_scout_web/templates/layout/app.html.eex:47
+#: lib/block_scout_web/templates/layout/app.html.eex:45
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:83
 #: lib/block_scout_web/views/address_view.ex:203
 #, elixir-autogen, elixir-format
@@ -1671,7 +1671,7 @@ msgid "Press / and focus will be moved to the search field"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:40
-#: lib/block_scout_web/templates/layout/app.html.eex:48
+#: lib/block_scout_web/templates/layout/app.html.eex:46
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:94
 #, elixir-autogen, elixir-format
 msgid "Price"
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "Twitter"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:50
+#: lib/block_scout_web/templates/layout/app.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "Tx/day"
 msgstr ""
@@ -2801,11 +2801,6 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract/index.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "button"
-msgstr ""
-
-#: lib/block_scout_web/templates/stats/index.html.eex:22
-#, elixir-autogen, elixir-format
-msgid "cStables"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/overview.html.eex:242
@@ -3672,7 +3667,7 @@ msgstr ""
 msgid "Your name*"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:45
+#: lib/block_scout_web/templates/layout/app.html.eex:43
 #, elixir-autogen, elixir-format
 msgid "Indexing Internal Transactions"
 msgstr ""
@@ -3728,4 +3723,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Contract was precompiled and created at genesis or contract creation transaction is missing"
+msgstr ""
+
+#: lib/block_scout_web/templates/stats/index.html.eex:22
+#, elixir-autogen, elixir-format
+msgid "Mento"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -94,7 +94,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:227
+#: lib/block_scout_web/templates/layout/app.html.eex:225
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Block Pending"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:44
+#: lib/block_scout_web/templates/layout/app.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Block Proposed, awaiting import..."
 msgstr ""
@@ -355,7 +355,7 @@ msgstr ""
 msgid "Blocks"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:43
+#: lib/block_scout_web/templates/layout/app.html.eex:41
 #, elixir-autogen, elixir-format
 msgid "Blocks Indexed"
 msgstr ""
@@ -1297,7 +1297,7 @@ msgstr ""
 msgid "Learn, Borrow, Earn"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:46
+#: lib/block_scout_web/templates/layout/app.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
@@ -1379,7 +1379,7 @@ msgid "Main Networks"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:51
-#: lib/block_scout_web/templates/layout/app.html.eex:47
+#: lib/block_scout_web/templates/layout/app.html.eex:45
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:83
 #: lib/block_scout_web/views/address_view.ex:203
 #, elixir-autogen, elixir-format
@@ -1672,7 +1672,7 @@ msgid "Press / and focus will be moved to the search field"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:40
-#: lib/block_scout_web/templates/layout/app.html.eex:48
+#: lib/block_scout_web/templates/layout/app.html.eex:46
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:94
 #, elixir-autogen, elixir-format
 msgid "Price"
@@ -2492,7 +2492,7 @@ msgstr ""
 msgid "Twitter"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:50
+#: lib/block_scout_web/templates/layout/app.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "Tx/day"
 msgstr ""
@@ -2802,11 +2802,6 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract/index.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "button"
-msgstr ""
-
-#: lib/block_scout_web/templates/stats/index.html.eex:22
-#, elixir-autogen, elixir-format
-msgid "cStables"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/overview.html.eex:242
@@ -3673,7 +3668,7 @@ msgstr ""
 msgid "Your name*"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:45
+#: lib/block_scout_web/templates/layout/app.html.eex:43
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Indexing Internal Transactions"
 msgstr ""
@@ -3729,4 +3724,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address/overview.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Contract was precompiled and created at genesis or contract creation transaction is missing"
+msgstr ""
+
+#: lib/block_scout_web/templates/stats/index.html.eex:22
+#, elixir-autogen, elixir-format
+msgid "Mento"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -94,7 +94,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:225
+#: lib/block_scout_web/templates/layout/app.html.eex:227
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
@@ -210,7 +210,7 @@ msgstr ""
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:239
+#: lib/block_scout_web/templates/address/overview.html.eex:250
 #, elixir-autogen, elixir-format
 msgid "All tokens in the account and total value."
 msgstr ""
@@ -247,7 +247,7 @@ msgid "Back Home"
 msgstr ""
 
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:24
-#: lib/block_scout_web/templates/address/overview.html.eex:150
+#: lib/block_scout_web/templates/address/overview.html.eex:161
 #: lib/block_scout_web/templates/address_token/overview.html.eex:51
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:60
 #, elixir-autogen, elixir-format
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Block Pending"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:42
+#: lib/block_scout_web/templates/layout/app.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Block Proposed, awaiting import..."
 msgstr ""
@@ -335,7 +335,7 @@ msgstr ""
 msgid "Block number containing the transaction."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:322
+#: lib/block_scout_web/templates/address/overview.html.eex:333
 #, elixir-autogen, elixir-format
 msgid "Block number in which the address was updated."
 msgstr ""
@@ -355,13 +355,13 @@ msgstr ""
 msgid "Blocks"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:41
+#: lib/block_scout_web/templates/layout/app.html.eex:43
 #, elixir-autogen, elixir-format
 msgid "Blocks Indexed"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
-#: lib/block_scout_web/templates/address/overview.html.eex:340
+#: lib/block_scout_web/templates/address/overview.html.eex:351
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/views/address_view.ex:438
 #, elixir-autogen, elixir-format
@@ -373,11 +373,11 @@ msgstr ""
 msgid "Blockscout is a tool for inspecting and analyzing EVM based blockchains. Blockchain explorer for the Celo Network."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:179
-#: lib/block_scout_web/templates/address/overview.html.eex:192
-#: lib/block_scout_web/templates/address/overview.html.eex:205
-#: lib/block_scout_web/templates/address/overview.html.eex:218
-#: lib/block_scout_web/templates/address/overview.html.eex:231
+#: lib/block_scout_web/templates/address/overview.html.eex:190
+#: lib/block_scout_web/templates/address/overview.html.eex:203
+#: lib/block_scout_web/templates/address/overview.html.eex:216
+#: lib/block_scout_web/templates/address/overview.html.eex:229
+#: lib/block_scout_web/templates/address/overview.html.eex:242
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:24
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:23
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:29
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Contract Libraries"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:74
+#: lib/block_scout_web/templates/address/overview.html.eex:85
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_name_field.html.eex:3
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:50
 #, elixir-autogen, elixir-format
@@ -655,8 +655,8 @@ msgstr ""
 #: lib/block_scout_web/templates/account/tag_transaction/row.html.eex:11
 #: lib/block_scout_web/templates/account/tag_transaction/row.html.eex:11
 #: lib/block_scout_web/templates/account/watchlist_address/row.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:37
-#: lib/block_scout_web/templates/address/overview.html.eex:38
+#: lib/block_scout_web/templates/address/overview.html.eex:48
+#: lib/block_scout_web/templates/address/overview.html.eex:49
 #: lib/block_scout_web/templates/block/overview.html.eex:159
 #: lib/block_scout_web/templates/block/overview.html.eex:160
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:42
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Create2"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:101
+#: lib/block_scout_web/templates/address/overview.html.eex:112
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:119
+#: lib/block_scout_web/templates/address/overview.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Error: Could not determine contract creator."
 msgstr ""
@@ -1113,7 +1113,7 @@ msgstr ""
 msgid "Gas Tracker"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:305
+#: lib/block_scout_web/templates/address/overview.html.eex:316
 #: lib/block_scout_web/templates/block/_tile.html.eex:92
 #: lib/block_scout_web/templates/block/overview.html.eex:250
 #: lib/block_scout_web/templates/block/overview.html.eex:352
@@ -1126,7 +1126,7 @@ msgstr ""
 msgid "Gas Used by Transaction"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:304
+#: lib/block_scout_web/templates/address/overview.html.eex:315
 #, elixir-autogen, elixir-format
 msgid "Gas used by the address."
 msgstr ""
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "If you have just submitted this transaction please wait for at least 30 seconds before refreshing this page."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:132
+#: lib/block_scout_web/templates/address/overview.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Implementation"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "Implementation Name:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:131
+#: lib/block_scout_web/templates/address/overview.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Implementation address of the proxy contract."
 msgstr ""
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "It could still be in the TX Pool of a different node, waiting to be broadcasted."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:323
+#: lib/block_scout_web/templates/address/overview.html.eex:334
 #, elixir-autogen, elixir-format
 msgid "Last Balance Update"
 msgstr ""
@@ -1297,7 +1297,7 @@ msgstr ""
 msgid "Learn, Borrow, Earn"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:44
+#: lib/block_scout_web/templates/layout/app.html.eex:46
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "License ID"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:215
+#: lib/block_scout_web/templates/address/overview.html.eex:226
 #, elixir-autogen, elixir-format
 msgid "Lifetime Voting Rewards"
 msgstr ""
@@ -1379,7 +1379,7 @@ msgid "Main Networks"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:51
-#: lib/block_scout_web/templates/layout/app.html.eex:45
+#: lib/block_scout_web/templates/layout/app.html.eex:47
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:83
 #: lib/block_scout_web/views/address_view.ex:203
 #, elixir-autogen, elixir-format
@@ -1548,12 +1548,12 @@ msgstr ""
 msgid "Not unique Token"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:250
+#: lib/block_scout_web/templates/address/overview.html.eex:261
 #, elixir-autogen, elixir-format
 msgid "Number of transactions related to this address."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:277
+#: lib/block_scout_web/templates/address/overview.html.eex:288
 #, elixir-autogen, elixir-format
 msgid "Number of transfers to/from this address."
 msgstr ""
@@ -1672,7 +1672,7 @@ msgid "Press / and focus will be moved to the search field"
 msgstr ""
 
 #: lib/block_scout_web/templates/chain/show.html.eex:40
-#: lib/block_scout_web/templates/layout/app.html.eex:46
+#: lib/block_scout_web/templates/layout/app.html.eex:48
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:94
 #, elixir-autogen, elixir-format
 msgid "Price"
@@ -2016,12 +2016,12 @@ msgstr ""
 msgid "The hash of the block from which this block was generated."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:73
+#: lib/block_scout_web/templates/address/overview.html.eex:84
 #, elixir-autogen, elixir-format
 msgid "The name found in the source code of the Contract."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:84
+#: lib/block_scout_web/templates/address/overview.html.eex:95
 #, elixir-autogen, elixir-format
 msgid "The name of the validator."
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:54
+#: lib/block_scout_web/templates/address/overview.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Token"
 msgstr ""
@@ -2308,13 +2308,13 @@ msgstr ""
 msgid "Token Transfers"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:53
+#: lib/block_scout_web/templates/address/overview.html.eex:64
 #, elixir-autogen, elixir-format
 msgid "Token name and symbol."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
-#: lib/block_scout_web/templates/address/overview.html.eex:240
+#: lib/block_scout_web/templates/address/overview.html.eex:251
 #: lib/block_scout_web/templates/address_token/overview.html.eex:58
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/tokens/index.html.eex:9
@@ -2449,9 +2449,9 @@ msgid "Transaction type, introduced in EIP-2718."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:251
-#: lib/block_scout_web/templates/address/overview.html.eex:257
-#: lib/block_scout_web/templates/address/overview.html.eex:265
+#: lib/block_scout_web/templates/address/overview.html.eex:262
+#: lib/block_scout_web/templates/address/overview.html.eex:268
+#: lib/block_scout_web/templates/address/overview.html.eex:276
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block/_tabs.html.eex:4
 #: lib/block_scout_web/templates/block/overview.html.eex:120
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:100
+#: lib/block_scout_web/templates/address/overview.html.eex:111
 #, elixir-autogen, elixir-format
 msgid "Transactions and address of creation."
 msgstr ""
@@ -2472,9 +2472,9 @@ msgstr ""
 msgid "Transactions sent"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:278
-#: lib/block_scout_web/templates/address/overview.html.eex:284
-#: lib/block_scout_web/templates/address/overview.html.eex:292
+#: lib/block_scout_web/templates/address/overview.html.eex:289
+#: lib/block_scout_web/templates/address/overview.html.eex:295
+#: lib/block_scout_web/templates/address/overview.html.eex:303
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:50
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:118
 #, elixir-autogen, elixir-format
@@ -2492,7 +2492,7 @@ msgstr ""
 msgid "Twitter"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:48
+#: lib/block_scout_web/templates/layout/app.html.eex:50
 #, elixir-autogen, elixir-format
 msgid "Tx/day"
 msgstr ""
@@ -2593,7 +2593,7 @@ msgstr ""
 msgid "Validator Group:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:85
+#: lib/block_scout_web/templates/address/overview.html.eex:96
 #, elixir-autogen, elixir-format
 msgid "Validator Name"
 msgstr ""
@@ -2727,7 +2727,7 @@ msgstr ""
 msgid "Voting Rewards"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:214
+#: lib/block_scout_web/templates/address/overview.html.eex:225
 #, elixir-autogen, elixir-format
 msgid "Voting rewards accumulated over time."
 msgstr ""
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:110
+#: lib/block_scout_web/templates/address/overview.html.eex:121
 #, elixir-autogen, elixir-format
 msgid "at"
 msgstr ""
@@ -2804,7 +2804,12 @@ msgstr ""
 msgid "button"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:231
+#: lib/block_scout_web/templates/stats/index.html.eex:22
+#, elixir-autogen, elixir-format
+msgid "cStables"
+msgstr ""
+
+#: lib/block_scout_web/templates/address/overview.html.eex:242
 #, elixir-autogen, elixir-format
 msgid "cUSD"
 msgstr ""
@@ -2898,19 +2903,19 @@ msgstr "CELO"
 msgid "CRC Worth"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:312
+#: lib/block_scout_web/templates/address/overview.html.eex:323
 #, elixir-autogen, elixir-format
 msgid "Fetching gas used..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:259
-#: lib/block_scout_web/templates/address/overview.html.eex:267
+#: lib/block_scout_web/templates/address/overview.html.eex:270
+#: lib/block_scout_web/templates/address/overview.html.eex:278
 #, elixir-autogen, elixir-format
 msgid "Fetching transactions..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:286
-#: lib/block_scout_web/templates/address/overview.html.eex:294
+#: lib/block_scout_web/templates/address/overview.html.eex:297
+#: lib/block_scout_web/templates/address/overview.html.eex:305
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:122
 #, elixir-autogen, elixir-format
 msgid "Fetching transfers..."
@@ -3031,7 +3036,7 @@ msgstr ""
 msgid "Attestations"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:176
+#: lib/block_scout_web/templates/address/overview.html.eex:187
 #, elixir-autogen, elixir-format
 msgid "Locked CELO Balance"
 msgstr ""
@@ -3046,12 +3051,12 @@ msgstr ""
 msgid "Moola"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:202
+#: lib/block_scout_web/templates/address/overview.html.eex:213
 #, elixir-autogen, elixir-format
 msgid "Pending Unlocked Gold"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:227
+#: lib/block_scout_web/templates/address/overview.html.eex:238
 #, elixir-autogen, elixir-format
 msgid "Total amount of epoch rewards this address has received, all time."
 msgstr ""
@@ -3061,7 +3066,7 @@ msgstr ""
 msgid "Uniswap"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:228
+#: lib/block_scout_web/templates/address/overview.html.eex:239
 #, elixir-autogen, elixir-format
 msgid "Validator Rewards | Voting Rewards"
 msgstr ""
@@ -3081,17 +3086,17 @@ msgstr ""
 msgid "cLabs"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:201
+#: lib/block_scout_web/templates/address/overview.html.eex:212
 #, elixir-autogen, elixir-format
 msgid "Amount of CELO that’s in the process of being unlocked (3 days)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:175
+#: lib/block_scout_web/templates/address/overview.html.eex:186
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO in the protocol"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:188
+#: lib/block_scout_web/templates/address/overview.html.eex:199
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO that has been activated to vote for validator(s)"
 msgstr ""
@@ -3118,7 +3123,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:339
+#: lib/block_scout_web/templates/address/overview.html.eex:350
 #, elixir-autogen, elixir-format
 msgid "Number of blocks validated by this validator."
 msgstr ""
@@ -3138,7 +3143,7 @@ msgstr ""
 msgid "View previous block"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:189
+#: lib/block_scout_web/templates/address/overview.html.eex:200
 #, elixir-autogen, elixir-format
 msgid "Voting CELO Balance"
 msgstr ""
@@ -3169,12 +3174,12 @@ msgstr ""
 msgid "Slow"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:149
+#: lib/block_scout_web/templates/address/overview.html.eex:160
 #, elixir-autogen, elixir-format
 msgid "Address balance in"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:149
+#: lib/block_scout_web/templates/address/overview.html.eex:160
 #, elixir-autogen, elixir-format
 msgid "doesn't include ERC20, ERC721, ERC1155 tokens)."
 msgstr ""
@@ -3668,7 +3673,7 @@ msgstr ""
 msgid "Your name*"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:43
+#: lib/block_scout_web/templates/layout/app.html.eex:45
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Indexing Internal Transactions"
 msgstr ""
@@ -3721,12 +3726,7 @@ msgstr ""
 msgid "View previous epoch"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:119
+#: lib/block_scout_web/templates/address/overview.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Contract was precompiled and created at genesis or contract creation transaction is missing"
-msgstr ""
-
-#: lib/block_scout_web/templates/stats/index.html.eex:22
-#, elixir-autogen, elixir-format
-msgid "Mento"
 msgstr ""

--- a/apps/explorer/lib/explorer/tags/address_tag_cataloger.ex
+++ b/apps/explorer/lib/explorer/tags/address_tag_cataloger.ex
@@ -5,8 +5,7 @@ defmodule Explorer.Tags.AddressTag.Cataloger do
 
   use GenServer
 
-  alias Explorer.EnvVarTranslator
-  alias Explorer.Repo
+  alias Explorer.{EnvVarTranslator, Repo}
   alias Explorer.Tags.{AddressTag, AddressToTag}
   require Explorer.Celo.Telemetry, as: Telemetry
 
@@ -54,8 +53,7 @@ defmodule Explorer.Tags.AddressTag.Cataloger do
     {:noreply, state}
   end
 
-  defp update_validators_tags_bindings() do
-    IO.inspect("Updating validators stuff")
+  defp update_validators_tags_bindings do
     Repo.query!("CALL update_validators_tags_bindings();", [], timeout: :timer.seconds(30))
   end
 

--- a/apps/explorer/lib/mix/tasks/list_events.ex
+++ b/apps/explorer/lib/mix/tasks/list_events.ex
@@ -82,11 +82,13 @@ defmodule Mix.Tasks.ListEvents do
       topic = SmartContractHelper.event_abi_to_topic_str(event)
       tracked = MapSet.member?(tracked_topics, topic)
 
-      IO.puts("  #{name} - #{topic} - #{if tracked do
-        "tracked"
-      else
-        "untracked"
-      end} ")
+      IO.puts(
+        "  #{name} - #{topic} - #{if tracked do
+          "tracked"
+        else
+          "untracked"
+        end} "
+      )
     end)
   end
 end

--- a/apps/explorer/lib/mix/tasks/list_events.ex
+++ b/apps/explorer/lib/mix/tasks/list_events.ex
@@ -82,13 +82,11 @@ defmodule Mix.Tasks.ListEvents do
       topic = SmartContractHelper.event_abi_to_topic_str(event)
       tracked = MapSet.member?(tracked_topics, topic)
 
-      IO.puts(
-        "  #{name} - #{topic} - #{if tracked do
-          "tracked"
-        else
-          "untracked"
-        end} "
-      )
+      IO.puts("  #{name} - #{topic} - #{if tracked do
+        "tracked"
+      else
+        "untracked"
+      end} ")
     end)
   end
 end

--- a/apps/explorer/priv/repo/migrations/20230109155142_populate_tags_table.exs
+++ b/apps/explorer/priv/repo/migrations/20230109155142_populate_tags_table.exs
@@ -104,6 +104,7 @@ defmodule Explorer.Repo.Local.Migrations.PopulateTagsTable do
     execute("""
       DELETE FROM address_to_tags;
       DELETE FROM address_tags;
+      DROP PROCEDURE IF EXISTS update_validators_tags_bindings;
     """)
   end
 end

--- a/apps/explorer/priv/repo/migrations/20230109155142_populate_tags_table.exs
+++ b/apps/explorer/priv/repo/migrations/20230109155142_populate_tags_table.exs
@@ -1,0 +1,110 @@
+defmodule Explorer.Repo.Local.Migrations.PopulateTagsTable do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+      INSERT INTO address_tags (label, inserted_at, updated_at, display_name)
+      VALUES
+        ('black-hole', NOW(), NOW(), 'Black Hole'),
+        ('eoa', NOW(), NOW(), 'EOA'),
+        ('contract', NOW(), NOW(), 'contract'),
+        ('proxy', NOW(), NOW(), 'proxy'),
+        ('validator', NOW(), NOW(), 'validator'),
+        ('validator-signer', NOW(), NOW(), 'validator signer'),
+        ('validator-group', NOW(), NOW(), 'validator group'),
+        ('token', NOW(), NOW(), 'token');
+    """)
+
+    execute("""
+      WITH tag_id AS (
+        SELECT id, label FROM address_tags
+      )
+      INSERT INTO address_to_tags (address_hash, tag_id, inserted_at, updated_at)
+      SELECT a.address, t.id, NOW(), NOW()
+      FROM ((
+        SELECT
+          UNNEST(ARRAY[decode('0000000000000000000000000000000000000000', 'hex'), decode('000000000000000000000000000000000000dead', 'hex')]) as address
+        ) a
+        CROSS JOIN (
+          SELECT * FROM tag_id WHERE label='black-hole'
+        ) t
+      )
+    """)
+
+    # Initially pre-populate all EOAs and contracts
+    execute("""
+      WITH tag_ids AS (
+        SELECT id, label FROM address_tags
+      )
+      INSERT INTO address_to_tags (address_hash, tag_id, inserted_at, updated_at)
+      SELECT
+        s1.hash, t.id, NOW(), NOW()
+      FROM (
+        SELECT
+          a.hash,
+          CASE WHEN contract_code IS NULL THEN 'eoa' ELSE 'contract' END as label
+        FROM addresses a
+      ) s1
+      LEFT JOIN (
+        SELECT * FROM tag_ids
+      ) t
+      ON s1.label = t.label;
+    """)
+
+    # Pre-populate proxies
+    execute("""
+      WITH tag_ids AS (
+        SELECT id, label FROM address_tags
+      )
+      INSERT INTO address_to_tags (address_hash, tag_id, inserted_at, updated_at)
+      SELECT
+        s.address_hash, t.id, NOW(), NOW()
+      FROM smart_contracts s
+      LEFT JOIN (
+        SELECT * FROM tag_ids
+      ) t ON t.label = 'proxy'
+      WHERE implementation_name IS NOT NULL;
+    """)
+
+    # Validators, validator signers and validator groups
+    execute("""
+      WITH tag_ids AS (
+        SELECT id, label FROM address_tags
+      )
+      INSERT INTO address_to_tags (address_hash, tag_id, inserted_at, updated_at)
+      SELECT
+        s1.address, t.id, NOW(), NOW()
+      FROM (
+        SELECT DISTINCT
+          UNNEST(ARRAY['validator', 'validator-group', 'validator-signer']) AS "label",
+          UNNEST(ARRAY[address, group_address_hash, signer_address_hash]) AS "address"
+        FROM celo_validator
+        WHERE member > 0
+      ) s1
+      LEFT JOIN address_tags t
+      ON s1.label = t.label;
+    """)
+
+    # Tokens
+    execute("""
+      WITH tag_ids AS (
+        SELECT id, label FROM address_tags
+      )
+      INSERT INTO address_to_tags (address_hash, tag_id, inserted_at, updated_at)
+      SELECT
+        s.contract_address_hash, t.id, NOW(), NOW()
+      FROM tokens s
+      LEFT JOIN (
+        SELECT * FROM tag_ids
+      ) t ON t.label = 'token'
+      WHERE implementation_name IS NOT NULL;
+    """)
+    end
+
+  def down do
+    execute("""
+      DELETE FROM address_to_tags;
+      DELETE FROM address_tags;
+    """)
+  end
+end

--- a/apps/indexer/lib/indexer/memory/monitor.ex
+++ b/apps/indexer/lib/indexer/memory/monitor.ex
@@ -14,7 +14,7 @@ defmodule Indexer.Memory.Monitor do
 
   alias Indexer.Memory.Shrinkable
 
-  defstruct limit: Application.get_env(:indexer, :memory_limit),
+  defstruct limit: Application.compile_env(:indexer, :memory_limit),
             timer_interval: :timer.minutes(1),
             timer_reference: nil,
             shrinkable_set: MapSet.new()


### PR DESCRIPTION
### Description

Displays tags as little "pillow" elements next to the address on the Address Details page.
Validator-related tags get updated every hour.
 
 ### Other changes

Minor formatting and warning fixes. Removes unused tags functionality.

### Tested

Tested on staging.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/607.
