### PR TITLE
Add base64 encoded JSON support while fetching NFTs

### DIFF
--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -155,6 +155,20 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
       {:error, json}
   end
 
+  def fetch_json(%{@token_uri => {:ok, ["data:application/json;base64," <> base64_encoded_json]}}, hex_token_id) do
+    case Base.decode64(base64_encoded_json) do
+      {:ok, json} ->
+        fetch_json(%{@token_uri => {:ok, [json]}}, hex_token_id)
+
+      :error ->
+        Logger.debug(["Failed decoding base64 encoded JSON: #{inspect(base64_encoded_json)}"],
+          fetcher: :token_instances
+        )
+
+        {:error, base64_encoded_json}
+    end
+  end
+
   def fetch_json(%{@uri => {:ok, ["data:application/json," <> json]}}, hex_token_id) do
     decoded_json = URI.decode(json)
 

--- a/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
@@ -286,5 +286,24 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
                   }
                 }}
     end
+
+    test "decodes base64 encoded JSON in tokenURI" do
+      data = %{
+        "c87b56dd" =>
+          {:ok,
+           [
+             "data:application/json;base64,eyJuYW1lIjoiVmFsb3JhIEV4cGxvcmEiLCJpbWFnZSI6ImlwZnM6Ly9RbWVuelZlOUJzQXFzSjlvQ3BpU3JtdVBaY0JhVjJyZFlNb3ljcnR2UWUzZktnIn0="
+           ]}
+      }
+
+      assert InstanceMetadataRetriever.fetch_json(data) ==
+               {:ok,
+                %{
+                  metadata: %{
+                    "name" => "Valora Explora",
+                    "image" => "ipfs://QmenzVe9BsAqsJ9oCpiSrmuPZcBaV2rdYMoycrtvQe3fKg"
+                  }
+                }}
+    end
   end
 end


### PR DESCRIPTION
### Description

Fixes case where `tokenURI` method of ERC-721 returns data url with base64 encoded JSON.
 
### Tested

Tested on staging.

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/656
