### PR TITLE
Added support for Celo Safe contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -51,6 +51,13 @@
             </span>
           </h1>
           <h3 class="address-detail-hash-title mb-4 <%= if BlockScoutWeb.AddressView.contract?(@address) do %>contract-address<% end %>" data-test="address_detail_hash"><%= @address %></h3>
+          <%= if smart_contract_is_gnosis_safe_proxy?(@address) do %>
+            <span class="ml-2 mr-4">
+              <a data-test="external_url" href=https://safe.celo.org/<%= Chain.get_celo_chain_name_by_id(BlockScoutWeb.chain_id()) %>:<%= @address.hash %>/transactions/history target="_blank">
+              View In Celo Safe App <span class="external-token-icon"><%= render BlockScoutWeb.IconsView, "_external_link.html" %></span>
+              </a>
+            </span>
+          <% end %>
           <!-- Verify in other explorers -->
           <!--
           <%# <%= render "_verify_other_explorers.html", hash: @address.hash, type: "address" %> %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -209,7 +209,7 @@ msgstr ""
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:250
+#: lib/block_scout_web/templates/address/overview.html.eex:257
 #, elixir-autogen, elixir-format
 msgid "All tokens in the account and total value."
 msgstr ""
@@ -246,7 +246,7 @@ msgid "Back Home"
 msgstr ""
 
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:24
-#: lib/block_scout_web/templates/address/overview.html.eex:161
+#: lib/block_scout_web/templates/address/overview.html.eex:168
 #: lib/block_scout_web/templates/address_token/overview.html.eex:51
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:60
 #, elixir-autogen, elixir-format
@@ -334,7 +334,7 @@ msgstr ""
 msgid "Block number containing the transaction."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:333
+#: lib/block_scout_web/templates/address/overview.html.eex:340
 #, elixir-autogen, elixir-format
 msgid "Block number in which the address was updated."
 msgstr ""
@@ -360,7 +360,7 @@ msgid "Blocks Indexed"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
-#: lib/block_scout_web/templates/address/overview.html.eex:351
+#: lib/block_scout_web/templates/address/overview.html.eex:358
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/views/address_view.ex:438
 #, elixir-autogen, elixir-format
@@ -372,11 +372,11 @@ msgstr ""
 msgid "Blockscout is a tool for inspecting and analyzing EVM based blockchains. Blockchain explorer for the Celo Network."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:190
-#: lib/block_scout_web/templates/address/overview.html.eex:203
-#: lib/block_scout_web/templates/address/overview.html.eex:216
-#: lib/block_scout_web/templates/address/overview.html.eex:229
-#: lib/block_scout_web/templates/address/overview.html.eex:242
+#: lib/block_scout_web/templates/address/overview.html.eex:197
+#: lib/block_scout_web/templates/address/overview.html.eex:210
+#: lib/block_scout_web/templates/address/overview.html.eex:223
+#: lib/block_scout_web/templates/address/overview.html.eex:236
+#: lib/block_scout_web/templates/address/overview.html.eex:249
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:24
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:23
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:29
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Contract Libraries"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:85
+#: lib/block_scout_web/templates/address/overview.html.eex:92
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_name_field.html.eex:3
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:50
 #, elixir-autogen, elixir-format
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Create2"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:112
+#: lib/block_scout_web/templates/address/overview.html.eex:119
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:130
+#: lib/block_scout_web/templates/address/overview.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Error: Could not determine contract creator."
 msgstr ""
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Gas Tracker"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:316
+#: lib/block_scout_web/templates/address/overview.html.eex:323
 #: lib/block_scout_web/templates/block/_tile.html.eex:92
 #: lib/block_scout_web/templates/block/overview.html.eex:250
 #: lib/block_scout_web/templates/block/overview.html.eex:352
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Gas Used by Transaction"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:315
+#: lib/block_scout_web/templates/address/overview.html.eex:322
 #, elixir-autogen, elixir-format
 msgid "Gas used by the address."
 msgstr ""
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "If you have just submitted this transaction please wait for at least 30 seconds before refreshing this page."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:143
+#: lib/block_scout_web/templates/address/overview.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Implementation"
 msgstr ""
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Implementation Name:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:142
+#: lib/block_scout_web/templates/address/overview.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Implementation address of the proxy contract."
 msgstr ""
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "It could still be in the TX Pool of a different node, waiting to be broadcasted."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:334
+#: lib/block_scout_web/templates/address/overview.html.eex:341
 #, elixir-autogen, elixir-format
 msgid "Last Balance Update"
 msgstr ""
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "License ID"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:226
+#: lib/block_scout_web/templates/address/overview.html.eex:233
 #, elixir-autogen, elixir-format
 msgid "Lifetime Voting Rewards"
 msgstr ""
