### PR TITLE
Small fixes

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -26,7 +26,7 @@
               <%= nil %>
           <% end %>
           <h1 class="card-title lg-card-title mb-2">
-            <div class="title-with-label"><%= address_title(@address) %> <%= gettext "Details" %></div>
+            <div class="title-with-label"><%= gettext "Address Details" %></div>
               <%= if contract?(@address) do %>
                 <%= render BlockScoutWeb.FormView, "_tag.html", text: "contract", additional_classes: ["contract", "ml-1"] %>
                 <%= if @is_proxy do %>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -163,14 +163,6 @@ defmodule BlockScoutWeb.AddressView do
     matching_address_check(current_address, address, false, truncate)
   end
 
-  def address_title(%Address{} = address) do
-    if contract?(address) do
-      gettext("Contract Address")
-    else
-      gettext("Address")
-    end
-  end
-
   @doc """
   Returns a formatted address balance and includes the unit.
   """

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -163,7 +163,6 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:20
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:42
-#: lib/block_scout_web/views/address_view.ex:170
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -362,7 +361,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
 #: lib/block_scout_web/templates/address/overview.html.eex:358
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:443
+#: lib/block_scout_web/views/address_view.ex:435
 #, elixir-autogen, elixir-format
 msgid "Blocks Validated"
 msgstr ""
@@ -453,13 +452,13 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:436
+#: lib/block_scout_web/views/address_view.ex:428
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:442
+#: lib/block_scout_web/views/address_view.ex:434
 #, elixir-autogen, elixir-format
 msgid "Coin Balance History"
 msgstr ""
@@ -567,7 +566,6 @@ msgstr ""
 #: lib/block_scout_web/templates/account/custom_abi/form.html.eex:18
 #: lib/block_scout_web/templates/account/custom_abi/index.html.eex:29
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex:4
-#: lib/block_scout_web/views/address_view.ex:168
 #, elixir-autogen, elixir-format
 msgid "Contract Address"
 msgstr ""
@@ -829,7 +827,7 @@ msgstr ""
 msgid "Decoded"
 msgstr ""
 
-#: lib/block_scout_web/views/address_view.ex:437
+#: lib/block_scout_web/views/address_view.ex:429
 #, elixir-autogen, elixir-format
 msgid "Decompiled Code"
 msgstr ""
@@ -868,7 +866,6 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:29
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:166
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:127
 #, elixir-autogen, elixir-format
@@ -1245,7 +1242,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:433
+#: lib/block_scout_web/views/address_view.ex:425
 #: lib/block_scout_web/views/transaction_view.ex:530
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
@@ -1366,7 +1363,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:444
+#: lib/block_scout_web/views/address_view.ex:436
 #: lib/block_scout_web/views/transaction_view.ex:531
 #, elixir-autogen, elixir-format
 msgid "Logs"
@@ -1380,7 +1377,7 @@ msgstr ""
 #: lib/block_scout_web/templates/chain/show.html.eex:51
 #: lib/block_scout_web/templates/layout/app.html.eex:45
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:83
-#: lib/block_scout_web/views/address_view.ex:208
+#: lib/block_scout_web/views/address_view.ex:200
 #, elixir-autogen, elixir-format
 msgid "Market Cap"
 msgstr ""
@@ -1729,7 +1726,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:105
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:27
-#: lib/block_scout_web/views/address_view.ex:438
+#: lib/block_scout_web/views/address_view.ex:430
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #, elixir-autogen, elixir-format
 msgid "Read Contract"
@@ -1737,7 +1734,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:112
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:41
-#: lib/block_scout_web/views/address_view.ex:439
+#: lib/block_scout_web/views/address_view.ex:431
 #, elixir-autogen, elixir-format
 msgid "Read Proxy"
 msgstr ""
@@ -2300,7 +2297,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:435
+#: lib/block_scout_web/views/address_view.ex:427
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:197
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:529
@@ -2318,7 +2315,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token/overview.html.eex:58
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/tokens/index.html.eex:9
-#: lib/block_scout_web/views/address_view.ex:432
+#: lib/block_scout_web/views/address_view.ex:424
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""
@@ -2457,7 +2454,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/overview.html.eex:120
 #: lib/block_scout_web/templates/chain/show.html.eex:210
 #: lib/block_scout_web/templates/stats/index.html.eex:32
-#: lib/block_scout_web/views/address_view.ex:434
+#: lib/block_scout_web/views/address_view.ex:426
 #, elixir-autogen, elixir-format
 msgid "Transactions"
 msgstr ""
@@ -2769,14 +2766,14 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:119
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:440
+#: lib/block_scout_web/views/address_view.ex:432
 #, elixir-autogen, elixir-format
 msgid "Write Contract"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:126
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:48
-#: lib/block_scout_web/views/address_view.ex:441
+#: lib/block_scout_web/views/address_view.ex:433
 #, elixir-autogen, elixir-format
 msgid "Write Proxy"
 msgstr ""
@@ -3739,4 +3736,9 @@ msgstr ""
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:116
 #, elixir-autogen, elixir-format
 msgid "Delegating Validator:"
