### PR TITLE
adding a dockerignore file to ignore gha-credentials

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,6 @@ logs
 erl_crash.dump
 *.ez
 *.beam
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ node_modules
 *.iml
 
 .vscode
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
### Description

 Testing a dockerignore file to make sure it ignores the gha credentials.