@@ -1547,12 +1547,12 @@ msgstr ""
 msgid "Not unique Token"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:261
+#: lib/block_scout_web/templates/address/overview.html.eex:268
 #, elixir-autogen, elixir-format
 msgid "Number of transactions related to this address."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:288
+#: lib/block_scout_web/templates/address/overview.html.eex:295
 #, elixir-autogen, elixir-format
 msgid "Number of transfers to/from this address."
 msgstr ""
@@ -2015,12 +2015,12 @@ msgstr ""
 msgid "The hash of the block from which this block was generated."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:84
+#: lib/block_scout_web/templates/address/overview.html.eex:91
 #, elixir-autogen, elixir-format
 msgid "The name found in the source code of the Contract."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:95
+#: lib/block_scout_web/templates/address/overview.html.eex:102
 #, elixir-autogen, elixir-format
 msgid "The name of the validator."
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:65
+#: lib/block_scout_web/templates/address/overview.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Token"
 msgstr ""
@@ -2307,13 +2307,13 @@ msgstr ""
 msgid "Token Transfers"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:64
+#: lib/block_scout_web/templates/address/overview.html.eex:71
 #, elixir-autogen, elixir-format
 msgid "Token name and symbol."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
-#: lib/block_scout_web/templates/address/overview.html.eex:251
+#: lib/block_scout_web/templates/address/overview.html.eex:258
 #: lib/block_scout_web/templates/address_token/overview.html.eex:58
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/tokens/index.html.eex:9
@@ -2448,9 +2448,9 @@ msgid "Transaction type, introduced in EIP-2718."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:262
-#: lib/block_scout_web/templates/address/overview.html.eex:268
-#: lib/block_scout_web/templates/address/overview.html.eex:276
+#: lib/block_scout_web/templates/address/overview.html.eex:269
+#: lib/block_scout_web/templates/address/overview.html.eex:275
+#: lib/block_scout_web/templates/address/overview.html.eex:283
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block/_tabs.html.eex:4
 #: lib/block_scout_web/templates/block/overview.html.eex:120
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:111
+#: lib/block_scout_web/templates/address/overview.html.eex:118
 #, elixir-autogen, elixir-format
 msgid "Transactions and address of creation."
 msgstr ""
@@ -2471,9 +2471,9 @@ msgstr ""
 msgid "Transactions sent"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:289
-#: lib/block_scout_web/templates/address/overview.html.eex:295
-#: lib/block_scout_web/templates/address/overview.html.eex:303
+#: lib/block_scout_web/templates/address/overview.html.eex:296
+#: lib/block_scout_web/templates/address/overview.html.eex:302
+#: lib/block_scout_web/templates/address/overview.html.eex:310
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:50
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:118
 #, elixir-autogen, elixir-format
@@ -2592,7 +2592,7 @@ msgstr ""
 msgid "Validator Group:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:96
+#: lib/block_scout_web/templates/address/overview.html.eex:103
 #, elixir-autogen, elixir-format
 msgid "Validator Name"
 msgstr ""
@@ -2726,7 +2726,7 @@ msgstr ""
 msgid "Voting Rewards"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:225
