### PR TITLE
Resolve Blockscout live issues

### DIFF
--- a/.github/workflows/helm_deploy_dispatch.yml
+++ b/.github/workflows/helm_deploy_dispatch.yml
@@ -1,6 +1,6 @@
 ---
 name: 'Deploy Helm Chart'
-run-name: 'helmfile ${{ github.event.inputs.action }} on ${{ github.event.inputs.deployment }} - ${{ github.event.inputs.image-commit }}'
+run-name: 'helmfile ${{ github.event.inputs.action }} on ${{ github.event.inputs.deployment }} - ${{ github.sha }}'
 
 on:
   workflow_dispatch:

--- a/apps/block_scout_web/.iex.exs
+++ b/apps/block_scout_web/.iex.exs
@@ -10,6 +10,6 @@ defmodule Clabs.Debug do
 
   def token_tx_for_valora_address do
     {:ok,hsh} = Address.cast("0x6131a6d616a4be3737b38988847270a64bc10caa")
-    Explorer.GraphQL.token_txtransfers_query_for_address(hsh, 26)
+    Explorer.GraphQL.token_txtransfers_query_for_address(hsh, 26, 0)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
@@ -50,7 +50,8 @@ defmodule BlockScoutWeb.VerifiedContractsController do
       page_number: params |> fetch_page_number() |> Integer.to_string(),
       contracts_count: Chain.count_contracts_from_cache(),
       verified_contracts_count: Chain.count_verified_contracts_from_cache(),
-      new_contracts_count: nil, #celo: disabling new contract count
+      # celo: disabling new contract count
+      new_contracts_count: nil,
       new_verified_contracts_count: Chain.count_new_verified_contracts_from_cache()
     )
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
@@ -50,7 +50,7 @@ defmodule BlockScoutWeb.VerifiedContractsController do
       page_number: params |> fetch_page_number() |> Integer.to_string(),
       contracts_count: Chain.count_contracts_from_cache(),
       verified_contracts_count: Chain.count_verified_contracts_from_cache(),
-      new_contracts_count: Chain.count_new_contracts_from_cache(),
+      new_contracts_count: nil, #celo: disabling new contract count
       new_verified_contracts_count: Chain.count_new_verified_contracts_from_cache()
     )
   end

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/token_transfer_tx.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/token_transfer_tx.ex
@@ -7,9 +7,10 @@ defmodule BlockScoutWeb.Resolvers.TokenTransferTx do
   def get_by(_, %{address_hash: address_hash, first: limit} = args, _) do
     connection_args = Map.take(args, [:after, :before, :first, :last])
 
-    offset = case Connection.offset(args) do
-      {:ok, offset} when is_integer(offset) -> offset
-      _ -> 0
+    offset =
+      case Connection.offset(args) do
+        {:ok, offset} when is_integer(offset) -> offset
+        _ -> 0
       end
 
     address_hash

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/token_transfer_tx.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/token_transfer_tx.ex
@@ -4,11 +4,16 @@ defmodule BlockScoutWeb.Resolvers.TokenTransferTx do
   alias Absinthe.Relay.Connection
   alias Explorer.{GraphQL, Repo}
 
-  def get_by(_, %{address_hash: address_hash, first: first} = args, _) do
+  def get_by(_, %{address_hash: address_hash, first: limit} = args, _) do
     connection_args = Map.take(args, [:after, :before, :first, :last])
 
+    offset = case Connection.offset(args) do
+      {:ok, offset} when is_integer(offset) -> offset
+      _ -> 0
+      end
+
     address_hash
-    |> GraphQL.token_txtransfers_query_for_address(first)
+    |> GraphQL.token_txtransfers_query_for_address(offset, limit)
     |> Connection.from_query(&Repo.all/1, connection_args, options(args))
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/verified_contracts/_stats.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/verified_contracts/_stats.html.eex
@@ -9,8 +9,10 @@
               <span class="text-muted"><%= gettext ("Total") %></span>
             </div>
             <div class="d-flex flex-column">
