### PR TITLE
Enable token_instance fetcher polling

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -17,6 +17,8 @@ defmodule Indexer.Fetcher.TokenInstance do
 
   @defaults [
     flush_interval: 300,
+    poll: true,
+    poll_interval: :timer.hours(24),
     max_batch_size: 1,
     max_concurrency: 10,
     task_supervisor: Indexer.Fetcher.TokenInstance.TaskSupervisor


### PR DESCRIPTION
### Description

This PR enables polling once a day for `token_instance` fetcher.
 
### Tested

No real need to be tested.

### Issues

 - Relates to https://github.com/celo-org/data-services/issues/671