### PR TITLE
Fix NFT metrics event typo

### DIFF
--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -87,7 +87,7 @@ defmodule Explorer.Chain.Token.Instance do
         }
       )
 
-    result = Repo.one(count_query)
+    result = Repo.one(count_query, timeout: :infinity)
 
     case result do
       nil -> 0

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -91,10 +91,10 @@ defmodule Indexer.Fetcher.TokenInstance do
 
         {:ok, _result} = Chain.upsert_token_instance(params)
 
-        Telemetry.event([:indexer, :nft, :ingestion_error], %{count: 1})
+        Telemetry.event([:indexer, :nft, :ingestion_errors], %{count: 1})
 
       result ->
-        Telemetry.event([:indexer, :nft, :ingestion_error], %{count: 1})
+        Telemetry.event([:indexer, :nft, :ingestion_errors], %{count: 1})
 
         Logger.debug(
           [

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -96,7 +96,7 @@ defmodule Indexer.Fetcher.TokenInstance do
       result ->
         Telemetry.event([:indexer, :nft, :ingestion_errors], %{count: 1})
 
-        Logger.debug(
+        Logger.error(
           [
             "failed to fetch token instance metadata for #{inspect({to_string(token_contract_address_hash), Decimal.to_integer(token_id)})}: ",
             inspect(result)


### PR DESCRIPTION
### Description

This PR fixes typo in telemetry event connected to NFT ingestion errors resulting in metrics not being available.