-              <h1 class="text-success"><%= if 0 |> Decimal.new() |> Decimal.lt?(@new_contracts_count), do: "+" %><%= BlockScoutWeb.Cldr.Number.to_string!(@new_contracts_count, format: "#,###") %></h1>
-              <span class="text-muted"><%= gettext ("Last 24h") %></span>
+              <%= if ! is_nil(@new_contracts_count) do %>
+                <h1 class="text-success"><%= if 0 |> Decimal.new() |> Decimal.lt?(@new_contracts_count), do: "+" %><%= BlockScoutWeb.Cldr.Number.to_string!(@new_contracts_count, format: "#,###") %></h1>
+                <span class="text-muted"><%= gettext ("Last 24h") %></span>
+              <% end %>
             </div>
           </div>
         </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1496,8 +1496,8 @@ msgstr ""
 msgid "Is Yul contract"
 msgstr ""
 
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:13
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:26
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:14
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:28
 #, elixir-autogen, elixir-format
 msgid "Last 24h"
 msgstr ""
@@ -2723,7 +2723,7 @@ msgid "Topics"
 msgstr ""
 
 #: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:9
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:22
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:24
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
@@ -2994,7 +2994,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:18
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:20
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:5
 #, elixir-autogen, elixir-format
 msgid "Verified Contracts"

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1496,8 +1496,8 @@ msgstr ""
 msgid "Is Yul contract"
 msgstr ""
 
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:13
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:26
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:14
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:28
 #, elixir-autogen, elixir-format
 msgid "Last 24h"
 msgstr ""
@@ -2723,7 +2723,7 @@ msgid "Topics"
 msgstr ""
 
 #: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:9
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:22
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:24
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
@@ -2994,7 +2994,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:18
+#: lib/block_scout_web/templates/verified_contracts/_stats.html.eex:20
 #: lib/block_scout_web/templates/verified_contracts/index.html.eex:5
 #, elixir-autogen, elixir-format
 msgid "Verified Contracts"

--- a/apps/block_scout_web/test/block_scout_web/controllers/verified_contracts_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/verified_contracts_controller_test.exs
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.VerifiedContractsControllerTest do
 
   alias Explorer.Chain.Cache.{
     ContractsCounter,
-    #NewContractsCounter,
+    # NewContractsCounter,
     NewVerifiedContractsCounter,
     VerifiedContractsCounter
   }
@@ -16,9 +16,9 @@ defmodule BlockScoutWeb.VerifiedContractsControllerTest do
     test "returns 200", %{conn: conn} do
       start_supervised!(ContractsCounter)
       ContractsCounter.consolidate()
-      #celo: disable new contracts count
-#      start_supervised!(NewContractsCounter)
-#      NewContractsCounter.consolidate()
+      # celo: disable new contracts count
+      #      start_supervised!(NewContractsCounter)
+      #      NewContractsCounter.consolidate()
       start_supervised!(NewVerifiedContractsCounter)
       NewVerifiedContractsCounter.consolidate()
       start_supervised!(VerifiedContractsCounter)

--- a/apps/block_scout_web/test/block_scout_web/controllers/verified_contracts_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/verified_contracts_controller_test.exs
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.VerifiedContractsControllerTest do
 
   alias Explorer.Chain.Cache.{
     ContractsCounter,
-    NewContractsCounter,
+    #NewContractsCounter,
     NewVerifiedContractsCounter,
     VerifiedContractsCounter
   }
@@ -16,8 +16,9 @@ defmodule BlockScoutWeb.VerifiedContractsControllerTest do
     test "returns 200", %{conn: conn} do
       start_supervised!(ContractsCounter)
       ContractsCounter.consolidate()
-      start_supervised!(NewContractsCounter)
-      NewContractsCounter.consolidate()
+      #celo: disable new contracts count
+#      start_supervised!(NewContractsCounter)
+#      NewContractsCounter.consolidate()
       start_supervised!(NewVerifiedContractsCounter)
       NewVerifiedContractsCounter.consolidate()
       start_supervised!(VerifiedContractsCounter)

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -98,8 +98,8 @@ defmodule Explorer.Application do
         configure(Explorer.Market.History.Cataloger),
         configure(Explorer.Chain.Cache.TokenExchangeRate),
         configure(Explorer.Chain.Cache.ContractsCounter),
