### PR TITLE
Add more metrics to the app

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -133,6 +133,8 @@ config :block_scout_web, :rpc_module_map, %{
   "epoch" => {BlockScoutWeb.API.RPC.EpochController, []}
 }
 
+config :block_scout_web, BlockScoutWeb.Celo.MetricsCron, metrics_cron_interval_seconds: 10
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -61,11 +61,13 @@ defmodule BlockScoutWeb.Application do
   end
 
   def metrics_processes(sibling_processes) do
-    sibling_processes ++ [
-      {MetricsCron, [[]]},
-      {Task.Supervisor, name: BlockScoutWeb.Celo.MetricsCron.TaskSupervisor}
-    ]
+    sibling_processes ++
+      [
+        {MetricsCron, [[]]},
+        {Task.Supervisor, name: BlockScoutWeb.Celo.MetricsCron.TaskSupervisor}
+      ]
   end
+
   def cluster_process(acc, :prod) do
     topologies = Application.get_env(:libcluster, :topologies)
 

--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.Application do
   alias BlockScoutWeb.{Endpoint, RealtimeEventHandler}
 
   alias EthereumJSONRPC.Celo.Instrumentation, as: EthRPC
-  alias Explorer.Celo.Telemetry.Instrumentation.FlyPostgres
+  alias Explorer.Celo.Telemetry.Instrumentation.{Database, FlyPostgres}
   alias Explorer.Celo.Telemetry.MetricsCollector, as: CeloPrometheusCollector
 
   def start(_type, _args) do
@@ -40,7 +40,7 @@ defmodule BlockScoutWeb.Application do
         {Phoenix.PubSub, name: BlockScoutWeb.PubSub},
         child_spec(Endpoint, []),
         {Absinthe.Subscription, Endpoint},
-        {CeloPrometheusCollector, metrics: [EthRPC.metrics(), FlyPostgres.metrics()]},
+        {CeloPrometheusCollector, metrics: [EthRPC.metrics(), Database.metrics(), FlyPostgres.metrics()]},
         {RealtimeEventHandler, name: RealtimeEventHandler},
         {BlocksIndexedCounter, name: BlocksIndexedCounter},
         {CampaignBannerCache, name: CampaignBannerCache}

--- a/apps/block_scout_web/lib/block_scout_web/celo/metrics_cron.ex
+++ b/apps/block_scout_web/lib/block_scout_web/celo/metrics_cron.ex
@@ -1,0 +1,72 @@
+defmodule BlockScoutWeb.Celo.MetricsCron do
+  @moduledoc "Periodic metrics tasks"
+
+  require Logger
+  use GenServer
+
+  alias BlockScoutWeb.Celo.MetricsCron.TaskSupervisor
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    repeat()
+    {:ok, %{running_operations: []}}
+  end
+
+  defp config(key) do
+    Application.get_env(:block_scout_web, __MODULE__, [])[key]
+  end
+
+  defp repeat do
+    interval = config(:metrics_cron_interval_seconds)
+    Process.send_after(self(), :import_and_reschedule, :timer.seconds(interval))
+  end
+
+  @metric_operations [
+    :dummy_log
+  ]
+
+  @impl true
+  def handle_info(:import_and_reschedule, %{running_operations: running} = state) do
+    unless running == [] do
+      Logger.info("MetricsCron scheduled, tasks still running: #{Enum.join(running, ",")}")
+    end
+
+    running_operations =
+      @metric_operations
+      |> Enum.filter(&(!Enum.member?(running, &1)))
+      |> Enum.map(fn operation ->
+        Task.Supervisor.async_nolink(TaskSupervisor, fn ->
+          apply(__MODULE__, operation, [])
+          {:completed, operation}
+        end)
+
+        operation
+      end)
+
+    repeat()
+
+    {:noreply, %{state | running_operations: running_operations}}
+  end
+
+  @impl true
+  def handle_info({_task_ref, {:completed, operation}}, %{running_operations: ops} = state) do
+    {:noreply, %{state | running_operations: List.delete(ops, operation)}}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _, _, _, :normal}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:DOWN, _, _, _, failure_message}, state) do
+    Logger.error("MetricsCron task received an error: #{failure_message |> inspect()}")
+    {:noreply, state}
+  end
+
+  def dummy_log do
+    Logger.info("Hello I have been invoked")
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/celo/metrics_cron.ex
+++ b/apps/block_scout_web/lib/block_scout_web/celo/metrics_cron.ex
@@ -5,8 +5,8 @@ defmodule BlockScoutWeb.Celo.MetricsCron do
   use GenServer
 
   alias BlockScoutWeb.Celo.MetricsCron.TaskSupervisor