+#: lib/block_scout_web/templates/address/overview.html.eex:232
 #, elixir-autogen, elixir-format
 msgid "Voting rewards accumulated over time."
 msgstr ""
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:121
+#: lib/block_scout_web/templates/address/overview.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "at"
 msgstr ""
@@ -2803,7 +2803,7 @@ msgstr ""
 msgid "button"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:242
+#: lib/block_scout_web/templates/address/overview.html.eex:249
 #, elixir-autogen, elixir-format
 msgid "cUSD"
 msgstr ""
@@ -2897,19 +2897,19 @@ msgstr "CELO"
 msgid "CRC Worth"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:323
+#: lib/block_scout_web/templates/address/overview.html.eex:330
 #, elixir-autogen, elixir-format
 msgid "Fetching gas used..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:270
-#: lib/block_scout_web/templates/address/overview.html.eex:278
+#: lib/block_scout_web/templates/address/overview.html.eex:277
+#: lib/block_scout_web/templates/address/overview.html.eex:285
 #, elixir-autogen, elixir-format
 msgid "Fetching transactions..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:297
-#: lib/block_scout_web/templates/address/overview.html.eex:305
+#: lib/block_scout_web/templates/address/overview.html.eex:304
+#: lib/block_scout_web/templates/address/overview.html.eex:312
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:122
 #, elixir-autogen, elixir-format
 msgid "Fetching transfers..."
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "Attestations"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:187
+#: lib/block_scout_web/templates/address/overview.html.eex:194
 #, elixir-autogen, elixir-format
 msgid "Locked CELO Balance"
 msgstr ""
@@ -3045,12 +3045,12 @@ msgstr ""
 msgid "Moola"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:213
+#: lib/block_scout_web/templates/address/overview.html.eex:220
 #, elixir-autogen, elixir-format
 msgid "Pending Unlocked Gold"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:238
+#: lib/block_scout_web/templates/address/overview.html.eex:245
 #, elixir-autogen, elixir-format
 msgid "Total amount of epoch rewards this address has received, all time."
 msgstr ""
@@ -3060,7 +3060,7 @@ msgstr ""
 msgid "Uniswap"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:239
+#: lib/block_scout_web/templates/address/overview.html.eex:246
 #, elixir-autogen, elixir-format
 msgid "Validator Rewards | Voting Rewards"
 msgstr ""
@@ -3080,17 +3080,17 @@ msgstr ""
 msgid "cLabs"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:212
+#: lib/block_scout_web/templates/address/overview.html.eex:219
 #, elixir-autogen, elixir-format
 msgid "Amount of CELO that’s in the process of being unlocked (3 days)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:186
+#: lib/block_scout_web/templates/address/overview.html.eex:193
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO in the protocol"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:199
+#: lib/block_scout_web/templates/address/overview.html.eex:206
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO that has been activated to vote for validator(s)"
 msgstr ""
@@ -3117,7 +3117,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:350
+#: lib/block_scout_web/templates/address/overview.html.eex:357
 #, elixir-autogen, elixir-format
 msgid "Number of blocks validated by this validator."
 msgstr ""
@@ -3137,7 +3137,7 @@ msgstr ""
 msgid "View previous block"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:200
+#: lib/block_scout_web/templates/address/overview.html.eex:207
 #, elixir-autogen, elixir-format
 msgid "Voting CELO Balance"
 msgstr ""
@@ -3168,12 +3168,12 @@ msgstr ""
 msgid "Slow"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:160
+#: lib/block_scout_web/templates/address/overview.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Address balance in"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:160
+#: lib/block_scout_web/templates/address/overview.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "doesn't include ERC20, ERC721, ERC1155 tokens)."
 msgstr ""
@@ -3720,7 +3720,7 @@ msgstr ""
 msgid "View previous epoch"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:130