-        #celo: disable new contract count
-        #configure(Explorer.Chain.Cache.NewContractsCounter),
+        # celo: disable new contract count
+        # configure(Explorer.Chain.Cache.NewContractsCounter),
         configure(Explorer.Chain.Cache.VerifiedContractsCounter),
         configure(Explorer.Chain.Cache.NewVerifiedContractsCounter),
         configure(Explorer.Chain.Transaction.History.Historian),

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -98,7 +98,8 @@ defmodule Explorer.Application do
         configure(Explorer.Market.History.Cataloger),
         configure(Explorer.Chain.Cache.TokenExchangeRate),
         configure(Explorer.Chain.Cache.ContractsCounter),
-        configure(Explorer.Chain.Cache.NewContractsCounter),
+        #celo: disable new contract count
+        #configure(Explorer.Chain.Cache.NewContractsCounter),
         configure(Explorer.Chain.Cache.VerifiedContractsCounter),
         configure(Explorer.Chain.Cache.NewVerifiedContractsCounter),
         configure(Explorer.Chain.Transaction.History.Historian),

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -80,7 +80,7 @@ defmodule Explorer.Chain do
     BlockNumber,
     Blocks,
     ContractsCounter,
-    NewContractsCounter,
+    # NewContractsCounter, celo: disable new contracts counter
     NewVerifiedContractsCounter,
     Transactions,
     Uncles,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1428,7 +1428,10 @@ defmodule Explorer.Chain do
               address_verified_twin_contract_updated =
                 address_verified_twin_contract
                 |> Map.put(:address_hash, hash)
-                |> Map.put_new(:metadata_from_verified_twin, true)
+                |> Map.put(:metadata_from_verified_twin, true)
+                |> Map.put(:implementation_address_hash, nil)
+                |> Map.put(:implementation_name, nil)
+                |> Map.put(:implementation_fetched_at, nil)
 
               address_result
               |> Map.put(:smart_contract, address_verified_twin_contract_updated)
@@ -1963,7 +1966,10 @@ defmodule Explorer.Chain do
               address_verified_twin_contract_updated =
                 address_verified_twin_contract
                 |> Map.put(:address_hash, hash)
-                |> Map.put_new(:metadata_from_verified_twin, true)
+                |> Map.put(:metadata_from_verified_twin, true)
+                |> Map.put(:implementation_address_hash, nil)
+                |> Map.put(:implementation_name, nil)
+                |> Map.put(:implementation_fetched_at, nil)
 
               address_result
               |> Map.put(:smart_contract, address_verified_twin_contract_updated)
@@ -4575,9 +4581,10 @@ defmodule Explorer.Chain do
       if address_verified_twin_contract do
         address_verified_twin_contract
         |> Map.put(:address_hash, address_hash)
-        |> Map.put(:implementation_address_hash, current_smart_contract.implementation_address_hash)
-        |> Map.put(:implementation_name, current_smart_contract.implementation_name)
-        |> Map.put(:implementation_fetched_at, current_smart_contract.implementation_fetched_at)
+        |> Map.put(:metadata_from_verified_twin, true)
+        |> Map.put(:implementation_address_hash, nil)
+        |> Map.put(:implementation_name, nil)
+        |> Map.put(:implementation_fetched_at, nil)
       else
         current_smart_contract
       end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -7161,7 +7161,8 @@ defmodule Explorer.Chain do
   end
 
   def count_new_contracts_from_cache do
-    NewContractsCounter.fetch()
+    0
+    #celo: disable new contract count NewContractsCounter.fetch()
   end
 
   def address_counters(address) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -7162,7 +7162,7 @@ defmodule Explorer.Chain do
 
   def count_new_contracts_from_cache do
     0
-    #celo: disable new contract count NewContractsCounter.fetch()
+    # celo: disable new contract count NewContractsCounter.fetch()
   end
 
   def address_counters(address) do

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -246,14 +246,16 @@ defmodule Explorer.GraphQL do
           transaction_hash: tt.transaction_hash,
           block_number: tt.block_number,
           to_address_hash: tt.to_address_hash,
