### PR TITLE
Fix txlist RPC endpoint to use the token info for fee currencies

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -129,7 +129,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "confirmations" => "#{transaction.confirmations}",
       "gatewayFeeRecipient" => "#{transaction.gas_fee_recipient_hash}",
       "gatewayFee" => "#{transaction.gateway_fee}",
-      "feeCurrency" => Util.contract_name_to_symbol(transaction.fee_currency, true)
+      "feeCurrency" => Util.fee_currency_token_symbol(transaction.fee_currency)
     }
   end
 

--- a/apps/explorer/lib/explorer/celo/util.ex
+++ b/apps/explorer/lib/explorer/celo/util.ex
@@ -79,13 +79,10 @@ defmodule Explorer.Celo.Util do
     Map.values(@celo_token_contract_symbols)
   end
 
-  def contract_name_to_symbol(name, use_celo_instead_cgld?) do
+  def fee_currency_token_symbol(name) do
     case name do
-      n when n in [nil, "goldToken"] ->
-        if(use_celo_instead_cgld?, do: "CELO", else: "cGLD")
-
-      _ ->
-        @celo_token_contract_symbols[name]
+      n when n in [nil, "cGLD"] -> "CELO"
+      _ -> name
     end
   end
 end

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Etherscan do
   alias Explorer.Etherscan.Logs
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Address.{CurrentTokenBalance, TokenBalance}
-  alias Explorer.Chain.{Address, Block, CeloParams, Hash, InternalTransaction, Log, TokenTransfer, Transaction}
+  alias Explorer.Chain.{Address, Block, CeloParams, Hash, InternalTransaction, Log, Token, TokenTransfer, Transaction}
   alias Explorer.Chain.Transaction.History.TransactionStats
 
   @default_options %{
@@ -490,8 +490,8 @@ defmodule Explorer.Etherscan do
         t in Transaction,
         join: a in ^addresses_wrapped_subquery,
         on: t.hash == a.hash,
-        left_join: p in CeloParams,
-        on: t.gas_currency_hash == p.address_value,
+        left_join: k in Token,
+        on: t.gas_currency_hash == k.contract_address_hash,
         inner_join: b in Block,
         on: b.number == t.block_number,
         order_by: [{^options.order_by_direction, t.block_number}],
@@ -499,7 +499,7 @@ defmodule Explorer.Etherscan do
         offset: ^offset(options),
         select:
           merge(map(t, ^@transaction_fields), %{
-            fee_currency: p.name,
+            fee_currency: k.symbol,
             block_timestamp: b.timestamp,
             confirmations: fragment("? - ?", ^max_block_number, t.block_number)
           })

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Etherscan do
   alias Explorer.Etherscan.Logs
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Address.{CurrentTokenBalance, TokenBalance}
-  alias Explorer.Chain.{Address, Block, CeloParams, Hash, InternalTransaction, Log, Token, TokenTransfer, Transaction}
+  alias Explorer.Chain.{Address, Block, Hash, InternalTransaction, Log, Token, TokenTransfer, Transaction}
   alias Explorer.Chain.Transaction.History.TransactionStats
 
   @default_options %{


### PR DESCRIPTION
### Description

The `txlist` RPC endpoint uses the `CeloParams` table to fetch names of stable tokens used as gas currencies. The way the `feeCurrency` mapping is implemented is a bit cumbersome and requires manual population of the table with the parameters. It can take it from the `Tokens` table instead.

Before:
```
curl -s https://explorer.celo.org/mainnet/api\?module\=account\&action\=txlist\&address\=0xccc9576F841de93Cd32bEe7B98fE8B9BD3070e3D | jq '.' | grep -i "0xcb625dd58eb29e8df606276927375ea8aa9c983cb09812aa5784b5da28d6e149" -A 10 -B 10 | grep feeCurrency
      "feeCurrency": "CELO",
```

After:
```
curl -s https://explorer.celo.org/mainnet/api\?module\=account\&action\=txlist\&address\=0xccc9576F841de93Cd32bEe7B98fE8B9BD3070e3D | jq '.' | grep -i "0xcb625dd58eb29e8df606276927375ea8aa9c983cb09812aa5784b5da28d6e149" -A 10 -B 10 | grep feeCurrency
      "feeCurrency": "USDC",
```