### PR TITLE
Fixed token total counter

### DIFF
--- a/apps/explorer/lib/explorer/known_tokens/source.ex
+++ b/apps/explorer/lib/explorer/known_tokens/source.ex
@@ -23,7 +23,7 @@ defmodule Explorer.KnownTokens.Source do
 
   @spec known_tokens_source() :: module()
   defp known_tokens_source do
-    config(:source) || Explorer.KnownTokens.Source.MyEtherWallet
+    config(:source) || Explorer.KnownTokens.Source.CeloTokens
   end
 
   @spec config(atom()) :: term

--- a/apps/explorer/lib/explorer/known_tokens/source/celo_tokens.ex
+++ b/apps/explorer/lib/explorer/known_tokens/source/celo_tokens.ex
@@ -1,0 +1,19 @@
+defmodule Explorer.KnownTokens.Source.CeloTokens do
+  @moduledoc """
+  Adapter for fetching known CELO tokens from Celo Explorer's GitHub
+  """
+
+  alias Explorer.KnownTokens.Source
+
+  @behaviour Source
+
+  @impl Source
+  def source_url do
+    "https://raw.githubusercontent.com/celo-org/blockscout/master/apps/ethereum_jsonrpc/priv/js/tokens/celoTokens.json"
+  end
+
+  @impl Source
+  def headers do
+    []
+  end
+end


### PR DESCRIPTION
### Description

This change enables total token value calculation. The data source pulls a list of "known tokens" from an external source (see https://github.com/celo-org/blockscout/pull/850). It relies on the exchange rates provided by the `Market` module.
The implementation caches results for 1 hour by default.
 
 ### Other changes

No.

### Tested

Locally, works for cStables + CELO.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/610.