-          from_address_hash: tt.from_address_hash
+          from_address_hash: tt.from_address_hash,
+          token_id: tt.token_id
         },
         distinct: [desc: tt.block_number, desc: tt.transaction_hash],
         order_by: [
           desc: tt.block_number,
           desc: tt.transaction_hash,
           desc: tt.from_address_hash,
-          desc: tt.to_address_hash
+          desc: tt.to_address_hash,
+          desc: tt.token_id
         ],
         limit: ^growing_limit
       )
@@ -281,7 +283,8 @@ defmodule Explorer.GraphQL do
         timestamp: b.timestamp,
         input: tx.input,
         nonce: tx.nonce,
-        block_number: tt.block_number
+        block_number: tt.block_number,
+        token_id: tt.token_id
       }
     )
     |> order_by([transaction: t],

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -246,16 +246,14 @@ defmodule Explorer.GraphQL do
           transaction_hash: tt.transaction_hash,
           block_number: tt.block_number,
           to_address_hash: tt.to_address_hash,
-          from_address_hash: tt.from_address_hash,
-          token_id: tt.token_id
+          from_address_hash: tt.from_address_hash
         },
         distinct: [desc: tt.block_number, desc: tt.transaction_hash],
         order_by: [
           desc: tt.block_number,
           desc: tt.transaction_hash,
           desc: tt.from_address_hash,
-          desc: tt.to_address_hash,
-          desc: tt.token_id
+          desc: tt.to_address_hash
         ],
         limit: ^growing_limit
       )
@@ -283,8 +281,7 @@ defmodule Explorer.GraphQL do
         timestamp: b.timestamp,
         input: tx.input,
         nonce: tx.nonce,
-        block_number: tt.block_number,
-        token_id: tt.token_id
+        block_number: tt.block_number
       }
     )
     |> order_by([transaction: t],

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -233,7 +233,7 @@ defmodule Explorer.GraphQL do
   end
 
   def token_txtransfers_query_for_address(address_hash, offset, limit) do
-    page = floor(offset/limit) + 1
+    page = floor(offset / limit) + 1
     growing_limit = limit * (page + 1)
 
     tokens =

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -232,8 +232,9 @@ defmodule Explorer.GraphQL do
     )
   end
 
-  def token_txtransfers_query_for_address(address_hash, first) do
-    tt_limit = first * 2
+  def token_txtransfers_query_for_address(address_hash, offset, limit) do
+    page = floor(offset/limit) + 1
+    growing_limit = limit * (page + 1)
 
     tokens =
       from(
@@ -254,8 +255,7 @@ defmodule Explorer.GraphQL do
           desc: tt.from_address_hash,
           desc: tt.to_address_hash
         ],
-        limit: ^tt_limit,
-        offset: 0
+        limit: ^growing_limit
       )
 
     from(
@@ -282,8 +282,7 @@ defmodule Explorer.GraphQL do
         input: tx.input,
         nonce: tx.nonce,
         block_number: tt.block_number
-      },
-      limit: ^first
+      }
     )
     |> order_by([transaction: t],
       desc: t.block_number,

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -424,7 +424,7 @@ defmodule Explorer.GraphQL do
         nonce: tx.nonce,
         block_number: tt.block_number,
         token_type: token.type,
-        token_id: tt.token_id
+        token_id: fragment("COALESCE(?, (COALESCE(?, ARRAY[]::Decimal[]))[1])", tt.token_id, tt.token_ids)
       },
       order_by: [desc: tt.block_number, desc: tt.amount, desc: tt.log_index]
     )

--- a/apps/explorer/test/explorer/chain/cache/new_contracts_counter_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/new_contracts_counter_test.exs
@@ -4,7 +4,8 @@ defmodule Explorer.Chain.Cache.NewContractsCounterTest do
   alias Explorer.Chain.Cache.NewContractsCounter
   alias Explorer.Chain
 
