### PR TITLE
Enable Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>celo-org/.github:renovate-config"]
+}


### PR DESCRIPTION
### Description

Enable Renovate instead of Dependabot for dependency management.
See https://github.com/celo-org/celo-labs/discussions/1051.
Dependabot updates have been disabled.
 
### Tested

Similar PR: https://github.com/celo-org/akeyless/pull/484
Similar commit: https://github.com/celo-org/fly_postgres_elixir/commit/407e92e8d2e7a92e95b743e4322ab34724139b6d
