### PR TITLE
Conditionally disable itx csv export

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/csv_export_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/csv_export_controller.ex
@@ -25,12 +25,19 @@ defmodule BlockScoutWeb.CsvExportController do
   end
 
   defp supported_types do
-    [
-      "internal-transactions",
+    base_types = [
       "transactions",
       "token-transfers",
       "logs",
       "epoch-transactions"
     ]
+
+    itx_export = Application.get_env(:block_scout_web, __MODULE__)[:itx_export_enabled]
+
+    if itx_export do
+      ["internal-transactions" | base_types]
+    else
+      base_types
+    end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -60,7 +60,7 @@
         </div>
 
         <div class="transaction-bottom-panel">
-          <% if Application.get_env(:block_scout_web, BlockScoutWeb.CsvExportController)[:itx_export_enabled] do %>
+          <%= if Application.get_env(:block_scout_web, BlockScoutWeb.CsvExportController)[:itx_export_enabled] do %>
             <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "internal-transactions", conn: @conn %>
           <% end %>
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -60,7 +60,9 @@
         </div>
 
         <div class="transaction-bottom-panel">
-          <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "internal-transactions", conn: @conn %>
+          <% if Application.get_env(:block_scout_web, BlockScoutWeb.CsvExportController)[:itx_export_enabled] do %>
+            <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "internal-transactions", conn: @conn %>
+          <% end %>
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 

--- a/config/runtime/dev.exs
+++ b/config/runtime/dev.exs
@@ -31,6 +31,9 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
     keyfile: System.get_env("KEYFILE") || "priv/cert/selfsigned_key.pem"
   ]
 
+
+config :block_scout_web, BlockScoutWeb.CsvExportController, itx_export_enabled: true
+
 ########################
 ### Ethereum JSONRPC ###
 ########################

--- a/config/runtime/dev.exs
+++ b/config/runtime/dev.exs
@@ -31,7 +31,6 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
     keyfile: System.get_env("KEYFILE") || "priv/cert/selfsigned_key.pem"
   ]
 
-
 config :block_scout_web, BlockScoutWeb.CsvExportController, itx_export_enabled: true
 
 ########################

--- a/config/runtime/prod.exs
+++ b/config/runtime/prod.exs
@@ -20,6 +20,9 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
     host: System.get_env("BLOCKSCOUT_HOST") || "localhost"
   ]
 
+config :block_scout_web, BlockScoutWeb.CsvExportController,
+       itx_export_enabled: System.get_env("ITX_CSV_EXPORT_ENABLED", "") == "true"
+
 ########################
 ### Ethereum JSONRPC ###
 ########################

--- a/config/runtime/prod.exs
+++ b/config/runtime/prod.exs
@@ -21,7 +21,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
   ]
 
 config :block_scout_web, BlockScoutWeb.CsvExportController,
-       itx_export_enabled: System.get_env("ITX_CSV_EXPORT_ENABLED", "") == "true"
+  itx_export_enabled: System.get_env("ITX_CSV_EXPORT_ENABLED", "") == "true"
 
 ########################
 ### Ethereum JSONRPC ###

--- a/config/runtime/test.exs
+++ b/config/runtime/test.exs
@@ -6,6 +6,8 @@ alias EthereumJSONRPC.Variant
 ### BlockScout Web ###
 ######################
 
+config :block_scout_web, BlockScoutWeb.CsvExportController, itx_export_enabled: true
+
 ########################
 ### Ethereum JSONRPC ###
 ########################


### PR DESCRIPTION
### Description

Based on discoveries by @shazarre and @carterqw2 it seems that long running internal transaction export queries (in this instance, 15 hours long) are causing locks to build up on the master database and preventing data from being inserted.

This pr disables internal transaction csv export by default, with an optional environment var override to enable.
 
### Tested

* Deployed to rc1staging
    * csv export link is removed
    * directly hitting itx export link results in 404

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/639