+#: lib/block_scout_web/templates/address/overview.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Contract was precompiled and created at genesis or contract creation transaction is missing"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -210,7 +210,7 @@ msgstr ""
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:250
+#: lib/block_scout_web/templates/address/overview.html.eex:257
 #, elixir-autogen, elixir-format
 msgid "All tokens in the account and total value."
 msgstr ""
@@ -247,7 +247,7 @@ msgid "Back Home"
 msgstr ""
 
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:24
-#: lib/block_scout_web/templates/address/overview.html.eex:161
+#: lib/block_scout_web/templates/address/overview.html.eex:168
 #: lib/block_scout_web/templates/address_token/overview.html.eex:51
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:60
 #, elixir-autogen, elixir-format
@@ -335,7 +335,7 @@ msgstr ""
 msgid "Block number containing the transaction."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:333
+#: lib/block_scout_web/templates/address/overview.html.eex:340
 #, elixir-autogen, elixir-format
 msgid "Block number in which the address was updated."
 msgstr ""
@@ -361,7 +361,7 @@ msgid "Blocks Indexed"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
-#: lib/block_scout_web/templates/address/overview.html.eex:351
+#: lib/block_scout_web/templates/address/overview.html.eex:358
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
 #: lib/block_scout_web/views/address_view.ex:438
 #, elixir-autogen, elixir-format
@@ -373,11 +373,11 @@ msgstr ""
 msgid "Blockscout is a tool for inspecting and analyzing EVM based blockchains. Blockchain explorer for the Celo Network."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:190
-#: lib/block_scout_web/templates/address/overview.html.eex:203
-#: lib/block_scout_web/templates/address/overview.html.eex:216
-#: lib/block_scout_web/templates/address/overview.html.eex:229
-#: lib/block_scout_web/templates/address/overview.html.eex:242
+#: lib/block_scout_web/templates/address/overview.html.eex:197
+#: lib/block_scout_web/templates/address/overview.html.eex:210
+#: lib/block_scout_web/templates/address/overview.html.eex:223
+#: lib/block_scout_web/templates/address/overview.html.eex:236
+#: lib/block_scout_web/templates/address/overview.html.eex:249
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:24
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:23
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:29
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Contract Libraries"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:85
+#: lib/block_scout_web/templates/address/overview.html.eex:92
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_name_field.html.eex:3
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:50
 #, elixir-autogen, elixir-format
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Create2"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:112
+#: lib/block_scout_web/templates/address/overview.html.eex:119
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:130
+#: lib/block_scout_web/templates/address/overview.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Error: Could not determine contract creator."
 msgstr ""
@@ -1113,7 +1113,7 @@ msgstr ""
 msgid "Gas Tracker"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:316
+#: lib/block_scout_web/templates/address/overview.html.eex:323
 #: lib/block_scout_web/templates/block/_tile.html.eex:92
 #: lib/block_scout_web/templates/block/overview.html.eex:250
 #: lib/block_scout_web/templates/block/overview.html.eex:352
@@ -1126,7 +1126,7 @@ msgstr ""
 msgid "Gas Used by Transaction"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:315
+#: lib/block_scout_web/templates/address/overview.html.eex:322
 #, elixir-autogen, elixir-format
 msgid "Gas used by the address."
 msgstr ""
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "If you have just submitted this transaction please wait for at least 30 seconds before refreshing this page."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:143
+#: lib/block_scout_web/templates/address/overview.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Implementation"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "Implementation Name:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:142
+#: lib/block_scout_web/templates/address/overview.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Implementation address of the proxy contract."
 msgstr ""
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "It could still be in the TX Pool of a different node, waiting to be broadcasted."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:334
+#: lib/block_scout_web/templates/address/overview.html.eex:341
 #, elixir-autogen, elixir-format
 msgid "Last Balance Update"
 msgstr ""
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "License ID"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:226
+#: lib/block_scout_web/templates/address/overview.html.eex:233
 #, elixir-autogen, elixir-format
 msgid "Lifetime Voting Rewards"
 msgstr ""
