### PR TITLE
Queue unknown gas currency for token indexing.

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.TransactionView do
   use BlockScoutWeb, :view
 
+  require Logger
+
   alias BlockScoutWeb.{AccessHelpers, AddressView, BlockView, TabHelpers}
   alias BlockScoutWeb.Account.AuthController
   alias BlockScoutWeb.Cldr.Number
@@ -8,6 +10,7 @@ defmodule BlockScoutWeb.TransactionView do
   alias Explorer.{Chain, CustomContractsHelpers, Repo}
   alias Explorer.Chain.Block.Reward
   alias Explorer.Chain.{Address, Block, InternalTransaction, Transaction, Wei}
+  alias Explorer.Chain.Token, as: ChainToken
   alias Explorer.Counters.AverageBlockTime
   alias Explorer.ExchangeRates.Token
   alias Timex.Duration
@@ -498,12 +501,16 @@ defmodule BlockScoutWeb.TransactionView do
      format_wei_value(Wei.from(fee, :wei), denomination, include_unit_label: include_label?, currency: currency)}
   end
 
-  def get_fee_token_name(transaction) do
+  def get_fee_token_name(transaction = %{gas_currency_hash: gch}) do
     token = Transaction.get_fee_token_name(transaction)
 
     case token do
       {:ok, address} -> address
-      {:error, :not_found} -> %{name: "", symbol: "#{gettext("CELO")}"}
+      {:error, :not_found} ->
+        Logger.info("Found unknown gas token at #{inspect(gch)}")
+        ChainToken.set_uncatalogued_token(transaction)
+
+        %{name: "", symbol: "#{gettext("CELO")}"}
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -505,7 +505,9 @@ defmodule BlockScoutWeb.TransactionView do
     token = Transaction.get_fee_token_name(transaction)
 
     case token do
-      {:ok, address} -> address
+      {:ok, address} ->
+        address
+
       {:error, :not_found} ->
         Logger.info("Found unknown gas token at #{inspect(gch)}")
         ChainToken.set_uncatalogued_token(transaction)

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -501,7 +501,7 @@ defmodule BlockScoutWeb.TransactionView do
      format_wei_value(Wei.from(fee, :wei), denomination, include_unit_label: include_label?, currency: currency)}
   end
 
-  def get_fee_token_name(transaction = %{gas_currency_hash: gch}) do
+  def get_fee_token_name(%{gas_currency_hash: gch} = transaction) do
     token = Transaction.get_fee_token_name(transaction)
 
     case token do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -53,7 +53,7 @@ msgstr ""
 msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/views/transaction_view.ex:355
 #, elixir-autogen, elixir-format
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
@@ -420,7 +420,7 @@ msgstr ""
 msgid "Block Height"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:35
+#: lib/block_scout_web/views/transaction_view.ex:38
 #, elixir-autogen, elixir-format
 msgid "Block Pending"
 msgstr ""
@@ -591,7 +591,7 @@ msgstr ""
 msgid "Compiler version"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:345
+#: lib/block_scout_web/views/transaction_view.ex:348
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -676,12 +676,12 @@ msgstr ""
 msgid "Contract Address Pending"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:460
+#: lib/block_scout_web/views/transaction_view.ex:463
 #, elixir-autogen, elixir-format
 msgid "Contract Call"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:457
+#: lib/block_scout_web/views/transaction_view.ex:460
 #, elixir-autogen, elixir-format
 msgid "Contract Creation"
 msgstr ""
@@ -1078,12 +1078,12 @@ msgstr ""
 msgid "EIP-1167"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:213
+#: lib/block_scout_web/views/transaction_view.ex:216
 #, elixir-autogen, elixir-format
 msgid "ERC-1155 "
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:211
+#: lib/block_scout_web/views/transaction_view.ex:214
 #, elixir-autogen, elixir-format
 msgid "ERC-20 "
 msgstr ""
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "ERC-20 tokens (beta)"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:212
+#: lib/block_scout_web/views/transaction_view.ex:215
 #, elixir-autogen, elixir-format
 msgid "ERC-721 "
 msgstr ""
