### PR TITLE
Don't broadcast messages on import.

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -125,6 +125,8 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
              ] = response["result"]
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "with a stale balance", %{conn: conn, params: params} do
       now = Timex.now()
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -225,7 +225,8 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       {:ok, expected_wei} = Wei.cast(2)
 
-      assert_receive({:chain_event, :addresses, :on_demand, [received_address]}, 1000)
+      # celo - deactivating event broadcast
+      # assert_receive({:chain_event, :addresses, :on_demand, [received_address]}, 1000)
 
       assert received_address.hash == address.hash
       assert received_address.fetched_coin_balance == expected_wei

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -230,9 +230,9 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       # celo - deactivating event broadcast
       # assert_receive({:chain_event, :addresses, :on_demand, [received_address]}, 1000)
 
-      assert received_address.hash == address.hash
-      assert received_address.fetched_coin_balance == expected_wei
-      assert received_address.fetched_coin_balance_block_number == 101
+      #      assert received_address.hash == address.hash
+      #      assert received_address.fetched_coin_balance == expected_wei
+      #      assert received_address.fetched_coin_balance_block_number == 101
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -133,7 +133,10 @@ defmodule Explorer.Chain.Import do
          {:ok, data} <- insert_runner_to_changes_list(runner_to_changes_list, options) do
       emit_ingestion_metrics(data)
       Notify.async(data[:transactions])
-      Publisher.broadcast(data, Map.get(options, :broadcast, false))
+
+      #elo - deactivating real time notifications of indexed + imported data
+      Publisher.broadcast(data, false)
+
       {:ok, data}
     end
   end

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -134,7 +134,7 @@ defmodule Explorer.Chain.Import do
       emit_ingestion_metrics(data)
       Notify.async(data[:transactions])
 
-      #elo - deactivating real time notifications of indexed + imported data
+      # elo - deactivating real time notifications of indexed + imported data
       Publisher.broadcast(data, false)
 
       {:ok, data}

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -472,18 +472,24 @@ defmodule Explorer.Chain.ImportTest do
       assert changeset_errors(changeset)[:call_type] == ["can't be blank"]
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "publishes addresses with updated fetched_coin_balance data to subscribers on insert" do
       Subscriber.to(:addresses, :realtime)
       Import.all(@import_data)
       assert_receive {:chain_event, :addresses, :realtime, [%Address{}, %Address{}, %Address{}]}
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "publishes block data to subscribers on insert" do
       Subscriber.to(:blocks, :realtime)
       Import.all(@import_data)
       assert_receive {:chain_event, :blocks, :realtime, [%Block{}]}
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "publishes internal_transaction data to subscribers on insert" do
       Subscriber.to(:internal_transactions, :realtime)
       Import.all(@import_data)
@@ -491,12 +497,16 @@ defmodule Explorer.Chain.ImportTest do
       assert_receive {:chain_event, :internal_transactions, :realtime, [%{transaction_hash: _, index: _}]}
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "publishes transactions data to subscribers on insert" do
       Subscriber.to(:transactions, :realtime)
       Import.all(@import_data)
       assert_receive {:chain_event, :transactions, :realtime, [%Transaction{}]}
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "publishes token_transfers data to subscribers on insert" do
       Subscriber.to(:token_transfers, :realtime)
 

--- a/apps/indexer/test/indexer/fetcher/coin_balance_on_demand_test.exs
+++ b/apps/indexer/test/indexer/fetcher/coin_balance_on_demand_test.exs
@@ -101,6 +101,8 @@ defmodule Indexer.Fetcher.CoinBalanceOnDemandTest do
       :ok
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "a stale address broadcasts the new address" do
       address = insert(:address, fetched_coin_balance: 1, fetched_coin_balance_block_number: 100)
       address_hash = address.hash
@@ -142,6 +144,8 @@ defmodule Indexer.Fetcher.CoinBalanceOnDemandTest do
       )
     end
 
+    # celo - deactivating event broadcast
+    @tag :skip
     test "a pending address broadcasts the new address and the new coin balance" do
       address = insert(:address, fetched_coin_balance: 0, fetched_coin_balance_block_number: 101)
       insert(:unfetched_balance, address_hash: address.hash, block_number: 102)


### PR DESCRIPTION
### Description

Deactivates broadcasting information from indexer to web / api pods via erlang clustering. 

Currently the handling of messages triggers db calls, which has exacerbated db contention in times of high blockchain activity. Additionally the real time update mechanism has never been compatible with the concept of replica db lag. 

Disabling this prevents user confusion + reduces the amount of db calls made by web & api pods.


 ### Other changes

* Disables some tests that explicitly assert event broadcast

### Tested

* Already running on baklava during load test

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/721