-  @tag :skip #celo: disabling new contract count
+  # celo: disabling new contract count
+  @tag :skip
   test "populates the cache with the number of new contracts (last 24h)" do
     :transaction
     |> insert(created_contract_code_indexed_at: Timex.shift(Timex.now(), hours: -1))

--- a/apps/explorer/test/explorer/chain/cache/new_contracts_counter_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/new_contracts_counter_test.exs
@@ -4,6 +4,7 @@ defmodule Explorer.Chain.Cache.NewContractsCounterTest do
   alias Explorer.Chain.Cache.NewContractsCounter
   alias Explorer.Chain
 
+  @tag :skip #celo: disabling new contract count
   test "populates the cache with the number of new contracts (last 24h)" do
     :transaction
     |> insert(created_contract_code_indexed_at: Timex.shift(Timex.now(), hours: -1))

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -136,6 +136,165 @@ defmodule Explorer.Chain.SmartContractTest do
       verify!(EthereumJSONRPC.Mox)
       assert_empty_implementation(smart_contract.address_hash)
     end
+
+    test "test get_implementation_adddress_hash/1 for twins contract" do
+      # return nils for nil
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(nil)
+      smart_contract = insert(:smart_contract)
+      another_address = insert(:contract_address)
+
+      twin = Chain.address_hash_to_smart_contract(another_address.hash)
+      implementation_smart_contract = insert(:smart_contract, name: "proxy")
+
+      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
+      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+
+      # fetch nil implementation
+      get_eip1967_implementation_zero_addresses()
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+      verify!(EthereumJSONRPC.Mox)
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      get_eip1967_implementation_zero_addresses()
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+      verify!(EthereumJSONRPC.Mox)
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      string_implementation_address_hash = to_string(implementation_smart_contract.address_hash)
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn %{
+                                                  id: 0,
+                                                  method: "eth_getStorageAt",
+                                                  params: [
+                                                    _,
+                                                    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+                                                    "latest"
+                                                  ]
+                                                },
+                                                _options ->
+        {:ok, string_implementation_address_hash}
+      end)
+
+      assert {^string_implementation_address_hash, "proxy"} = SmartContract.get_implementation_address_hash(twin)
+
+      verify!(EthereumJSONRPC.Mox)
+
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      get_eip1967_implementation_error_response()
+
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+
+      verify!(EthereumJSONRPC.Mox)
+
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      {:ok, addr} = Chain.hash_to_address(another_address.hash)
+      twin = addr.smart_contract
+
+      implementation_smart_contract = insert(:smart_contract, name: "proxy")
+
+      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
+      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+
+      # fetch nil implementation
+      get_eip1967_implementation_zero_addresses()
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+      verify!(EthereumJSONRPC.Mox)
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      get_eip1967_implementation_zero_addresses()
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+      verify!(EthereumJSONRPC.Mox)
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      string_implementation_address_hash = to_string(implementation_smart_contract.address_hash)
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn %{
+                                                  id: 0,
+                                                  method: "eth_getStorageAt",
+                                                  params: [
+                                                    _,
+                                                    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+                                                    "latest"
+                                                  ]
+                                                },
+                                                _options ->
+        {:ok, string_implementation_address_hash}
+      end)
+
+      assert {^string_implementation_address_hash, "proxy"} = SmartContract.get_implementation_address_hash(twin)
+
+      verify!(EthereumJSONRPC.Mox)
+
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      get_eip1967_implementation_error_response()
+
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+
+      verify!(EthereumJSONRPC.Mox)
+
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      {:ok, addr} =
+        Chain.find_contract_address(
+          another_address.hash,
+          [
+            necessity_by_association: %{
+              :smart_contract => :optional
+            }
+          ],
+          true
+        )
+
+      twin = addr.smart_contract
+
+      implementation_smart_contract = insert(:smart_contract, name: "proxy")
+
+      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
+      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+
+      # fetch nil implementation
+      get_eip1967_implementation_zero_addresses()
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+      verify!(EthereumJSONRPC.Mox)
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      get_eip1967_implementation_zero_addresses()
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+      verify!(EthereumJSONRPC.Mox)
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      string_implementation_address_hash = to_string(implementation_smart_contract.address_hash)
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn %{
+                                                  id: 0,
+                                                  method: "eth_getStorageAt",
+                                                  params: [
+                                                    _,
+                                                    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+                                                    "latest"
+                                                  ]
+                                                },
+                                                _options ->
+        {:ok, string_implementation_address_hash}
+      end)
+
+      assert {^string_implementation_address_hash, "proxy"} = SmartContract.get_implementation_address_hash(twin)
+
+      verify!(EthereumJSONRPC.Mox)
+
+      assert_implementation_never_fetched(smart_contract.address_hash)
+
+      get_eip1967_implementation_error_response()
+
+      assert {nil, nil} = SmartContract.get_implementation_address_hash(twin)
+
+      verify!(EthereumJSONRPC.Mox)
+
+      assert_implementation_never_fetched(smart_contract.address_hash)
+    end
   end
 
   def get_eip1967_implementation_zero_addresses do