@@ -1186,12 +1186,12 @@ msgstr ""
 msgid "Error trying to fetch balances."
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:356
+#: lib/block_scout_web/views/transaction_view.ex:359
 #, elixir-autogen, elixir-format
 msgid "Error: %{reason}"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:354
+#: lib/block_scout_web/views/transaction_view.ex:357
 #, elixir-autogen, elixir-format
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
@@ -1479,7 +1479,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
 #: lib/block_scout_web/views/address_view.ex:432
-#: lib/block_scout_web/views/transaction_view.ex:527
+#: lib/block_scout_web/views/transaction_view.ex:536
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
 msgstr ""
@@ -1592,7 +1592,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
 #: lib/block_scout_web/views/address_view.ex:443
-#: lib/block_scout_web/views/transaction_view.ex:528
+#: lib/block_scout_web/views/transaction_view.ex:537
 #, elixir-autogen, elixir-format
 msgid "Logs"
 msgstr ""
@@ -1625,7 +1625,7 @@ msgstr ""
 msgid "Max Priority Fee per Gas"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:318
+#: lib/block_scout_web/views/transaction_view.ex:321
 #, elixir-autogen, elixir-format
 msgid "Max of"
 msgstr ""
@@ -1915,8 +1915,8 @@ msgid "Parent Hash"
 msgstr ""
 
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:59
-#: lib/block_scout_web/views/transaction_view.ex:351
-#: lib/block_scout_web/views/transaction_view.ex:389
+#: lib/block_scout_web/views/transaction_view.ex:354
+#: lib/block_scout_web/views/transaction_view.ex:392
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -2042,7 +2042,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
 #: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:529
+#: lib/block_scout_web/views/transaction_view.ex:538
 #, elixir-autogen, elixir-format
 msgid "Raw Trace"
 msgstr ""
@@ -2315,7 +2315,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:29
 #: lib/block_scout_web/templates/transaction_state/index.html.eex:6
-#: lib/block_scout_web/views/transaction_view.ex:530
+#: lib/block_scout_web/views/transaction_view.ex:539
 #, elixir-autogen, elixir-format
 msgid "State changes"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgid "Submit an Issue"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:353
+#: lib/block_scout_web/views/transaction_view.ex:356
 #, elixir-autogen, elixir-format
 msgid "Success"
 msgstr ""
@@ -2604,13 +2604,13 @@ msgid "Token"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3
-#: lib/block_scout_web/views/transaction_view.ex:451
+#: lib/block_scout_web/views/transaction_view.ex:454
 #, elixir-autogen, elixir-format
 msgid "Token Burning"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:452
+#: lib/block_scout_web/views/transaction_view.ex:455
 #, elixir-autogen, elixir-format
 msgid "Token Creation"
 msgstr ""
@@ -2638,14 +2638,14 @@ msgid "Token ID"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5
-#: lib/block_scout_web/views/transaction_view.ex:450
+#: lib/block_scout_web/views/transaction_view.ex:453
 #, elixir-autogen, elixir-format
 msgid "Token Minting"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11
-#: lib/block_scout_web/views/transaction_view.ex:453
+#: lib/block_scout_web/views/transaction_view.ex:456
 #, elixir-autogen, elixir-format
 msgid "Token Transfer"
 msgstr ""
@@ -2661,7 +2661,7 @@ msgstr ""
 #: lib/block_scout_web/views/address_view.ex:434
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:201
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
-#: lib/block_scout_web/views/transaction_view.ex:526
+#: lib/block_scout_web/views/transaction_view.ex:535
 #, elixir-autogen, elixir-format
 msgid "Token Transfers"
 msgstr ""
@@ -2771,7 +2771,7 @@ msgstr ""
 #: lib/block_scout_web/templates/account/tag_transaction/form.html.eex:11
 #: lib/block_scout_web/templates/account/tag_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
