### PR TITLE
Don't use compile_env for value that changes at runtime.

### DIFF
--- a/apps/event_stream/lib/event_stream/publishers/publisher.ex
+++ b/apps/event_stream/lib/event_stream/publishers/publisher.ex
@@ -8,12 +8,13 @@ defmodule EventStream.Publisher do
 
   @callback live() :: boolean
 
-  # credo:disable-for-next-line
-  @implementation Application.compile_env!(:event_stream, __MODULE__)
-
-  defdelegate publish(contract_name), to: @implementation
+  def publish(event) do
+    implementation = Application.get_env(:event_stream, __MODULE__)
+    implementation.publish(event)
+  end
 
   def connected? do
-    @implementation.live()
+    implementation = Application.get_env(:event_stream, __MODULE__)
+    implementation.live()
   end
 end


### PR DESCRIPTION
### Description

Fix an error where the publisher instance is not configurable in production environment due to compile time config.
 
 ### Other changes

None

### Tested

Tested on rc1staging and saw beanstalkd connection attempts

### Issues

 - Relates to https://github.com/celo-org/data-services/issues/653