+  alias Explorer.Celo.Metrics.DatabaseMetrics
   alias Explorer.Celo.Telemetry
-  alias Explorer.Celo.Telemetry.Instrumentation.Database
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -70,17 +70,17 @@ defmodule BlockScoutWeb.Celo.MetricsCron do
 
   def database_stats do
     number_of_locks = DatabaseMetrics.fetch_number_of_locks()
-    Telemetry.event([:db, :locks],  %{value: number_of_locks})
+    Telemetry.event([:db, :locks], %{value: number_of_locks})
 
     number_of_dead_locks = DatabaseMetrics.fetch_number_of_dead_locks()
-    Telemetry.event([:db, :deadlocks],  %{value: number_of_dead_locks})
+    Telemetry.event([:db, :deadlocks], %{value: number_of_dead_locks})
 
     longest_query_duration = DatabaseMetrics.fetch_name_and_duration_of_longest_query()
-    Telemetry.event([:db, :longest_query_duration],  %{value: longest_query_duration})
+    Telemetry.event([:db, :longest_query_duration], %{value: longest_query_duration})
 
     tables_by_size = DatabaseMetrics.fetch_top_10_tables_by_size()
 
     tables_by_size
-    |> Enum.each(fn {name, size} -> Telemetry.event([:db, :table_size], %{size: size}, %{name: name})  end)
+    |> Enum.each(fn {name, size} -> Telemetry.event([:db, :table_size], %{size: size}, %{name: name}) end)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/celo/metrics_cron.ex
+++ b/apps/block_scout_web/lib/block_scout_web/celo/metrics_cron.ex
@@ -77,5 +77,10 @@ defmodule BlockScoutWeb.Celo.MetricsCron do
 
     longest_query_duration = DatabaseMetrics.fetch_name_and_duration_of_longest_query()
     Telemetry.event([:db, :longest_query_duration],  %{value: longest_query_duration})
+
+    tables_by_size = DatabaseMetrics.fetch_top_10_tables_by_size()
+
+    tables_by_size
+    |> Enum.each(fn {name, size} -> Telemetry.event([:db, :table_size], %{size: size}, %{name: name})  end)
   end
 end

--- a/apps/explorer/lib/explorer/celo/metrics/database_metrics.ex
+++ b/apps/explorer/lib/explorer/celo/metrics/database_metrics.ex
@@ -82,4 +82,17 @@ defmodule Explorer.Celo.Metrics.DatabaseMetrics do
 
     result |> Enum.into(%{}, fn [count, app] -> {app, count} end)
   end
+
+  @doc "Returns a map of the top 10 largest table names by size"
+  def fetch_top_10_tables_by_size do
+    query = """
+      select table_name, pg_relation_size(quote_ident(table_name))
+      from information_schema.tables
+      where table_schema = 'public'
+      order by 2 desc limit 10;
+    """
+
+    {:ok, %{rows: result}} = SQL.query(Repo, query)
+    result |> Enum.into(%{}, fn [name, size] -> {name, size} end)
+  end
 end

--- a/apps/explorer/lib/explorer/celo/metrics/database_metrics.ex
+++ b/apps/explorer/lib/explorer/celo/metrics/database_metrics.ex
@@ -85,14 +85,14 @@ defmodule Explorer.Celo.Metrics.DatabaseMetrics do
 
   @doc "Returns a map of the top 10 largest table names by size"
   def fetch_top_10_tables_by_size do
-    query = """
-      select table_name, pg_relation_size(quote_ident(table_name))
-      from information_schema.tables
-      where table_schema = 'public'
-      order by 2 desc limit 10;
-    """
+    {:ok, %{rows: result}} =
+      SQL.query(Repo, """
+        select table_name, pg_relation_size(quote_ident(table_name))
+        from information_schema.tables
+        where table_schema = 'public'
+        order by 2 desc limit 10;
+      """)
 
-    {:ok, %{rows: result}} = SQL.query(Repo, query)
     result |> Enum.into(%{}, fn [name, size] -> {name, size} end)
   end
 end

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
@@ -5,20 +5,21 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Database do
   use Instrumentation
 
   def metrics do
