### PR TITLE
Added list of known tokens

### DIFF
--- a/apps/ethereum_jsonrpc/priv/js/tokens/celoTokens.json
+++ b/apps/ethereum_jsonrpc/priv/js/tokens/celoTokens.json
@@ -1,0 +1,26 @@
+[
+  {
+    "address": "0x471ece3750da237f93b8e339c536989b8978a438",
+    "symbol": "CELO",
+    "decimal": 18,
+    "type": "default"
+  },
+  {
+    "address": "0x765de816845861e75a25fca122bb6898b8b1282a",
+    "symbol": "cUSD",
+    "decimal": 18,
+    "type": "default"
+  },
+  {
+    "address": "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73",
+    "symbol": "cEUR",
+    "decimal": 18,
+    "type": "default"
+  },
+  {
+    "address": "0xe8537a3d056da446677b9e9d6c5db704eaab4787",
+    "symbol": "cREAL",
+    "decimal": 18,
+    "type": "default"
+  }
+]


### PR DESCRIPTION
### Description

Adds a "datasource" for known tokens (used to display total tokens value), see an example [here](https://github.com/celo-org/blockscout/blob/master/apps/explorer/lib/explorer/known_tokens/source/my_ether_wallet.ex#L12). Will be referenced in a subsequent PR.
 
 ### Other changes

No.

### Tested

Locally.

### Issues

 - Relates to https://github.com/celo-org/data-services/issues/610.