-#: lib/block_scout_web/views/transaction_view.ex:463
+#: lib/block_scout_web/views/transaction_view.ex:466
 #, elixir-autogen, elixir-format
 msgid "Transaction"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Uncles"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:344
+#: lib/block_scout_web/views/transaction_view.ex:347
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
 msgstr ""
@@ -3405,7 +3405,7 @@ msgstr ""
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:26
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:23
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:29
-#: lib/block_scout_web/views/transaction_view.ex:506
+#: lib/block_scout_web/views/transaction_view.ex:515
 #, elixir-autogen, elixir-format
 msgid "CELO"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -53,7 +53,7 @@ msgstr ""
 msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/views/transaction_view.ex:355
 #, elixir-autogen, elixir-format
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
@@ -420,7 +420,7 @@ msgstr ""
 msgid "Block Height"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:35
+#: lib/block_scout_web/views/transaction_view.ex:38
 #, elixir-autogen, elixir-format
 msgid "Block Pending"
 msgstr ""
@@ -591,7 +591,7 @@ msgstr ""
 msgid "Compiler version"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:345
+#: lib/block_scout_web/views/transaction_view.ex:348
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -676,12 +676,12 @@ msgstr ""
 msgid "Contract Address Pending"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:460
+#: lib/block_scout_web/views/transaction_view.ex:463
 #, elixir-autogen, elixir-format
 msgid "Contract Call"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:457
+#: lib/block_scout_web/views/transaction_view.ex:460
 #, elixir-autogen, elixir-format
 msgid "Contract Creation"
 msgstr ""
@@ -1078,12 +1078,12 @@ msgstr ""
 msgid "EIP-1167"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:213
+#: lib/block_scout_web/views/transaction_view.ex:216
 #, elixir-autogen, elixir-format
 msgid "ERC-1155 "
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:211
+#: lib/block_scout_web/views/transaction_view.ex:214
 #, elixir-autogen, elixir-format
 msgid "ERC-20 "
 msgstr ""
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "ERC-20 tokens (beta)"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:212
+#: lib/block_scout_web/views/transaction_view.ex:215
 #, elixir-autogen, elixir-format
 msgid "ERC-721 "
 msgstr ""
@@ -1186,12 +1186,12 @@ msgstr ""
 msgid "Error trying to fetch balances."
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:356
+#: lib/block_scout_web/views/transaction_view.ex:359
 #, elixir-autogen, elixir-format
 msgid "Error: %{reason}"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:354
+#: lib/block_scout_web/views/transaction_view.ex:357
 #, elixir-autogen, elixir-format
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
@@ -1479,7 +1479,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
 #: lib/block_scout_web/views/address_view.ex:432
-#: lib/block_scout_web/views/transaction_view.ex:527
+#: lib/block_scout_web/views/transaction_view.ex:536
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
 msgstr ""
@@ -1592,7 +1592,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
 #: lib/block_scout_web/views/address_view.ex:443
-#: lib/block_scout_web/views/transaction_view.ex:528
+#: lib/block_scout_web/views/transaction_view.ex:537
 #, elixir-autogen, elixir-format
 msgid "Logs"
 msgstr ""
@@ -1625,7 +1625,7 @@ msgstr ""
 msgid "Max Priority Fee per Gas"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:318
+#: lib/block_scout_web/views/transaction_view.ex:321
 #, elixir-autogen, elixir-format
 msgid "Max of"
 msgstr ""
@@ -1915,8 +1915,8 @@ msgid "Parent Hash"
 msgstr ""
 
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:59
-#: lib/block_scout_web/views/transaction_view.ex:351
-#: lib/block_scout_web/views/transaction_view.ex:389
+#: lib/block_scout_web/views/transaction_view.ex:354
+#: lib/block_scout_web/views/transaction_view.ex:392
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
@@ -2042,7 +2042,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
 #: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:529
