### PR TITLE
Add sanction tag to read contract controllers + templates

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_read_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_read_contract_controller.ex
@@ -43,7 +43,8 @@ defmodule BlockScoutWeb.AddressReadContractController do
       type: :regular,
       action: :read,
       custom_abi: custom_abi?,
-      exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null()
+      exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
+      sanctions: Explorer.Celo.SanctionCache.get_sanction_list()
     ]
 
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_read_proxy_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_read_proxy_controller.ex
@@ -37,7 +37,8 @@ defmodule BlockScoutWeb.AddressReadProxyController do
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
         counters_path: address_path(conn, :address_counters, %{"id" => Address.checksum(address_hash)}),
         tags: get_address_tags(address_hash, current_user(conn)),
-        celo_epoch: EpochUtil.get_address_summary(address)
+        celo_epoch: EpochUtil.get_address_summary(address),
+        sanctions: Explorer.Celo.SanctionCache.get_sanction_list()
       )
     else
       _ ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/contract_controller.ex
@@ -37,7 +37,8 @@ defmodule BlockScoutWeb.Tokens.ContractController do
         action: action,
         token: Market.add_price(token),
         counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)}),
-        tags: get_address_tags(address_hash, current_user(conn))
+        tags: get_address_tags(address_hash, current_user(conn)),
+        sanctions: Explorer.Celo.SanctionCache.get_sanction_list()
       )
     else
       {:restricted_access, _} ->

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_read_contract/index.html.eex
@@ -12,9 +12,13 @@
     tags: @tags,
     celo_epoch: @celo_epoch
   %>
+  <%
+    {:ok, sanctions} = Jason.encode(@sanctions)
+  %>
 
   <div class="card">
-    <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
+      <div id="sanctions" data-sanctions=<%= sanctions %> hidden ></div>
+      <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
     <%= if @need_wallet do %>
       <div class="card-misc-container">
         <%= render BlockScoutWeb.SmartContractView, "_connect_container.html" %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_read_proxy/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_read_proxy/index.html.eex
@@ -12,8 +12,12 @@
     tags: @tags,
     celo_epoch: @celo_epoch
   %>
+  <%
+    {:ok, sanctions} = Jason.encode(@sanctions)
+  %>
 
   <div class="card">
+    <div id="sanctions" data-sanctions=<%= sanctions %> hidden ></div>
     <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
     <!-- loaded via AJAX -->
     <div class="card-body" data-smart-contract-functions data-hash="<%= to_string(@address.hash) %>" data-type="<%= @type %>" data-action="<%= @action %>" data-url="<%= smart_contract_path(@conn, :index) %>">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/contract/index.html.eex
@@ -8,8 +8,13 @@
     conn: @conn
   ) %>
 
+  <%
+    {:ok, sanctions} = Jason.encode(@sanctions)
+  %>
+
   <section>
     <div class="card">
+      <div id="sanctions" data-sanctions=<%= sanctions %> hidden ></div>
       <%= render OverviewView, "_tabs.html", assigns %>
       <!-- loaded via AJAX -->
       <div class="card-body" data-smart-contract-functions data-hash="<%= Address.checksum(@token.contract_address.hash) %>" data-type="<%= @type %>" data-action="<%= @action %>" data-url="<%= smart_contract_path(@conn, :index) %>">


### PR DESCRIPTION
### Description

JS is broken on read contract + proxy pages due to the `#sanctions` element not existing. This PR adds the data + element to relevant controllers and templates.

See https://explorer.celo.org/mainnet/token/0x471EcE3750Da237f93B8E339c536989b8978a438/read-proxy for an example

### Tested

* Tested locally against rc1staging database

