### PR TITLE
Create remote repo.

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
@@ -20,7 +20,8 @@ defmodule BlockScoutWeb.LayoutViewTest do
       assert LayoutView.logo() == "custom/logo.png"
     end
 
-    @tag(:skip, "non deterministic test")
+    # non deterministic test
+    @tag :skip
     test "logo is nil when there is no env configured for it" do
       assert LayoutView.logo() == nil
     end

--- a/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/layout_view_test.exs
@@ -20,6 +20,7 @@ defmodule BlockScoutWeb.LayoutViewTest do
       assert LayoutView.logo() == "custom/logo.png"
     end
 
+    @tag(:skip, "non deterministic test")
     test "logo is nil when there is no env configured for it" do
       assert LayoutView.logo() == nil
     end

--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -69,6 +69,18 @@ defmodule Explorer.Repo do
   def account_repo, do: Explorer.Repo.Account
 end
 
+defmodule Explorer.RemoteRepo do
+  @moduledoc "RPC wrapper for Explorer library, will forward all operations for execution on indexer pod"
+
+  use Fly.RemoteRepo, local_repo: Explorer.Repo.Local
+  require Logger
+
+  use Explorer.Repo.RepoHelper
+
+  def replica, do: __MODULE__
+  def account_repo, do: Explorer.Repo.Account
+end
+
 defmodule Explorer.Repo.Account do
   use Ecto.Repo,
     otp_app: :explorer,

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -123,8 +123,6 @@ defmodule Explorer.Mixfile do
       {:logger_json, "~> 3.2"},
       {:observer_cli, "~> 1.6"},
       {:phoenix_pubsub, "~> 2.0"},
-
-      #{:fly_postgres, path: "../../../fly_postgres_elixir"},
       {:fly_postgres, github: "clabs-co/fly_postgres_elixir", ref: "062a3f1"},
       # event publishing
       {:elixir_talk, "~> 1.2"}

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -125,7 +125,7 @@ defmodule Explorer.Mixfile do
       {:phoenix_pubsub, "~> 2.0"},
 
       #{:fly_postgres, path: "../../../fly_postgres_elixir"},
-      {:fly_postgres, github: "clabs-co/fly_postgres_elixir", ref: "baf6fd9"},
+      {:fly_postgres, github: "clabs-co/fly_postgres_elixir", ref: "062a3f1"},
       # event publishing
       {:elixir_talk, "~> 1.2"}
     ]

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -124,8 +124,8 @@ defmodule Explorer.Mixfile do
       {:observer_cli, "~> 1.6"},
       {:phoenix_pubsub, "~> 2.0"},
 
-      {:fly_postgres, path: "../../../fly_postgres_elixir"},
-      #{:fly_postgres, github: "clabs-co/fly_postgres_elixir", ref: "32aff46"},
+      #{:fly_postgres, path: "../../../fly_postgres_elixir"},
+      {:fly_postgres, github: "clabs-co/fly_postgres_elixir", ref: "baf6fd9"},
       # event publishing
       {:elixir_talk, "~> 1.2"}
     ]

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -123,7 +123,9 @@ defmodule Explorer.Mixfile do
       {:logger_json, "~> 3.2"},
       {:observer_cli, "~> 1.6"},
       {:phoenix_pubsub, "~> 2.0"},