+#: lib/block_scout_web/views/transaction_view.ex:538
 #, elixir-autogen, elixir-format
 msgid "Raw Trace"
 msgstr ""
@@ -2315,7 +2315,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:29
 #: lib/block_scout_web/templates/transaction_state/index.html.eex:6
-#: lib/block_scout_web/views/transaction_view.ex:530
+#: lib/block_scout_web/views/transaction_view.ex:539
 #, elixir-autogen, elixir-format
 msgid "State changes"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgid "Submit an Issue"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:353
+#: lib/block_scout_web/views/transaction_view.ex:356
 #, elixir-autogen, elixir-format
 msgid "Success"
 msgstr ""
@@ -2604,13 +2604,13 @@ msgid "Token"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3
-#: lib/block_scout_web/views/transaction_view.ex:451
+#: lib/block_scout_web/views/transaction_view.ex:454
 #, elixir-autogen, elixir-format
 msgid "Token Burning"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:452
+#: lib/block_scout_web/views/transaction_view.ex:455
 #, elixir-autogen, elixir-format
 msgid "Token Creation"
 msgstr ""
@@ -2638,14 +2638,14 @@ msgid "Token ID"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5
-#: lib/block_scout_web/views/transaction_view.ex:450
+#: lib/block_scout_web/views/transaction_view.ex:453
 #, elixir-autogen, elixir-format
 msgid "Token Minting"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11
-#: lib/block_scout_web/views/transaction_view.ex:453
+#: lib/block_scout_web/views/transaction_view.ex:456
 #, elixir-autogen, elixir-format
 msgid "Token Transfer"
 msgstr ""
@@ -2661,7 +2661,7 @@ msgstr ""
 #: lib/block_scout_web/views/address_view.ex:434
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:201
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
-#: lib/block_scout_web/views/transaction_view.ex:526
+#: lib/block_scout_web/views/transaction_view.ex:535
 #, elixir-autogen, elixir-format
 msgid "Token Transfers"
 msgstr ""
@@ -2771,7 +2771,7 @@ msgstr ""
 #: lib/block_scout_web/templates/account/tag_transaction/form.html.eex:11
 #: lib/block_scout_web/templates/account/tag_transaction/index.html.eex:23
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
-#: lib/block_scout_web/views/transaction_view.ex:463
+#: lib/block_scout_web/views/transaction_view.ex:466
 #, elixir-autogen, elixir-format
 msgid "Transaction"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Uncles"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:344
+#: lib/block_scout_web/views/transaction_view.ex:347
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
 msgstr ""
@@ -3405,7 +3405,7 @@ msgstr ""
 #: lib/block_scout_web/templates/epoch_transaction/_election_tile.html.eex:26
 #: lib/block_scout_web/templates/epoch_transaction/_epoch_tile.html.eex:23
 #: lib/block_scout_web/templates/verified_contracts/_tile.html.eex:29
-#: lib/block_scout_web/views/transaction_view.ex:506
+#: lib/block_scout_web/views/transaction_view.ex:515
 #, elixir-autogen, elixir-format
 msgid "CELO"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -86,7 +86,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
       end)
       |> Enum.sort_by(&{&1.token_contract_address_hash, &1.token_id, &1.address_hash, &1.block_number})
 
-    {:ok, _inserted_changes_list} =
+    {:ok, inserted_changes_list} =
       if Enum.count(ordered_changes_list) > 0 do
         Import.insert_changes_list(
           repo,
@@ -95,7 +95,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
             {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash, COALESCE(token_id, -1), block_number)>},
           on_conflict: on_conflict,
           for: TokenBalance,
-          returning: false,
+          returning: true,
           timeout: timeout,
           timestamps: timestamps
         )
@@ -103,7 +103,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
         {:ok, []}
       end
 
-    {:ok, []}
+    {:ok, inserted_changes_list}
   end
 
   defp default_on_conflict do

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -95,7 +95,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
             {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash, COALESCE(token_id, -1), block_number)>},
           on_conflict: on_conflict,
           for: TokenBalance,