+msgstr ""
+
+#: lib/block_scout_web/templates/address/overview.html.eex:29
+#, elixir-autogen, elixir-format
+msgid "Address Details"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -164,7 +164,6 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:20
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:42
-#: lib/block_scout_web/views/address_view.ex:170
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -363,7 +362,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
 #: lib/block_scout_web/templates/address/overview.html.eex:358
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:443
+#: lib/block_scout_web/views/address_view.ex:435
 #, elixir-autogen, elixir-format
 msgid "Blocks Validated"
 msgstr ""
@@ -454,13 +453,13 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:436
+#: lib/block_scout_web/views/address_view.ex:428
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:442
+#: lib/block_scout_web/views/address_view.ex:434
 #, elixir-autogen, elixir-format
 msgid "Coin Balance History"
 msgstr ""
@@ -568,7 +567,6 @@ msgstr ""
 #: lib/block_scout_web/templates/account/custom_abi/form.html.eex:18
 #: lib/block_scout_web/templates/account/custom_abi/index.html.eex:29
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex:4
-#: lib/block_scout_web/views/address_view.ex:168
 #, elixir-autogen, elixir-format
 msgid "Contract Address"
 msgstr ""
@@ -830,7 +828,7 @@ msgstr ""
 msgid "Decoded"
 msgstr ""
 
-#: lib/block_scout_web/views/address_view.ex:437
+#: lib/block_scout_web/views/address_view.ex:429
 #, elixir-autogen, elixir-format
 msgid "Decompiled Code"
 msgstr ""
@@ -869,7 +867,6 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/block_scout_web/templates/address/overview.html.eex:29
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:166
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:127
 #, elixir-autogen, elixir-format
@@ -1246,7 +1243,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:433
+#: lib/block_scout_web/views/address_view.ex:425
 #: lib/block_scout_web/views/transaction_view.ex:530
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
@@ -1367,7 +1364,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:444
+#: lib/block_scout_web/views/address_view.ex:436
 #: lib/block_scout_web/views/transaction_view.ex:531
 #, elixir-autogen, elixir-format
 msgid "Logs"
@@ -1381,7 +1378,7 @@ msgstr ""
 #: lib/block_scout_web/templates/chain/show.html.eex:51
 #: lib/block_scout_web/templates/layout/app.html.eex:45
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:83
-#: lib/block_scout_web/views/address_view.ex:208
+#: lib/block_scout_web/views/address_view.ex:200
 #, elixir-autogen, elixir-format
 msgid "Market Cap"
 msgstr ""
@@ -1730,7 +1727,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:105
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:27
-#: lib/block_scout_web/views/address_view.ex:438
+#: lib/block_scout_web/views/address_view.ex:430
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #, elixir-autogen, elixir-format
 msgid "Read Contract"
@@ -1738,7 +1735,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:112
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:41
-#: lib/block_scout_web/views/address_view.ex:439
+#: lib/block_scout_web/views/address_view.ex:431
 #, elixir-autogen, elixir-format
 msgid "Read Proxy"
 msgstr ""
@@ -2301,7 +2298,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:435
+#: lib/block_scout_web/views/address_view.ex:427
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:197
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:529
@@ -2319,7 +2316,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token/overview.html.eex:58
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/tokens/index.html.eex:9
-#: lib/block_scout_web/views/address_view.ex:432
+#: lib/block_scout_web/views/address_view.ex:424
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""
@@ -2458,7 +2455,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/overview.html.eex:120
 #: lib/block_scout_web/templates/chain/show.html.eex:210
 #: lib/block_scout_web/templates/stats/index.html.eex:32
-#: lib/block_scout_web/views/address_view.ex:434
+#: lib/block_scout_web/views/address_view.ex:426
 #, elixir-autogen, elixir-format
 msgid "Transactions"
 msgstr ""
@@ -2770,14 +2767,14 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:119
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:440
+#: lib/block_scout_web/views/address_view.ex:432
 #, elixir-autogen, elixir-format
 msgid "Write Contract"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:126
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:48
-#: lib/block_scout_web/views/address_view.ex:441
+#: lib/block_scout_web/views/address_view.ex:433
 #, elixir-autogen, elixir-format
 msgid "Write Proxy"
 msgstr ""
@@ -3740,4 +3737,9 @@ msgstr ""
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:116
 #, elixir-autogen, elixir-format
 msgid "Delegating Validator:"
+msgstr ""
+
+#: lib/block_scout_web/templates/address/overview.html.eex:29
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Address Details"
 msgstr ""

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -99,6 +99,7 @@ config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: :ti
 config :explorer, Explorer.Tags.AddressTag.Cataloger, enabled: true
 
 config :explorer, Explorer.Chain.Cache.MinMissingBlockNumber, enabled: System.get_env("DISABLE_WRITE_API") != "true"
+config :explorer, Explorer.Tags.AddressTag.Cataloger, enabled: System.get_env("DISABLE_WRITE_API") != "true"
 
 config :explorer, :write_api_enabled, System.get_env("DISABLE_WRITE_API") != "true"
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -22,8 +22,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   use BufferedTask
 
-  @max_batch_size 8
-  @max_concurrency 10
+  @max_batch_size 3
+  @max_concurrency 20
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),


### PR DESCRIPTION
### Description

It does three things:
- disables the address tag cataloger for pods working with replicas
- updates concurrency settings for internal TXs
- removed the word "Contract" from the address details label in favor of tags `EOA` / `contract`

### Tested

Tested locally.