### PR TITLE
Expose GraphQL resolution metrics

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -14,7 +14,7 @@ defmodule BlockScoutWeb.Application do
   alias BlockScoutWeb.{Endpoint, RealtimeEventHandler}
 
   alias EthereumJSONRPC.Celo.Instrumentation, as: EthRPC
-  alias Explorer.Celo.Telemetry.Instrumentation.{Database, FlyPostgres}
+  alias Explorer.Celo.Telemetry.Instrumentation.{Api, Database, FlyPostgres}
   alias Explorer.Celo.Telemetry.MetricsCollector, as: CeloPrometheusCollector
 
   def start(_type, _args) do
@@ -41,7 +41,8 @@ defmodule BlockScoutWeb.Application do
         {Phoenix.PubSub, name: BlockScoutWeb.PubSub},
         child_spec(Endpoint, []),
         {Absinthe.Subscription, Endpoint},
-        {CeloPrometheusCollector, metrics: [EthRPC.metrics(), Database.metrics(), FlyPostgres.metrics()]},
+        {CeloPrometheusCollector,
+         metrics: [EthRPC.metrics(), Database.metrics(), FlyPostgres.metrics(), Api.metrics()]},
         {RealtimeEventHandler, name: RealtimeEventHandler},
         {BlocksIndexedCounter, name: BlocksIndexedCounter},
         {CampaignBannerCache, name: CampaignBannerCache}

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
@@ -27,9 +27,7 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Api do
         tags: [:label],
         tag_values: fn metadata ->
           if Keyword.has_key?(metadata.options, :document) and is_binary(metadata.options[:document]) do
-            document_hash =
-              :crypto.hash(:sha256, metadata.options[:document])
-              |> Base.encode16(case: :lower)
+            document_hash = Base.encode16(:crypto.hash(:sha256, metadata.options[:document]), case: :lower)
 
             %{
               label:

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
@@ -1,0 +1,41 @@
+defmodule Explorer.Celo.Telemetry.Instrumentation.Api do
+  @moduledoc "Api metric definitions"
+
+  alias Explorer.Celo.Telemetry.Instrumentation
+  use Instrumentation
+
+  def metrics do
+    [
+      distribution("api_graphql_resolution_duration_milliseconds",
+        reporter_options: [
+          buckets: [
+            30,
+            50,
+            100,
+            200,
+            300,
+            500,
+            :timer.seconds(1),
+            :timer.seconds(2),
+            :timer.seconds(3),
+            :timer.seconds(5),
+            :timer.seconds(10),
+            :timer.seconds(20),
+            :timer.seconds(30),
+            :timer.minutes(1)
+          ]
+        ],
+        event_name: [:absinthe, :resolve, :field, :stop],
+        measurement: :duration,
+        description: "Resolution times for requests send to Blockscout API",
+        tags: [:path],
+        tag_values: fn metadata ->
+          path = Absinthe.Resolution.path(metadata.resolution)
+
+          Map.put(%{}, :path, path)
+        end,
+        unit: {:native, :millisecond}
+      )
+    ]
+  end
+end

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
@@ -32,7 +32,7 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Api do
             %{
               label:
                 case document_hash do
-                  "246e2a78320c905309513371f93cf7d2ae04e6a652828c845a6095ea4b6327be" -> "transfers"
+                  "56c1c866ec3cde643e2d930226f99f6e02d951c12db459898f2d6abf057d23ea" -> "transfers"
                   _ -> "unlabelled"
                 end
             }

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
@@ -32,7 +32,7 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Api do
             %{
               label:
                 case document_hash do
-                  "56c1c866ec3cde643e2d930226f99f6e02d951c12db459898f2d6abf057d23ea" -> "transfers"
+                  "d545db1eaf240b6ebefe95eb095db8bf572eddd382b3b4b695b6eb31dbcdabe1" -> "transfers"
                   _ -> "unlabelled"
                 end
             }

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
@@ -24,10 +24,20 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Api do
         event_name: [:absinthe, :execute, :operation, :stop],
         measurement: :duration,
         description: "Operation times for requests send to Blockscout API",
-        tags: [:name],
+        tags: [:label],
         tag_values: fn metadata ->
-          if Keyword.has_key?(metadata.options, :operation_name) and is_binary(metadata.options[:operation_name]) do
-            Map.put(%{}, :name, metadata.options[:operation_name])
+          if Keyword.has_key?(metadata.options, :document) and is_binary(metadata.options[:document]) do
+            document_hash =
+              :crypto.hash(:sha256, metadata.options[:document])
+              |> Base.encode16(case: :lower)
+
+            %{
+              label:
+                case document_hash do
+                  "246e2a78320c905309513371f93cf7d2ae04e6a652828c845a6095ea4b6327be" -> "transfers"
+                  _ -> "unlabelled"
+                end
+            }
           else
             %{}
           end

--- a/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
+++ b/apps/explorer/lib/explorer/celo/telemetry/instrumentation/api.ex
@@ -6,33 +6,31 @@ defmodule Explorer.Celo.Telemetry.Instrumentation.Api do
 
   def metrics do
     [
-      distribution("api_graphql_resolution_duration_milliseconds",
+      distribution("api_graphql_operation_duration_milliseconds",
         reporter_options: [
           buckets: [
-            30,
             50,
             100,
-            200,
             300,
             500,
             :timer.seconds(1),
-            :timer.seconds(2),
             :timer.seconds(3),
             :timer.seconds(5),
             :timer.seconds(10),
-            :timer.seconds(20),
             :timer.seconds(30),
             :timer.minutes(1)
           ]
         ],
-        event_name: [:absinthe, :resolve, :field, :stop],
+        event_name: [:absinthe, :execute, :operation, :stop],
         measurement: :duration,
-        description: "Resolution times for requests send to Blockscout API",
-        tags: [:path],
+        description: "Operation times for requests send to Blockscout API",
+        tags: [:name],
         tag_values: fn metadata ->
-          path = Absinthe.Resolution.path(metadata.resolution)
-
-          Map.put(%{}, :path, path)
+          if Keyword.has_key?(metadata.options, :operation_name) and is_binary(metadata.options[:operation_name]) do
+            Map.put(%{}, :name, metadata.options[:operation_name])
+          else
+            %{}
+          end
         end,
         unit: {:native, :millisecond}
       )


### PR DESCRIPTION
### Description

This PR exposes metrics for absinthe operation times.
 
### Tested

Tested locally and in production.

### Issues

 - Relates to https://github.com/celo-org/data-services/issues/631