-    # referencing indexer + `_current` suffix for backwards compatibility
+    # todo: currently referencing indexer + `_current` suffix for backwards compatibility, this should be removed after
+    # new dashboards are made
     [
       last_value("indexer_db_deadlocks_current",
-        event_name: [:indexer, :db, :deadlocks],
+        event_name: [:blockscout, :db, :deadlocks],
         measurement: :value,
         description: "Number of deadlocks on the db as reported by pg_stat_database (cumulative)"
       ),
       last_value("indexer_db_locks_current",
-        event_name: [:indexer, :db, :locks],
+        event_name: [:blockscout, :db, :locks],
         measurement: :value,
         description: "Number of locks held on relations in the current database"
       ),
       last_value("indexer_db_longest_query_duration_current",
-        event_name: [:indexer, :db, :longest_query_duration],
+        event_name: [:blockscout, :db, :longest_query_duration],
         measurement: :value,
         description: "Age of longest running query"
       ),
@@ -27,7 +28,29 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Database do
         measurement: :count,
         tags: [:app],
         description: "Connections to the current database by app name"
-      )
+      ),
+
+      last_value("db_deadlocks_current",
+        event_name: [:blockscout, :db, :deadlocks],
+        measurement: :value,
+        description: "Number of deadlocks on the db as reported by pg_stat_database (cumulative)"
+      ),
+      last_value("db_locks_current",
+        event_name: [:blockscout, :db, :locks],
+        measurement: :value,
+        description: "Number of locks held on relations in the current database"
+      ),
+      last_value("db_longest_query_duration_current",
+        event_name: [:blockscout, :db, :longest_query_duration],
+        measurement: :value,
+        description: "Age of longest running query"
+      ),
+      last_value("db_connections_count",
+        event_name: [:blockscout, :db, :connections],
+        measurement: :count,
+        tags: [:app],
+        description: "Connections to the current database by app name"
+      ),
     ]
   end
 end

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
@@ -5,8 +5,8 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Database do
   use Instrumentation
 
   def metrics do
-    # todo: currently referencing indexer + `_current` suffix for backwards compatibility, this should be removed after
-    # new dashboards are made
+    # currently referencing indexer + `_current` suffix for backwards compatibility, this should be removed after
+    # new dashboards are made that reference the new metric names
     [
       last_value("indexer_db_deadlocks_current",
         event_name: [:blockscout, :db, :deadlocks],

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
@@ -29,7 +29,6 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Database do
         tags: [:app],
         description: "Connections to the current database by app name"
       ),
-
       last_value("db_deadlocks_current",
         event_name: [:blockscout, :db, :deadlocks],
         measurement: :value,
@@ -51,13 +50,12 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Database do
         tags: [:app],
         description: "Connections to the current database by app name"
       ),
-
       last_value("db_table_size_current",
         event_name: [:blockscout, :db, :table_size],
         measurement: :size,
         tags: [:name],
-        description: "Largest tables by size"
-      ),
+        description: "Largest tables by size in bytes"
+      )
     ]
   end
 end

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/third_party/database.ex
@@ -51,6 +51,13 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Database do
         tags: [:app],
         description: "Connections to the current database by app name"
       ),
+
+      last_value("db_table_size_current",
+        event_name: [:blockscout, :db, :table_size],
+        measurement: :size,
+        tags: [:name],
+        description: "Largest tables by size"
+      ),
     ]
   end
 end

--- a/apps/explorer/lib/explorer/chain/events/pubsub_source.ex
+++ b/apps/explorer/lib/explorer/chain/events/pubsub_source.ex
@@ -19,6 +19,7 @@ defmodule Explorer.Chain.Events.PubSubSource do
     |> tap(fn
       {:chain_event, type, _broadcast_type, _event_data} ->
         Telemetry.event(:chain_event_receive, %{type: type, payload_size: byte_size(payload)})
+
       {:chain_event, type} ->
         Telemetry.event(:chain_event_receive, %{type: type})
     end)

--- a/apps/explorer/lib/explorer/chain/events/pubsub_source.ex
+++ b/apps/explorer/lib/explorer/chain/events/pubsub_source.ex
@@ -16,8 +16,11 @@ defmodule Explorer.Chain.Events.PubSubSource do
   def handle_source_msg({:chain_event, payload}) do
     payload
     |> decode_payload!()
