### PR TITLE
Fix spelling. Remove moved link

### DIFF
--- a/apps/block_scout_web/config/navigation.exs
+++ b/apps/block_scout_web/config/navigation.exs
@@ -3,8 +3,7 @@ import Config
 config :block_scout_web,
   defi: [
     %{title: "Moola", url: "https://moola.market/"},
-    %{title: "Revo", url: "https://revo.market/"},
-    %{title: "ImmortalDao Finance", url: "https://www.immortaldao.finance"}
+    %{title: "Revo", url: "https://revo.market/"}
   ],
   swap: [
     %{title: "Ubeswap", url: "https://ubeswap.org/"},

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -204,7 +204,7 @@
                     <% end %>
                   </div>
                   <div class="col-xs-12 col-md-3 col-lg-3">
-                    <h3 class="apps-menu-header pl-2"><b><%= gettext("Derivates Platforms") %></b></h3>
+                    <h3 class="apps-menu-header pl-2"><b><%= gettext("Derivatives Platforms") %></b></h3>
                     <%= for %{url: url, title: title} <- derivates_platforms_list() do %>
                     <a href="<%= url%>" class="dropdown-item" target="_blank" data-selector="app-url"><%= title %></a>
                     <% end %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -3933,5 +3933,5 @@ msgstr ""
 
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:207
 #, elixir-autogen, elixir-format
-msgid "Derivates Platforms"
+msgid "Derivatives Platforms"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -3933,5 +3933,5 @@ msgstr ""
 
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:207
 #, elixir-autogen, elixir-format
-msgid "Derivates Platforms"
+msgid "Derivatives Platforms"
 msgstr ""


### PR DESCRIPTION
### Description

- Spelling `Derivates` -> `Derivatives`
- Remove `ImmortalDAO` from defi list (replaced in new section by ImmortalX)
