### PR TITLE
Rename "Downtime" tab to "Unsigned Blocks" for validator addresses

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -38,7 +38,7 @@
       ) %>
   <%= if BlockScoutWeb.AddressView.is_validator_signer?(@address) do %>
     <%= link(
-      gettext("Downtime"),
+      gettext("Unsigned Blocks"),
       class: "card-tab #{tab_status("signed", @conn.request_path)}",
       "data-test": "signed_tab_link",
       to: AccessHelpers.get_path(@conn, :address_signed_path, :index, @address.hash)


### PR DESCRIPTION
### Description

Renames "Downtime" tab to "Unsigned Blocks" for validator addresses.
 
 ### Other changes

None.

### Issues

 - Fixes #971 
