### PR TITLE
Reduce max concurrency + increase batch size.

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -22,8 +22,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   use BufferedTask
 
-  @max_batch_size 3
-  @max_concurrency 20
+  @max_batch_size 8
+  @max_concurrency 8
   @defaults [
     flush_interval: :timer.seconds(3),
     poll_interval: :timer.seconds(3),


### PR DESCRIPTION
### Description

The past week has resulted in a lot of incidents around itx fetching x locks on the database table. This didn't occur over christmas, so let's revert to settings close to what was there.
 
 ### Other changes

* n/a

### Tested

* values are currently set live on rc11 (will not survive a restart)

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/637