@@ -1548,12 +1548,12 @@ msgstr ""
 msgid "Not unique Token"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:261
+#: lib/block_scout_web/templates/address/overview.html.eex:268
 #, elixir-autogen, elixir-format
 msgid "Number of transactions related to this address."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:288
+#: lib/block_scout_web/templates/address/overview.html.eex:295
 #, elixir-autogen, elixir-format
 msgid "Number of transfers to/from this address."
 msgstr ""
@@ -2016,12 +2016,12 @@ msgstr ""
 msgid "The hash of the block from which this block was generated."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:84
+#: lib/block_scout_web/templates/address/overview.html.eex:91
 #, elixir-autogen, elixir-format
 msgid "The name found in the source code of the Contract."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:95
+#: lib/block_scout_web/templates/address/overview.html.eex:102
 #, elixir-autogen, elixir-format
 msgid "The name of the validator."
 msgstr ""
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:65
+#: lib/block_scout_web/templates/address/overview.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Token"
 msgstr ""
@@ -2308,13 +2308,13 @@ msgstr ""
 msgid "Token Transfers"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:64
+#: lib/block_scout_web/templates/address/overview.html.eex:71
 #, elixir-autogen, elixir-format
 msgid "Token name and symbol."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:21
-#: lib/block_scout_web/templates/address/overview.html.eex:251
+#: lib/block_scout_web/templates/address/overview.html.eex:258
 #: lib/block_scout_web/templates/address_token/overview.html.eex:58
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/tokens/index.html.eex:9
@@ -2449,9 +2449,9 @@ msgid "Transaction type, introduced in EIP-2718."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:262
-#: lib/block_scout_web/templates/address/overview.html.eex:268
-#: lib/block_scout_web/templates/address/overview.html.eex:276
+#: lib/block_scout_web/templates/address/overview.html.eex:269
+#: lib/block_scout_web/templates/address/overview.html.eex:275
+#: lib/block_scout_web/templates/address/overview.html.eex:283
 #: lib/block_scout_web/templates/address_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/block/_tabs.html.eex:4
 #: lib/block_scout_web/templates/block/overview.html.eex:120
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:111
+#: lib/block_scout_web/templates/address/overview.html.eex:118
 #, elixir-autogen, elixir-format
 msgid "Transactions and address of creation."
 msgstr ""
@@ -2472,9 +2472,9 @@ msgstr ""
 msgid "Transactions sent"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:289
-#: lib/block_scout_web/templates/address/overview.html.eex:295
-#: lib/block_scout_web/templates/address/overview.html.eex:303
+#: lib/block_scout_web/templates/address/overview.html.eex:296
+#: lib/block_scout_web/templates/address/overview.html.eex:302
+#: lib/block_scout_web/templates/address/overview.html.eex:310
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:50
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:118
 #, elixir-autogen, elixir-format
@@ -2593,7 +2593,7 @@ msgstr ""
 msgid "Validator Group:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:96
+#: lib/block_scout_web/templates/address/overview.html.eex:103
 #, elixir-autogen, elixir-format
 msgid "Validator Name"
 msgstr ""
@@ -2727,7 +2727,7 @@ msgstr ""
 msgid "Voting Rewards"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:225
+#: lib/block_scout_web/templates/address/overview.html.eex:232
 #, elixir-autogen, elixir-format
 msgid "Voting rewards accumulated over time."
 msgstr ""
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:121
+#: lib/block_scout_web/templates/address/overview.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "at"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "button"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:242
+#: lib/block_scout_web/templates/address/overview.html.eex:249
 #, elixir-autogen, elixir-format
 msgid "cUSD"
 msgstr ""
@@ -2898,19 +2898,19 @@ msgstr "CELO"
 msgid "CRC Worth"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:323
+#: lib/block_scout_web/templates/address/overview.html.eex:330
 #, elixir-autogen, elixir-format
 msgid "Fetching gas used..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:270