-    |> tap(fn {:chain_event, type, _broadcast_type, _event_data} ->
-      Telemetry.event(:chain_event_receive, %{type: type, payload_size: byte_size(payload)})
+    |> tap(fn
+      {:chain_event, type, _broadcast_type, _event_data} ->
+        Telemetry.event(:chain_event_receive, %{type: type, payload_size: byte_size(payload)})
+      {:chain_event, type} ->
+        Telemetry.event(:chain_event_receive, %{type: type})
     end)
   end
 

--- a/apps/indexer/lib/indexer/celo/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/celo/metrics_cron.ex
@@ -3,6 +3,7 @@ defmodule Indexer.Celo.MetricsCron do
   Periodically retrieves and updates prometheus metrics
   """
   use GenServer
+  alias Indexer.BufferedTask
   alias Explorer.Celo.Metrics.{BlockchainMetrics, DatabaseMetrics}
   alias Explorer.Celo.Telemetry
   alias Explorer.Chain
@@ -166,8 +167,8 @@ defmodule Indexer.Celo.MetricsCron do
         Logger.error("Couldn't get config values for fetcher #{fetcher_module} - no pid")
 
       {fetcher_module, fetcher_process_id} ->
-        max_concurrency = fetcher_process_id |> Indexer.BufferedTask.get_state(:max_concurrency)
-        batch_size = fetcher_process_id |> Indexer.BufferedTask.get_state(:max_batch_size)
+        max_concurrency = fetcher_process_id |> BufferedTask.get_state(:max_concurrency)
+        batch_size = fetcher_process_id |> BufferedTask.get_state(:max_batch_size)
 
         Telemetry.event([:fetcher, :config], %{concurrency: max_concurrency, batch_size: batch_size}, %{
           fetcher: fetcher_module

--- a/apps/indexer/lib/indexer/celo/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/celo/metrics_cron.ex
@@ -40,7 +40,7 @@ defmodule Indexer.Celo.MetricsCron do
     :address_count,
     :total_token_supply,
     :db_connections_by_app,
-    :itx_fetcher_config
+    :fetcher_config
   ]
 
   @impl true

--- a/apps/indexer/lib/indexer/celo/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/celo/metrics_cron.ex
@@ -96,17 +96,17 @@ defmodule Indexer.Celo.MetricsCron do
 
   def number_of_locks do
     number_of_locks = DatabaseMetrics.fetch_number_of_locks()
-    Telemetry.event([:db, :locks],  %{value: number_of_locks})
+    Telemetry.event([:db, :locks], %{value: number_of_locks})
   end
 
   def number_of_deadlocks do
     number_of_dead_locks = DatabaseMetrics.fetch_number_of_dead_locks()
-    Telemetry.event([:db, :deadlocks],  %{value: number_of_dead_locks})
+    Telemetry.event([:db, :deadlocks], %{value: number_of_dead_locks})
   end
 
   def longest_query_duration do
     longest_query_duration = DatabaseMetrics.fetch_name_and_duration_of_longest_query()
-    Telemetry.event([:db, :longest_query_duration],  %{value: longest_query_duration})
+    Telemetry.event([:db, :longest_query_duration], %{value: longest_query_duration})
   end
 
   def transaction_count do
@@ -157,19 +157,21 @@ defmodule Indexer.Celo.MetricsCron do
     end)
   end
 
-
   @fetchers [Indexer.Fetcher.InternalTransaction]
   def fetcher_config do
     @fetchers
-    |> Enum.map(&({to_string(&1), Process.whereis(&1)}))
+    |> Enum.map(&{to_string(&1), Process.whereis(&1)})
     |> Enum.each(fn
       {fetcher_module, nil} ->
         Logger.error("Couldn't get config values for fetcher #{fetcher_module} - no pid")
+
       {fetcher_module, fetcher_process_id} ->
         max_concurrency = fetcher_process_id |> Indexer.BufferedTask.get_state(:max_concurrency)
         batch_size = fetcher_process_id |> Indexer.BufferedTask.get_state(:max_batch_size)
 
-        Telemetry.event([:fetcher, :config], %{concurrency: max_concurrency, batch_size: batch_size}, %{fetcher: fetcher_module})
+        Telemetry.event([:fetcher, :config], %{concurrency: max_concurrency, batch_size: batch_size}, %{
+          fetcher: fetcher_module
+        })
     end)
   end
 end

--- a/apps/indexer/lib/indexer/celo/metrics_cron.ex
+++ b/apps/indexer/lib/indexer/celo/metrics_cron.ex
@@ -96,17 +96,17 @@ defmodule Indexer.Celo.MetricsCron do
 
   def number_of_locks do
     number_of_locks = DatabaseMetrics.fetch_number_of_locks()
-    :telemetry.execute([:indexer, :db, :locks], %{value: number_of_locks})
+    Telemetry.event([:db, :locks],  %{value: number_of_locks})
   end
 
   def number_of_deadlocks do
     number_of_dead_locks = DatabaseMetrics.fetch_number_of_dead_locks()
-    :telemetry.execute([:indexer, :db, :deadlocks], %{value: number_of_dead_locks})
+    Telemetry.event([:db, :deadlocks],  %{value: number_of_dead_locks})
   end
 
   def longest_query_duration do
     longest_query_duration = DatabaseMetrics.fetch_name_and_duration_of_longest_query()
-    :telemetry.execute([:indexer, :db, :longest_query_duration], %{value: longest_query_duration})
+    Telemetry.event([:db, :longest_query_duration],  %{value: longest_query_duration})
   end
 
   def transaction_count do

--- a/apps/indexer/lib/indexer/celo/telemetry/instrumentation/indexer.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/instrumentation/indexer.ex
@@ -18,6 +18,16 @@ defmodule Indexer.Celo.Telemetry.Instrumentation do
         measurement: :count,
         description: "Pubsub notifications sent via erlang cluster"
       ),
+      counter("indexer_pending_transactions_sanitizer_count",
+        event_name: [:blockscout, :pending_transactions_sanitize],
+        measurement: :count,
+        description: "Invocations of pending transaction sanitizer"
+      ),
+      counter("indexer_empty_block_sanitizer_count",
+        event_name: [:blockscout, :empty_block_sanitize],
+        measurement: :count,
+        description: "Invocations of empty block sanitizer"
+      ),
       last_value(
         "indexer_blocks_pending_blockcount_current",
         event_name: [:indexer, :blocks, :pending_blockcount],

--- a/apps/indexer/lib/indexer/celo/telemetry/instrumentation/indexer.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/instrumentation/indexer.ex
@@ -53,7 +53,7 @@ defmodule Indexer.Celo.Telemetry.Instrumentation do
         measurement: :batch_size,
         description: "Max batch size for fetcher (number of items each fetcher process will work upon)",
         tags: [:fetcher]
-      ),
+      )
     ]
   end
 end

--- a/apps/indexer/lib/indexer/celo/telemetry/instrumentation/indexer.ex
+++ b/apps/indexer/lib/indexer/celo/telemetry/instrumentation/indexer.ex
@@ -29,7 +29,21 @@ defmodule Indexer.Celo.Telemetry.Instrumentation do
         event_name: [:indexer, :blocks, :pending],
         measurement: :value,
         description: "Number of blocks still to be fetched in past range"
-      )
+      ),
+      last_value(
+        "indexer_fetcher_config_concurrency_current",
+        event_name: [:blockscout, :fetcher, :config],
+        measurement: :concurrency,
+        description: "Max concurrent fetcher processes",
+        tags: [:fetcher]
+      ),
+      last_value(
+        "indexer_fetcher_config_batch_size_current",
+        event_name: [:blockscout, :fetcher, :config],
+        measurement: :batch_size,
+        description: "Max batch size for fetcher (number of items each fetcher process will work upon)",
+        tags: [:fetcher]
+      ),
     ]
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -13,6 +13,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   import EthereumJSONRPC, only: [integer_to_quantity: 1, json_rpc: 2, request: 1]
 
   alias Ecto.Changeset
+  alias Explorer.Celo.Telemetry
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Block, Transaction}
   alias Explorer.Chain.Import.Runner.Blocks
@@ -68,6 +69,8 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   end
 
   defp sanitize_empty_blocks(json_rpc_named_arguments) do
+    Telemetry.event(:empty_block_sanitize)
+
     unprocessed_non_empty_blocks_from_db = unprocessed_non_empty_blocks_query_list(limit())
 
     uniq_block_hashes = unprocessed_non_empty_blocks_from_db

--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -66,6 +66,8 @@ defmodule Indexer.PendingTransactionsSanitizer do
   end
 
   defp sanitize_pending_transactions(json_rpc_named_arguments) do
+    Telemetry.event(:pending_transactions_sanitize)
+
     pending_transactions_list_from_db = Chain.pending_transactions_list()
 
     pending_transactions_list_from_db

--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -12,6 +12,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
   import EthereumJSONRPC.Receipt, only: [to_elixir: 1]
 
   alias Ecto.Changeset
+  alias Explorer.Celo.Telemetry
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Hash.Full, as: Hash
   alias Explorer.Chain.Import.Runner.Blocks


### PR DESCRIPTION
### Description

Adds more metrics to the indexer + web + api apps, specifically:

* Add database stats to web and api pods
    * This gives us insight into replica db behavior
* Expose the top 10 database tables by size
* Expose internal transaction fetcher concurrency values 
    * Functionality exists to add other fetchers
* Expose empty block + pending transaction sanitizer invocation count

 ### Other changes

* Add periodic measurement functionality to blockscoutweb (web + api pods)
* Minor refactoring of metric labels
    * `indexer_db_locks` etc no longer valid name, as this is measured from different apps

### Tested

* Passed test suite
* Deployed to rc1staging and viewed metrics directly on prometheus endpoint

### Issues

 - Closes https://github.com/celo-org/data-services/issues/633