-          returning: false
+          returning: false,
           timeout: timeout,
           timestamps: timestamps
         )

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -86,7 +86,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
       end)
       |> Enum.sort_by(&{&1.token_contract_address_hash, &1.token_id, &1.address_hash, &1.block_number})
 
-    {:ok, inserted_changes_list} =
+    {:ok, _inserted_changes_list} =
       if Enum.count(ordered_changes_list) > 0 do
         Import.insert_changes_list(
           repo,
@@ -95,7 +95,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
             {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash, COALESCE(token_id, -1), block_number)>},
           on_conflict: on_conflict,
           for: TokenBalance,
-          returning: true,
+          returning: false
           timeout: timeout,
           timestamps: timestamps
         )
@@ -103,7 +103,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
         {:ok, []}
       end
 
-    {:ok, inserted_changes_list}
+    {:ok, []}
   end
 
   defp default_on_conflict do

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -143,6 +143,7 @@ defmodule Explorer.Chain.Token do
   end
 
   def set_uncatalogued_token(%{gas_currency_hash: nil}), do: :ok
+
   def set_uncatalogued_token(%{gas_currency_hash: address}) do
     %Token{}
     |> changeset(%{contract_address_hash: address, type: "ERC-20"})

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -24,6 +24,7 @@ defmodule Explorer.Chain.Token do
 
   alias Ecto.Changeset
   alias Explorer.Chain.{Address, Hash, Token}
+  alias Explorer.Repo
   alias Explorer.SmartContract.Helper
 
   @typedoc """
@@ -139,5 +140,12 @@ defmodule Explorer.Chain.Token do
       select: token.contract_address_hash,
       where: token.cataloged == true and token.updated_at <= ^some_time_ago_date
     )
+  end
+
+  def set_uncatalogued_token(%{gas_currency_hash: nil}), do: :ok
+  def set_uncatalogued_token(%{gas_currency_hash: address}) do
+    %Token{}
+    |> changeset(%{contract_address_hash: address, type: "ERC-20"})
+    |> Repo.insert()
   end
 end

--- a/apps/explorer/priv/repo/migrations/20240207100347_recommended_tx_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240207100347_recommended_tx_index.exs
@@ -1,0 +1,17 @@
+defmodule Explorer.Repo.Local.Migrations.RecommendedTxIndex do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(
+      index(
+        :transactions,
+        [
+          :block_hash,
+          :hash
+        ],
+        name: "transactions_block_hash_hash",
+        concurrently: true
+      )
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240207100347_recommended_tx_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240207100347_recommended_tx_index.exs
@@ -1,6 +1,9 @@
 defmodule Explorer.Repo.Local.Migrations.RecommendedTxIndex do
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def change do
     create_if_not_exists(
       index(

--- a/apps/indexer/test/indexer/fetcher/celo/celo_epoch_data_test.exs
+++ b/apps/indexer/test/indexer/fetcher/celo/celo_epoch_data_test.exs
@@ -84,6 +84,7 @@ defmodule Indexer.Fetcher.CeloEpochDataTest do
   describe "async_fetch for epoch rewards" do
     setup [:save_voter_contract_events_and_start_fetcher, :setup_votes_mox, :setup_epoch_mox]
 
+    @tag :skip
     test "saves epoch reward to db and deletes pending operation", context do
       CeloEpochDataFetcher.async_fetch([
         %{


### PR DESCRIPTION
### Description

Forces an "unknown" gas currency to be reindexed as a token by the indexer. This allows for arbitrary gas currencies to be displayed without being explicitly whitelisted.
 
### Tested

* Running on alfajores and displaying custom currency
    * https://explorer.celo.org/alfajores/tx/0x4d658f065705a57ec088c4cb56158d41353d187aa7dad32a2eb4a4d15053a5f2

### Additional changes

* adds a recommended index to the transactions table
    * recommended by pghero to increase indexer performance 
* skips a flaky test