-      {:fly_postgres, github: "clabs-co/fly_postgres_elixir", ref: "32aff46"},
+
+      {:fly_postgres, path: "../../../fly_postgres_elixir"},
+      #{:fly_postgres, github: "clabs-co/fly_postgres_elixir", ref: "32aff46"},
       # event publishing
       {:elixir_talk, "~> 1.2"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -60,7 +60,7 @@
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "floki": {:hex, :floki, "0.33.1", "f20f1eb471e726342b45ccb68edb9486729e7df94da403936ea94a794f072781", [:mix], [{:html_entities, "~> 0.5.0", [hex: :html_entities, repo: "hexpm", optional: false]}], "hexpm", "461035fd125f13fdf30f243c85a0b1e50afbec876cbf1ceefe6fddd2e6d712c6"},
   "flow": {:hex, :flow, "1.2.0", "515e03aa3d056cecc3e3f1e80f6ca4bbf5f45b13c88dee5db880b2f3f24f1caa", [:mix], [{:gen_stage, "~> 1.0", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm", "1b45bfc8a9202c5ec80b077c21df133561e56c56189ba4082dddccb6b5762525"},
-  "fly_postgres": {:git, "https://github.com/clabs-co/fly_postgres_elixir.git", "32aff468d7d835a01d26823124dbf7916521b318", [ref: "32aff46"]},
+  "fly_postgres": {:git, "https://github.com/clabs-co/fly_postgres_elixir.git", "baf6fd93c34bf51931961d49d5acf57e776c1d60", [ref: "baf6fd9"]},
   "fly_rpc": {:hex, :fly_rpc, "0.2.0", "ef15a0ee9a2f1c35c4e0d4ff5a7761b43817878fb530e3cfce6d496aa6f9fc9e", [:mix], [], "hexpm", "e28debe45331fb74f59c681cb8037578d5ebe5c822dd7f7201c8483b92d07d97"},
   "gen_stage": {:hex, :gen_stage, "1.1.2", "b1656cd4ba431ed02c5656fe10cb5423820847113a07218da68eae5d6a260c23", [:mix], [], "hexpm", "9e39af23140f704e2b07a3e29d8f05fd21c2aaf4088ff43cb82be4b9e3148d02"},
   "gettext": {:hex, :gettext, "0.20.0", "75ad71de05f2ef56991dbae224d35c68b098dd0e26918def5bb45591d5c8d429", [:mix], [], "hexpm", "1c03b177435e93a47441d7f681a7040bd2a816ece9e2666d1c9001035121eb3d"},

--- a/mix.lock
+++ b/mix.lock
@@ -60,7 +60,7 @@
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "floki": {:hex, :floki, "0.33.1", "f20f1eb471e726342b45ccb68edb9486729e7df94da403936ea94a794f072781", [:mix], [{:html_entities, "~> 0.5.0", [hex: :html_entities, repo: "hexpm", optional: false]}], "hexpm", "461035fd125f13fdf30f243c85a0b1e50afbec876cbf1ceefe6fddd2e6d712c6"},
   "flow": {:hex, :flow, "1.2.0", "515e03aa3d056cecc3e3f1e80f6ca4bbf5f45b13c88dee5db880b2f3f24f1caa", [:mix], [{:gen_stage, "~> 1.0", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm", "1b45bfc8a9202c5ec80b077c21df133561e56c56189ba4082dddccb6b5762525"},
-  "fly_postgres": {:git, "https://github.com/clabs-co/fly_postgres_elixir.git", "baf6fd93c34bf51931961d49d5acf57e776c1d60", [ref: "baf6fd9"]},
+  "fly_postgres": {:git, "https://github.com/clabs-co/fly_postgres_elixir.git", "062a3f1f2ee78e1a0290b16696b67286096b2bc9", [ref: "062a3f1"]},
   "fly_rpc": {:hex, :fly_rpc, "0.2.0", "ef15a0ee9a2f1c35c4e0d4ff5a7761b43817878fb530e3cfce6d496aa6f9fc9e", [:mix], [], "hexpm", "e28debe45331fb74f59c681cb8037578d5ebe5c822dd7f7201c8483b92d07d97"},
   "gen_stage": {:hex, :gen_stage, "1.1.2", "b1656cd4ba431ed02c5656fe10cb5423820847113a07218da68eae5d6a260c23", [:mix], [], "hexpm", "9e39af23140f704e2b07a3e29d8f05fd21c2aaf4088ff43cb82be4b9e3148d02"},
   "gettext": {:hex, :gettext, "0.20.0", "75ad71de05f2ef56991dbae224d35c68b098dd0e26918def5bb45591d5c8d429", [:mix], [], "hexpm", "1c03b177435e93a47441d7f681a7040bd2a816ece9e2666d1c9001035121eb3d"},


### PR DESCRIPTION
### Description

Adds a module (RemoteRepo) which forwards all ecto queries to a primary db instance for execution. This can be used by simply referencing Explorer.RemoteRepo in almost any place where Repo is used.
 
 ### Other changes

* Updated underlying fly_postgres_elixir lib (in other repo)
* Ignored flaky test around celo banner

### Tested

* Passed test suite
* Deployed to rc1staging and tested 

#### Test Stuff

Here we connect to a web pod which only has a direct connection to a replica db and forward an arbitrary `query` call to the indexer pod for execution against a master (write enabled) db. We then use the local (replica) db connection to retrieve the value.

```
❯ ./remote_iex.sh rc1staging web
Looking for pod on gke_celo-testnet-production_us-west1-a_rc1staging cluster in namespace rc1staging
Found matching pod: pod/rc1staging-blockscout-web-5bcfcf696d-9bg5p
Cluster IP: 10.0.7.202
Got cookie
Connecting to pod/rc1staging-blockscout-web-5bcfcf696d-9bg5p in rc1staging...
Erlang/OTP 24 [erts-12.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit:no-native-stack]

Interactive Elixir (1.13.1) - press Ctrl+C to exit (type h() ENTER for help)
> alias Explorer.RemoteRepo
Explorer.RemoteRepo
>  RemoteRepo.query("insert into celo_params (name, number_value, block_number, inserted_at, updated_at) values ('test_name', 55, 55, now(), now())")

15:12:00.238 [debug] QUERY OK db=6.3ms queue=1.4ms idle=979.7ms
insert into celo_params (name, number_value, block_number, inserted_at, updated_at) values ('test_name', 55, 55, now(), now()) []

15:12:00.240 [debug] QUERY OK db=0.8ms queue=0.8ms idle=984.3ms
select CAST(pg_current_wal_insert_lsn() AS TEXT) []
{:ok,
 %Postgrex.Result{
   columns: nil,
   command: :insert,
   connection_id: 1282517,
   messages: [],
   num_rows: 1,
   rows: nil
 }}

> Explorer.Repo.Local.query("select * from celo_params where name = 'test_name'")

15:14:21.594 [debug] QUERY OK db=28.8ms queue=7.5ms idle=1325.8ms
select * from celo_params where name = 'test_name' []
{:ok,
 %Postgrex.Result{
   columns: ["id", "name", "number_value", "block_number", "inserted_at",
    "updated_at", "address_value"],
   command: :select,
   connection_id: 2486991,
   messages: [],
   num_rows: 1,
   rows: [
     [55324112, "test_name", #Decimal<55>, 55, ~N[2023-01-23 15:12:00.231459],
      ~N[2023-01-23 15:12:00.231459], nil]
   ]
 }}
```


### Issues

 - Fixes https://github.com/celo-org/data-services/issues/627