### PR TITLE
Preload `celo_account` on AddressReadProxyController when available.

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_read_proxy_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_read_proxy_controller.ex
@@ -19,7 +19,8 @@ defmodule BlockScoutWeb.AddressReadProxyController do
         :names => :optional,
         :smart_contract => :optional,
         :token => :optional,
-        :contracts_creation_transaction => :optional
+        :contracts_creation_transaction => :optional,
+        :celo_account => :optional
       }
     ]
 


### PR DESCRIPTION
### Description

The application is crashing when trying to display data it has not loaded from the database (specifically celo epoch data). This PR adds an optional preload to the db fetch to include `celo_accounts` information should it exist for the `address` being fetched.

### Tested

* tested locally against rc11 db
    * http://localhost:4011/address/0x4aAD04D41FD7fd495503731C5a2579e19054C432/read-proxy#address-tabs loads correctly without 500 error

### Issues

 - Fixes https://github.com/celo-org/data-services/issues/734