-#: lib/block_scout_web/templates/address/overview.html.eex:278
+#: lib/block_scout_web/templates/address/overview.html.eex:277
+#: lib/block_scout_web/templates/address/overview.html.eex:285
 #, elixir-autogen, elixir-format
 msgid "Fetching transactions..."
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:297
-#: lib/block_scout_web/templates/address/overview.html.eex:305
+#: lib/block_scout_web/templates/address/overview.html.eex:304
+#: lib/block_scout_web/templates/address/overview.html.eex:312
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:122
 #, elixir-autogen, elixir-format
 msgid "Fetching transfers..."
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "Attestations"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:187
+#: lib/block_scout_web/templates/address/overview.html.eex:194
 #, elixir-autogen, elixir-format
 msgid "Locked CELO Balance"
 msgstr ""
@@ -3046,12 +3046,12 @@ msgstr ""
 msgid "Moola"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:213
+#: lib/block_scout_web/templates/address/overview.html.eex:220
 #, elixir-autogen, elixir-format
 msgid "Pending Unlocked Gold"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:238
+#: lib/block_scout_web/templates/address/overview.html.eex:245
 #, elixir-autogen, elixir-format
 msgid "Total amount of epoch rewards this address has received, all time."
 msgstr ""
@@ -3061,7 +3061,7 @@ msgstr ""
 msgid "Uniswap"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:239
+#: lib/block_scout_web/templates/address/overview.html.eex:246
 #, elixir-autogen, elixir-format
 msgid "Validator Rewards | Voting Rewards"
 msgstr ""
@@ -3081,17 +3081,17 @@ msgstr ""
 msgid "cLabs"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:212
+#: lib/block_scout_web/templates/address/overview.html.eex:219
 #, elixir-autogen, elixir-format
 msgid "Amount of CELO that’s in the process of being unlocked (3 days)"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:186
+#: lib/block_scout_web/templates/address/overview.html.eex:193
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO in the protocol"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:199
+#: lib/block_scout_web/templates/address/overview.html.eex:206
 #, elixir-autogen, elixir-format
 msgid "Amount of locked CELO that has been activated to vote for validator(s)"
 msgstr ""
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:350
+#: lib/block_scout_web/templates/address/overview.html.eex:357
 #, elixir-autogen, elixir-format
 msgid "Number of blocks validated by this validator."
 msgstr ""
@@ -3138,7 +3138,7 @@ msgstr ""
 msgid "View previous block"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:200
+#: lib/block_scout_web/templates/address/overview.html.eex:207
 #, elixir-autogen, elixir-format
 msgid "Voting CELO Balance"
 msgstr ""
@@ -3169,12 +3169,12 @@ msgstr ""
 msgid "Slow"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:160
+#: lib/block_scout_web/templates/address/overview.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Address balance in"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:160
+#: lib/block_scout_web/templates/address/overview.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "doesn't include ERC20, ERC721, ERC1155 tokens)."
 msgstr ""
@@ -3721,7 +3721,7 @@ msgstr ""
 msgid "View previous epoch"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:130
+#: lib/block_scout_web/templates/address/overview.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Contract was precompiled and created at genesis or contract creation transaction is missing"
 msgstr ""


### PR DESCRIPTION
### Description

Adds a link `View in Celo Safe App` to the address details page for `GnosisSafeProxy` contracts.
Updates the detection logic for that from master copy to singleton according to the latest implementation of the [proxy contract](https://github.com/safe-global/safe-contracts/blob/main/contracts/proxies/GnosisSafeProxy.sol#L20).
Also supports Alfajores.

![image](https://user-images.githubusercontent.com/20768968/212298288-af371b92-6dab-41fc-90e7-0a2fe488b979.png)

The link leads to https://safe.celo.org/mainnet:0x89C097aDffb38644af11E6246B7cd13e1E287e64/transactions/history

 ### Other changes

Adds a convenience function mapping chain ids to Celo chain names.

### Tested

Tested locally.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/608