@@ -212,6 +371,13 @@ defmodule Explorer.Chain.SmartContractTest do
   def assert_empty_implementation(address_hash) do
     contract = Chain.address_hash_to_smart_contract(address_hash)
     assert contract.implementation_fetched_at
+    refute contract.implementation_name
+    refute contract.implementation_address_hash
+  end
+
+  def assert_implementation_never_fetched(address_hash) do
+    contract = Chain.address_hash_to_smart_contract(address_hash)
+    refute contract.implementation_fetched_at
     refute contract.implementation_name
     refute contract.implementation_address_hash
   end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -833,7 +833,8 @@ defmodule Explorer.Factory do
   def smart_contract_factory do
     contract_code_info = contract_code_info()
 
-    bytecode_md5 = Helper.contract_code_md5(contract_code_info.bytecode)
+    {:ok, data} = Explorer.Chain.Data.cast(contract_code_info.bytecode)
+    bytecode_md5 = Helper.contract_code_md5(data.bytes)
 
     %SmartContract{
       address_hash: insert(:address, contract_code: contract_code_info.bytecode, verified: true).hash,


### PR DESCRIPTION
### Description

A collection of patches to resolve issues that have occurred since the last upstream merge and deployment.

#### High db cpu usage

`NewContractsCounter` runs an expensive query whenever a pod is started + every 30 minutes. This should be very cheap via an index on the transactions table, but the query plan does not use it. Instead this feature is just disabled and new contract count is no longer shown

#### GraphQL issues

* Custom graphql queries became very expensive due to db changes, the optimised replacement query lacked pagination support - this has been readded
* Support for token_id within the token_transfer response has been readded, and backwards compatibility from lists of token ids
    * A single transfer can presumably include multiple token_ids, but it's unclear to what extent this feature is used / supported in external projects
    * The first id within the list of `token_ids` will be returned should `token_id` be null

#### Proxy contract support

* `git cherry-pick` the upstream commit at 8167d6eb78766cd1fafc12d9ebe7c1b5a93b1f15 to support UI view of proxy contracts
    * e.g. https://explorer.celo.org/mainnet/address/0x282F95AdA81610be70D7e1e8557F96866404A632

### Other Changes

* Modifies deployment workflow to include the deployment sha in the title

### Tested

* Tested locally against rc13 db
    * Asserted that graphql query contains `token_id` value for erc-721 tokens
    * Can navigate to contract address specified above
    * Application functions without `NewContractsCounter` being added to supervision tree
    * Saw pagination in graphql response
        ```
        "endCursor": "YXJyYXljb25uZWN0aW9uOjI0",
        "hasNextPage": true,
        "hasPreviousPage": false,
        "startCursor": "YXJyYXljb25uZWN0aW9uOjA="
        ```
* Ran and passed test suite

### Issues

 - Relates to https://github.com/celo-org/blockscout/discussions/912
 - Relates to https://github.com/celo-org/blockscout/discussions/915
 - Relates to https://github.com/celo-org/blockscout/discussions/917
 - Closes https://github.com/celo-org/blockscout/pull/913